### PR TITLE
FIX - Daemon refactor

### DIFF
--- a/bin/kbd
+++ b/bin/kbd
@@ -4,24 +4,25 @@
  * Kinesis Broker Daemon
  */
 
-const path = require('path');
-const program = require('caporal');
+const path = require('path')
+const program = require('caporal')
 
-const startServer = require('../broker-daemon');
+const startServer = require('../broker-daemon')
 
-const { version: CLI_VERSION } = require('../package.json');
+const { version: CLI_VERSION } = require('../package.json')
 
-const RPC_ADDRESS = process.env.RPC_ADDRESS || '0.0.0.0:27492';
-const DATA_DIR = process.env.DATA_DIR || '~/.kinesis/data';
-const ENGINE_TYPE = process.env.ENGINE_TYPE || 'lnd';
-const EXCHANGE_RPC_HOST = process.env.EXCHANGE_RPC_HOST || '0.0.0.0:28492';
+const RPC_ADDRESS = process.env.RPC_ADDRESS || '0.0.0.0:27492'
+const DATA_DIR = process.env.DATA_DIR || '~/.kinesis/data'
+const ENGINE_TYPE = process.env.ENGINE_TYPE || 'lnd'
+const EXCHANGE_RPC_HOST = process.env.EXCHANGE_RPC_HOST || '0.0.0.0:28492'
 
 // TODO: Do not provide defaults for these certs because they could
 //   exist in an array of places?
-const LND_TLS_CERT = process.env.LND_TLS_CERT || '~/.lnd/tls.cert';
-const LND_MACAROON = process.env.LND_MACAROON || '~/.lnd/admin.macaroon';
-const LND_RPC_HOST = process.env.ENGINE_RPC_HOST || '0.0.0.0:10009';
+const LND_TLS_CERT = process.env.LND_TLS_CERT || '~/.lnd/tls.cert'
+const LND_MACAROON = process.env.LND_MACAROON || '~/.lnd/admin.macaroon'
+const LND_RPC_HOST = process.env.ENGINE_RPC_HOST || '0.0.0.0:10009'
 
+// TODO: Add validations to ./bin/kbd when they become available
 program
   .version(CLI_VERSION)
   .option('--rpc-address <server>', 'Host and port to set up the RPC server on.', /^.+(:[0-9]*)?$/, RPC_ADDRESS)
@@ -34,6 +35,6 @@ program
   .option('--lnd-rpc <server>', 'Location of the LND RPC server to use.', /^.+(:[0-9]*)?$/, LND_RPC_HOST)
   .option('--lnd-tls <path>', 'Location of the certificate to use when communicating with LND.', /^.+$/, LND_TLS_CERT)
   .option('--lnd-macaroon <path>', 'Location of the macaroon to use when communicating with LND.', /^.+$/, LND_MACAROON)
-  .action(startServer);
+  .action(startServer)
 
-program.parse(process.argv);
+program.parse(process.argv)

--- a/broker-daemon/broker-actions/create-order.js
+++ b/broker-daemon/broker-actions/create-order.js
@@ -1,0 +1,55 @@
+const { status } = require('grpc')
+
+const RelayerClient = require('../relayer')
+
+/**
+ * Creates an order w/ the exchange
+ *
+ * @param {Object} call
+ * @param {Object} call.request
+ * @param {String} call.request.amount
+ * @param {String} call.request.price
+ * @param {String} call.request.market
+ * @param {String} call.request.side
+ * @param {String} [timeinforce] call.request.timeinforce
+ * @param {fn} cb
+ */
+async function createOrder (call, cb) {
+  const {
+    // amount,
+    // price,
+    market,
+    // timeinforce,
+    side
+  } = call.request
+
+  // We need to calculate the base amount/counter amount based off of current
+  // prices
+
+  const [baseSymbol, counterSymbol] = market.split('/')
+
+  const request = {
+    ownerId: '123455678',
+    payTo: 'ln:12234987',
+    baseSymbol,
+    counterSymbol,
+    baseAmount: '10000',
+    counterAmount: '1000000',
+    side
+  }
+
+  const relayer = new RelayerClient()
+
+  try {
+    this.logger.info('Attempting to create order')
+    const order = await relayer.createOrder(request)
+    cb(null, { orderId: order.orderId })
+  } catch (e) {
+    this.logger.error('createOrder failed', { error: e.toString() })
+
+    // eslint-disable-next-line
+    return cb({ message: e.message, code: status.INTERNAL })
+  }
+}
+
+module.exports = createOrder

