### PR TITLE
FIX - suppress logs from relayer watchmarket tests

### DIFF
--- a/broker-daemon/orderbook-service/watch-market.js
+++ b/broker-daemon/orderbook-service/watch-market.js
@@ -1,6 +1,7 @@
 /**
  * Creates a stream with the exchange that watches for market events
  *
+ * @function
  * @param {GrpcServerStreamingMethod~request} request - request object
  * @param {Object} request.params - Request parameters from the client
  * @param {function} request.send - Send a chunk of data to the client

--- a/broker-daemon/relayer/relayer-client.js
+++ b/broker-daemon/relayer/relayer-client.js
@@ -4,11 +4,30 @@ const path = require('path')
 const { MarketEvent } = require('../models')
 const { loadProto } = require('../utils')
 
-// TODO: Add this to config for CLI
+/**
+ * @todo Add this config to CLI
+ * @constant
+ * @type {String}
+ * @default
+ */
 const EXCHANGE_RPC_HOST = process.env.EXCHANGE_RPC_HOST || 'localhost:28492'
+
+/**
+ * @constant
+ * @type {String}
+ * @default
+ */
 const RELAYER_PROTO_PATH = './proto/relayer.proto'
 
+/**
+ * Interface for daemon to interact with a Kinesis Relayer
+ *
+ * @author kinesis
+ */
 class RelayerClient {
+  /**
+   * @param {Logger} logger
+   */
   constructor (logger) {
     this.logger = logger || console
     this.address = EXCHANGE_RPC_HOST
@@ -90,6 +109,12 @@ class RelayerClient {
     })
   }
 
+  /**
+   * Checks the health of the relayer
+   *
+   * @param {Object} params
+   * @returns {Promise}
+   */
   async healthCheck (params) {
     const deadline = grpcDeadline()
 
@@ -102,8 +127,13 @@ class RelayerClient {
   }
 }
 
-// gRPC uses the term `deadline` which is a timeout feature that is an absolute
-// point in time, instead of a duration.
+/**
+ * gRPC uses the term `deadline` which is a timeout feature that is an absolute
+ * point in time, instead of a duration.
+ *
+ * @param {Number} [timeoutInSeconds=5]
+ * @return {Date}
+ */
 function grpcDeadline (timeoutInSeconds = 5) {
   new Date().setSeconds(new Date().getSeconds() + timeoutInSeconds)
 }

--- a/broker-daemon/relayer/relayer-client.spec.js
+++ b/broker-daemon/relayer/relayer-client.spec.js
@@ -18,6 +18,7 @@ describe('RelayerClient', () => {
     EXISTING_EVENTS_DONE: 'EXISTING_EVENTS_DONE',
     NEW_EVENT: 'NEW_EVENT'
   }
+  let fakeConsole
 
   let exchangeRpcHost = 'localhost:1337'
 
@@ -45,6 +46,12 @@ describe('RelayerClient', () => {
     RelayerClient.__set__('loadProto', loadProto)
     RelayerClient.__set__('EXCHANGE_RPC_HOST', exchangeRpcHost)
 
+    fakeConsole = {
+      info: sinon.stub(),
+      error: sinon.stub()
+    }
+    RelayerClient.__set__('console', fakeConsole)
+
     grpcCredentialsInsecure = sinon.stub()
 
     RelayerClient.__set__('grpc', {
@@ -67,7 +74,7 @@ describe('RelayerClient', () => {
       const relayer = new RelayerClient()
 
       expect(relayer).to.have.property('logger')
-      expect(relayer.logger).to.be.equal(console)
+      expect(relayer.logger).to.be.equal(fakeConsole)
     })
 
     it('loads the proto', () => {


### PR DESCRIPTION
Logs on the relayer watchmarket tests are adding unneeded lines to our test spec. This PR stubs out console on `relayer-client` tests to suppress log messages.

1. Suppresses log messages in relayer-client tests by stubbing console
2. adds jsdoc to relayer client