### PR TITLE
check client and required node version

### DIFF
--- a/bin/kcli
+++ b/bin/kcli
@@ -3,9 +3,10 @@
 /**
  * Kinesis Broker CLI
  */
-
+const { engines: { node: currentVersion } } = require('../package.json')
+const compareVersions = require('compare-versions')
+require('colors')
 const program = require('caporal')
-
 const { version: CLI_VERSION } = require('../package.json')
 
 const {
@@ -16,6 +17,13 @@ const {
   setupCommand,
   healthCheckCommand
 } = require('../broker-cli')
+
+const clientVersion = process.version.substring(1)
+
+if (compareVersions(clientVersion, currentVersion) !== 0) {
+  console.error(`Wrong node version, required version: ${currentVersion}, your version: ${clientVersion}`.red)
+  process.exit(1)
+}
 
 /**
  * Initial Program Setup

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
   "homepage": "https://github.com/kinesis-exchange/broker#readme",
   "dependencies": {
     "caporal": "0.10.0",
+    "colors": "1.2.4",
+    "compare-versions": "3.1.0",
     "grpc": "1.10.1",
     "level": "3.0.0",
     "level-sublevel": "6.6.1",
@@ -58,5 +60,8 @@
     "sinon-chai": "3.0.0",
     "standard": "11.0.1",
     "timeout-as-promise": "1.0.0"
+  },
+  "engines": {
+    "node": "8.x.x"
   }
 }


### PR DESCRIPTION
https://trello.com/c/1vIZ0TjY/81-add-nodejs-check-for-cli-for-running-locally

Before being able to use the CLI, we should make sure that the Node version is appropriately set on the host machine (or there will be issues with the libraries we use)