### PR TITLE
FIX - Cleanup destructuring of expect

### DIFF
--- a/broker-cli/buy.spec.js
+++ b/broker-cli/buy.spec.js
@@ -1,11 +1,10 @@
 const path = require('path')
 const {
-  chai,
   sinon,
-  rewire
+  rewire,
+  expect
 } = require('test/test-helper')
 
-const { expect } = chai
 const programPath = path.resolve('broker-cli', 'buy')
 const program = rewire(programPath)
 

--- a/broker-cli/health-check.spec.js
+++ b/broker-cli/health-check.spec.js
@@ -1,11 +1,10 @@
 const path = require('path')
 const {
-  chai,
   sinon,
-  rewire
+  rewire,
+  expect
 } = require('test/test-helper')
 
-const { expect } = chai
 const programPath = path.resolve('broker-cli', 'health-check')
 const program = rewire(programPath)
 

--- a/broker-cli/index.spec.js
+++ b/broker-cli/index.spec.js
@@ -1,5 +1,4 @@
-const { chai } = require('test/test-helper')
-const { expect } = chai
+const { expect } = require('test/test-helper')
 
 const {
   buyCommand,

--- a/broker-cli/new-deposit-address.spec.js
+++ b/broker-cli/new-deposit-address.spec.js
@@ -1,11 +1,10 @@
 const path = require('path')
 const {
-  chai,
   sinon,
-  rewire
+  rewire,
+  expect
 } = require('test/test-helper')
 
-const { expect } = chai
 const program = rewire(path.resolve('broker-cli', 'new-deposit-address'))
 
 describe('newDepositAddress', () => {

--- a/broker-cli/sell.spec.js
+++ b/broker-cli/sell.spec.js
@@ -1,11 +1,10 @@
 const path = require('path')
 const {
-  chai,
   sinon,
-  rewire
+  rewire,
+  expect
 } = require('test/test-helper')
 
-const { expect } = chai
 const programPath = path.resolve('broker-cli', 'sell')
 const program = rewire(programPath)
 

--- a/broker-cli/utils/enums.spec.js
+++ b/broker-cli/utils/enums.spec.js
@@ -1,5 +1,4 @@
-const { chai } = require('test/test-helper')
-const { expect } = chai
+const { expect } = require('test/test-helper')
 
 const {
   TIME_IN_FORCE,

--- a/broker-cli/utils/index.spec.js
+++ b/broker-cli/utils/index.spec.js
@@ -1,5 +1,4 @@
-const { chai } = require('test/test-helper')
-const { expect } = chai
+const { expect } = require('test/test-helper')
 
 const {
   ENUMS,

--- a/broker-cli/utils/validations.spec.js
+++ b/broker-cli/utils/validations.spec.js
@@ -1,5 +1,4 @@
-const { chai } = require('test/test-helper')
-const { expect } = chai
+const { expect } = require('test/test-helper')
 
 const {
   isPrice,

--- a/broker-daemon/admin-service/health-check.spec.js
+++ b/broker-daemon/admin-service/health-check.spec.js
@@ -1,11 +1,10 @@
 const path = require('path')
 const {
-  chai,
   sinon,
-  rewire
+  rewire,
+  expect
 } = require('test/test-helper')
 
-const { expect } = chai
 const programPath = path.resolve(__dirname, 'health-check')
 const program = rewire(programPath)
 const healthCheck = program

--- a/broker-daemon/admin-service/index.spec.js
+++ b/broker-daemon/admin-service/index.spec.js
@@ -1,7 +1,5 @@
 const path = require('path')
-const { chai, rewire, sinon } = require('test/test-helper')
-
-const { expect } = chai
+const { expect, rewire, sinon } = require('test/test-helper')
 
 const AdminService = rewire(path.resolve(__dirname))
 

--- a/broker-daemon/grpc-server.spec.js
+++ b/broker-daemon/grpc-server.spec.js
@@ -1,6 +1,5 @@
 const path = require('path')
-const { chai, sinon, rewire } = require('test/test-helper')
-const { expect } = chai
+const { expect, sinon, rewire } = require('test/test-helper')
 
 const GrpcServer = rewire(path.resolve('broker-daemon', 'grpc-server'))
 

--- a/broker-daemon/models/market-event.spec.js
+++ b/broker-daemon/models/market-event.spec.js
@@ -1,5 +1,4 @@
-const { chai } = require('test/test-helper')
-const { expect } = chai
+const { expect } = require('test/test-helper')
 
 const MarketEvent = require('./market-event')
 

--- a/broker-daemon/models/order.spec.js
+++ b/broker-daemon/models/order.spec.js
@@ -1,6 +1,5 @@
 const path = require('path')
-const { chai, rewire } = require('test/test-helper')
-const { expect } = chai
+const { expect, rewire } = require('test/test-helper')
 
 const Order = rewire(path.resolve('broker-daemon', 'models', 'order'))
 

--- a/broker-daemon/order-service/index.spec.js
+++ b/broker-daemon/order-service/index.spec.js
@@ -1,7 +1,5 @@
 const path = require('path')
-const { chai, rewire, sinon } = require('test/test-helper')
-
-const { expect } = chai
+const { expect, rewire, sinon } = require('test/test-helper')
 
 const OrderService = rewire(path.resolve(__dirname))
 

--- a/broker-daemon/orderbook-service/index.spec.js
+++ b/broker-daemon/orderbook-service/index.spec.js
@@ -1,7 +1,5 @@
 const path = require('path')
-const { chai, rewire, sinon } = require('test/test-helper')
-
-const { expect } = chai
+const { expect, rewire, sinon } = require('test/test-helper')
 
 const OrderBookService = rewire(path.resolve(__dirname))
 

--- a/broker-daemon/orderbook-service/watch-market.spec.js
+++ b/broker-daemon/orderbook-service/watch-market.spec.js
@@ -1,9 +1,5 @@
-const {
-  chai,
-  sinon
-} = require('test/test-helper')
+const { sinon, expect } = require('test/test-helper')
 
-const { expect } = chai
 const watchMarket = require('./watch-market')
 
 describe('watchMarket', () => {

--- a/broker-daemon/orderbook/index.spec.js
+++ b/broker-daemon/orderbook/index.spec.js
@@ -1,6 +1,5 @@
 const path = require('path')
-const { chai, rewire, sinon } = require('test/test-helper')
-const { expect } = chai
+const { rewire, sinon, expect } = require('test/test-helper')
 
 const Orderbook = rewire(path.resolve('broker-daemon', 'orderbook', 'index'))
 

--- a/broker-daemon/relayer/index.spec.js
+++ b/broker-daemon/relayer/index.spec.js
@@ -1,5 +1,4 @@
-const { chai } = require('test/test-helper')
-const { expect } = chai
+const { expect } = require('test/test-helper')
 
 const RelayerClient = require('./index')
 

--- a/broker-daemon/relayer/relayer-client.spec.js
+++ b/broker-daemon/relayer/relayer-client.spec.js
@@ -1,6 +1,5 @@
 const path = require('path')
-const { chai, sinon, rewire, delay } = require('test/test-helper')
-const { expect } = chai
+const { sinon, rewire, delay, expect } = require('test/test-helper')
 
 const RelayerClient = rewire(path.resolve('broker-daemon', 'relayer', 'relayer-client'))
 

--- a/broker-daemon/utils/get-records.spec.js
+++ b/broker-daemon/utils/get-records.spec.js
@@ -1,5 +1,4 @@
-const { chai, sinon } = require('test/test-helper')
-const { expect } = chai
+const { sinon, expect } = require('test/test-helper')
 
 const getRecords = require('./get-records')
 


### PR DESCRIPTION
In the broker, we have areas in the test where we de-structure `expect` from chai. We can clean up this code by exposing `expect` through our test helper

1. expose `expect` through test helper
2. fix tests