### PR TITLE
Global Event Handler

### DIFF
--- a/broker-daemon/grpc-server.js
+++ b/broker-daemon/grpc-server.js
@@ -17,9 +17,10 @@ const BROKER_PROTO_PATH = './broker-daemon/proto/broker.proto'
  * @author kinesis
  */
 class GrpcServer {
-  constructor (logger, store) {
+  constructor (logger, store, eventHandler) {
     this.logger = logger
     this.store = store
+    this.eventHandler = eventHandler
 
     this.protoPath = BROKER_PROTO_PATH
     this.proto = loadProto(this.protoPath)

--- a/broker-daemon/grpc-server.spec.js
+++ b/broker-daemon/grpc-server.spec.js
@@ -71,6 +71,14 @@ describe('GrpcServer', () => {
       expect(server.store).to.be.eql(store)
     })
 
+    it('assigns an eventHandler', () => {
+      const eventHandler = 'myevents'
+      const server = new GrpcServer(null, null, eventHandler)
+
+      expect(server).to.have.property('eventHandler')
+      expect(server.eventHandler).to.be.eql(eventHandler)
+    })
+
     it('assigns the proto path', () => {
       const protoPath = GrpcServer.__get__('BROKER_PROTO_PATH')
 

--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -1,5 +1,6 @@
 const level = require('level')
 const sublevel = require('sublevelup')
+const EventEmitter = require('events')
 
 const GrpcServer = require('./grpc-server')
 
@@ -31,7 +32,8 @@ function startServer (args, opts, logger) {
 
   try {
     const store = sublevel(level(dataDir))
-    const grpc = new GrpcServer(logger, store)
+    const eventHandler = new EventEmitter()
+    const grpc = new GrpcServer(logger, store, eventHandler)
     grpc.listen(rpcAddress)
     logger.info(`gRPC server started: Server listening on ${rpcAddress}`)
   } catch (e) {

--- a/broker-daemon/index.spec.js
+++ b/broker-daemon/index.spec.js
@@ -10,6 +10,7 @@ describe('broker daemon', () => {
   let level
   let sublevel
   let logger
+  let EventEmitter
 
   beforeEach(() => {
     listen = sinon.stub()
@@ -29,6 +30,9 @@ describe('broker daemon', () => {
       info: sinon.spy(),
       error: sinon.spy()
     }
+
+    EventEmitter = sinon.stub()
+    brokerDaemon.__set__('EventEmitter', EventEmitter)
   })
 
   describe('startServer', () => {
@@ -49,14 +53,25 @@ describe('broker daemon', () => {
       expect(sublevel).to.have.been.calledWith(fakeLevel)
     })
 
+    it('creates an event handler', () => {
+      startServer(null, {}, logger)
+
+      expect(EventEmitter).to.have.been.calledOnce()
+      expect(EventEmitter).to.have.been.calledWithExactly()
+      expect(EventEmitter).to.have.been.calledWithNew()
+    })
+
     it('creates a server', () => {
       const fakeSublevel = 'mysublevel'
       sublevel.returns(fakeSublevel)
 
+      const fakeEventHandler = {}
+      EventEmitter.returns(fakeEventHandler)
+
       startServer(null, {}, logger)
 
       expect(GrpcServer).to.have.been.calledOnce()
-      expect(GrpcServer).to.have.been.calledWith(logger, fakeSublevel)
+      expect(GrpcServer).to.have.been.calledWith(logger, fakeSublevel, fakeEventHandler)
       expect(GrpcServer).to.have.been.calledWithNew()
     })
 


### PR DESCRIPTION
As PRs like #17 show, we need a way to manage events for the whole grpc server.

This PR adds an event handler in a similar style to the relayer. It's a foundational PR that doesn't have any use yet.

It should be merged to master after #18 since it builds on the testing work established in that PR.