--- a/broker-daemon/broker-actions/index.js
+++ b/broker-daemon/broker-actions/index.js
@@ -1,0 +1,7 @@
+const createOrder = require('./create-order')
+const watchMarket = require('./watch-market')
+
+module.exports = {
+  createOrder,
+  watchMarket
+}

--- a/broker-daemon/broker-actions/watch-market.js
+++ b/broker-daemon/broker-actions/watch-market.js
@@ -1,0 +1,33 @@
+const RelayerClient = require('../relayer')
+
+/**
+ * Creates a stream with the exchange that watches for market events
+ *
+ * @param {Object} call
+ * @param {Object} call.request
+ * @param {String} call.request.market
+ */
+async function watchMarket (call) {
+  // TODO: Some validation on here. Maybe the client can call out for valid markets
+  // from the relayer so we dont event make a request if it is invalid
+  const { market } = call.request
+  const [baseSymbol, counterSymbol] = market.split('/')
+
+  // TODO: Rethink the lastUpdated null value for relayer
+  const request = { baseSymbol, counterSymbol, lastUpdated: 0 }
+  const relayer = new RelayerClient()
+
+  try {
+    const watchOrder = await relayer.watchMarket(request)
+
+    watchOrder.on('data', (order) => call.write(order))
+    watchOrder.on('end', () => this.logger.info('Finished sending'))
+  } catch (e) {
+    this.logger.error('watchMarket failed', { error: e.toString() })
+
+    // Figure out a better way to handle errors for call
+    call.destroy()
+  }
+}
+
+module.exports = watchMarket

--- a/broker-daemon/grpc-action.js
+++ b/broker-daemon/grpc-action.js
@@ -1,0 +1,13 @@
+/**
+ * Generic 'Action' class to allow passing of logger and shared attributes to gRPC
+ * event handlers
+ *
+ * @author kinesis.exchange
+ */
+class GrpcAction {
+  constructor (logger) {
+    this.logger = logger
+  }
+}
+
+module.exports = GrpcAction

--- a/broker-daemon/grpc-server.js
+++ b/broker-daemon/grpc-server.js
@@ -1,88 +1,14 @@
 const grpc = require('grpc')
-const path = require('path')
-const fs = require('fs')
-const { status } = require('grpc')
 
-const { RelayerClient } = require('./relayer')
+const { loadProto } = require('./utils')
+const GrpcAction = require('./grpc-action')
 
-const PROTO_PATH = path.resolve('./broker-daemon/proto/broker.proto')
-const PROTO_GRPC_TYPE = 'proto'
-const PROTO_GRPC_OPTIONS = {
-  convertFieldsToCamelCase: true,
-  binaryAsBase64: true,
-  longsAsStrings: true
-}
+const {
+  createOrder,
+  watchMarket
+} = require('./broker-actions')
 
