### PR TITLE
FIX - update build scripts to grab relayer proto from relayer directory;

### DIFF
--- a/proto/relayer.proto
+++ b/proto/relayer.proto
@@ -114,19 +114,32 @@ service Taker {
 message MarketEvent {
 
     string event_id = 0;
-    string order_id = 1;
-    int32 timestamp = 3;
-    EventType event_type = 4;
-    int64 base_amount = 5;
-    int64 counter_amount = 6;
-    int64 fill_amount = 7;
-    Side side = 8;
+    EventType event_type = 1;
+    int64 timestamp = 2;
+    string order_id = 3;
+    int64 base_amount = 10;
+    int64 counter_amount = 11;
+    Side side = 12;
+    int64 fill_amount = 20;
 
     enum EventType {
 
         PLACED = 0;
         CANCELLED = 1;
         FILLED = 2;
+    }
+}
+
+message WatchMarketResponse {
+
+    ResponseType type = 0;
+    MarketEvent market_event = 1;
+
+    enum ResponseType {
+
+        NEW_EVENT = 1;
+        EXISTING_EVENT = 2;
+        EXISTING_EVENTS_DONE = 3;
     }
 }
 
@@ -137,7 +150,7 @@ message WatchMarketRequest {
     int64 last_updated = 2;
 }
 service OrderBook {
-    rpc WatchMarket (WatchMarketRequest) returns (stream MarketEvent);
+    rpc WatchMarket (WatchMarketRequest) returns (stream WatchMarketResponse);
 }
 
 message GetPublicKeyResponse {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,8 +8,8 @@ echo ""
 
 # Download the relayer proto
 rm -rf ./proto/relayer
-git clone git@github.com:kinesis-exchange/relayer-proto.git ./proto/relayer
-cp ./proto/relayer/lib/relayer.proto ./proto/
+git clone git@github.com:kinesis-exchange/relayer.git ./proto/relayer
+cp ./proto/relayer/proto/relayer.proto ./proto/
 
 # Rebuild gRPC for docker target
 npm rebuild grpc --target_arch=x64 --target_platform=linux --target_libc=glibc


### PR DESCRIPTION
This is related to https://github.com/kinesis-exchange/relayer/pull/40

Relayer will be the owner of the relayer proto files and will expose them to public repos. This PR grabs the proto file from the relayer repo on `npm run build` instead of the `relayer-proto` repo