-if (!fs.existsSync(PROTO_PATH)) {
-  throw new Error(`broker.proto does not exist at ${PROTO_PATH}. please run 'npm run build'`)
-}
-
-class Action {
-  constructor (logger) {
-    this.logger = logger
-  }
-}
-
-async function watchMarket (call) {
-  // TODO: Some validation on here. Maybe the client can call out for valid markets
-  // from the relayer so we dont event make a request if it is invalid
-  const { market } = call.request
-  const [baseSymbol, counterSymbol] = market.split('/')
-
-  // TODO: Rethink the lastUpdated null value for relayer
-  const request = { baseSymbol, counterSymbol, lastUpdated: 0 }
-  const relayer = new RelayerClient()
-
-  try {
-    const watchOrder = await relayer.watchMarket(request)
-
-    watchOrder.on('data', (order) => call.write(order))
-    watchOrder.on('end', () => this.logger.info('Finished sending'))
-  } catch (e) {
-    this.logger.error('watchMarket failed', { error: e.toString() })
-
-    // Figure out a better way to handle errors for call
-    call.destroy()
-  }
-}
-
-async function createOrder (call, cb) {
-  const {
-    // amount,
-    // price,
-    market,
-    // timeinforce,
-    side
-  } = call.request
-
-  // We need to calculate the base amount/counter amount based off of current
-  // prices
-
-  const [baseSymbol, counterSymbol] = market.split('/')
-
-  const request = {
-    ownerId: '123455678',
-    payTo: 'ln:12234987',
-    baseSymbol,
-    counterSymbol,
-    baseAmount: '10000',
-    counterAmount: '1000000',
-    side
-  }
-
-  const relayer = new RelayerClient()
-
-  try {
-    this.logger.info('Attempting to create order')
-    const order = await relayer.createOrder(request)
-    cb(null, { orderId: order.orderId })
-  } catch (e) {
-    this.logger.error('createOrder failed', { error: e.toString() })
-
-    // eslint-disable-next-line
-    return cb({ message: e.message, code: status.INTERNAL })
-  }
-}
+const BROKER_PROTO_PATH = './broker-daemon/proto/broker.proto'
 
 /**
  * Abstract class for a grpc server
@@ -92,10 +18,14 @@ async function createOrder (call, cb) {
 class GrpcServer {
   constructor (logger) {
     this.logger = logger
-    this.proto = grpc.load(PROTO_PATH, PROTO_GRPC_TYPE, PROTO_GRPC_OPTIONS)
-    this.brokerService = this.proto.Broker.service
+
+    this.protoPath = BROKER_PROTO_PATH
+    this.proto = loadProto(this.protoPath)
+
     this.server = new grpc.Server()
-    this.action = new Action(this.logger)
+    this.action = new GrpcAction(this.logger)
+
+    this.brokerService = this.proto.Broker.service
 
     this.server.addService(this.brokerService, {
       createOrder: createOrder.bind(this.action),
@@ -104,10 +34,9 @@ class GrpcServer {
   }
 
   /**
-   * Binds a given port/host to our grpc server
+   * Binds a given rpc address for our grpc server
    *
    * @param {String} host
-   * @param {String} port
    * @returns {void}
    */
   listen (host) {

--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -1,11 +1,17 @@
 const GrpcServer = require('./grpc-server')
 
 /**
- * Interface for the KBD client
+ * Creates an RPC server with params from kbd cli
  *
- * @NOTE: the method signature is from the #action mathod in Caporal
  * @param {Object} args
  * @param {Object} opts
+ * @param {String} opts.rpcAddress
+ * @param {String} opts.dataDir
+ * @param {String} opts.engineType
+ * @param {String} opts.exchangeHost
+ * @param {String} [lndRpc] opts.lndRpc
+ * @param {String} [lndTls] opts.lndTls
+ * @param {String} [lndMacaroon] opts.lndMacaroon
  * @param {Logger} logger
  */
 
@@ -26,7 +32,6 @@ function startServer (args, opts, logger) {
     logger.info(`gRPC server started: Server listening on ${rpcAddress}`)
   } catch (e) {
     logger.error(e.toString())
-    throw (e)
   }
 }
 

--- a/broker-daemon/utils/index.js
+++ b/broker-daemon/utils/index.js
@@ -1,0 +1,6 @@
+/**
+ * @author kinesis
+ */
+const loadProto = require('./load-proto')
+
+module.exports = { loadProto }

--- a/broker-daemon/utils/load-proto.js
+++ b/broker-daemon/utils/load-proto.js
@@ -1,0 +1,16 @@
+const path = require('path')
+const grpc = require('grpc')
+
+const PROTO_FILE_TYPE = 'proto'
+const PROTO_OPTIONS = {
+  convertFieldsToCamelCase: true,
+  binaryAsBase64: true,
+  longsAsStrings: true
+}
+
+function loadGrpc (protoPath) {
+  const resolvedPath = path.resolve(protoPath)
+  return grpc.load(resolvedPath, PROTO_FILE_TYPE, PROTO_OPTIONS)
+}
+
+module.exports = loadGrpc


### PR DESCRIPTION
@treygriffith Did some broker refactoring that makes things easier to work with for the broker daemon.

Specifically
1. move proto creation to its own module
2. added a bunch of jsdoc stuff
3. moved actions out of the grpc-server
4. moved proto creation out of relayer files