### PR TITLE
FIX - use engine instead of lnd-engine in healthcheck

### DIFF
--- a/broker-daemon/admin-service/health-check.spec.js
+++ b/broker-daemon/admin-service/health-check.spec.js
@@ -5,51 +5,115 @@ const {
   expect
 } = require('test/test-helper')
 
-const programPath = path.resolve(__dirname, 'health-check')
-const program = rewire(programPath)
-const healthCheck = program
-describe('healthCheck', () => {
-  let HealthCheckResponse
-  let relayerStub
-  let loggerStub
-  let engineStatusStub
-  let relayerStatusStub
-  let revertLnd
-  let revertRelayer
+const healthCheck = rewire(path.resolve(__dirname, 'health-check'))
 
-  beforeEach(() => {
-    relayerStub = sinon.stub()
-    loggerStub = {
-      info: sinon.stub(),
-      debug: sinon.stub()
-    }
-    HealthCheckResponse = sinon.stub()
-    engineStatusStub = sinon.stub().callsFake(() => 'OK')
-    relayerStatusStub = sinon.stub().callsFake(() => 'OK')
-    revertLnd = program.__set__('engineStatus', engineStatusStub)
-    revertRelayer = program.__set__('relayerStatus', relayerStatusStub)
+describe('health-check', () => {
+  describe('healthCheck', () => {
+    let HealthCheckResponse
+    let relayerStub
+    let loggerStub
+    let engineStatusStub
+    let relayerStatusStub
+    let statusOK
+    let result
+    let engineStub
+    let reverts = []
+
+    beforeEach(() => {
+      relayerStub = sinon.stub()
+      engineStub = sinon.stub()
+      loggerStub = {
+        info: sinon.stub(),
+        debug: sinon.stub()
+      }
+      HealthCheckResponse = sinon.stub()
+      engineStatusStub = sinon.stub().returns(statusOK)
+      relayerStatusStub = sinon.stub().returns(statusOK)
+
+      statusOK = healthCheck.__get__('STATUS_CODES').OK
+
+      reverts.push(healthCheck.__set__('getEngineStatus', engineStatusStub))
+      reverts.push(healthCheck.__set__('getRelayerStatus', relayerStatusStub))
+    })
+
+    beforeEach(async () => {
+      result = await healthCheck({ relayer: relayerStub, logger: loggerStub, engine: engineStub }, { HealthCheckResponse })
+    })
+
+    afterEach(() => {
+      reverts.forEach(r => r())
+    })
+
+    it('calls getEngineStatus to retrieve engine health status', () => {
+      expect(engineStatusStub).to.have.been.calledOnce()
+      expect(engineStatusStub).to.have.been.calledWith(engineStub)
+    })
+
+    it('calls relayer to retrieve relayer health status', () => {
+      expect(relayerStatusStub).to.have.been.calledOnce()
+      expect(relayerStatusStub).to.have.been.calledWith(relayerStub)
+    })
+
+    it('returns status values', async () => {
+      expect(result).to.be.an.instanceOf(HealthCheckResponse)
+      expect(HealthCheckResponse).to.have.been.calledOnce()
+      expect(HealthCheckResponse).to.have.been.calledWith(sinon.match({ engineStatus: statusOK, relayerStatus: statusOK }))
+    })
   })
 
-  afterEach(() => {
-    revertLnd()
-    revertRelayer()
+  describe('getEngineStatus', () => {
+    let getEngineStatus
+    let engineStub
+    let getInfoStub
+    let statusOK
+
+    beforeEach(() => {
+      getInfoStub = sinon.stub()
+      engineStub = {
+        getInfo: getInfoStub
+      }
+      statusOK = healthCheck.__get__('STATUS_CODES').OK
+      getEngineStatus = healthCheck.__get__('getEngineStatus')
+    })
+
+    it('returns an OK if engine#getInfo is a successful call', async () => {
+      const res = await getEngineStatus(engineStub)
+      expect(res).to.eql(statusOK)
+    })
+
+    it('returns an error if engine#getInfo fails', async () => {
+      const error = 'MY ERROR'
+      getInfoStub.throws(error)
+      const res = await getEngineStatus(engineStub)
+      expect(res).to.eql(error)
+    })
   })
 
-  it('calls engineStatus to retrieve lnd health status', async () => {
-    await healthCheck({ relayer: relayerStub, logger: loggerStub }, { HealthCheckResponse })
-    expect(engineStatusStub).to.have.been.called()
-  })
+  describe('getRelayerStatus', () => {
+    let getRelayerStatus
+    let relayerStub
+    let healthCheckStub
+    let statusOK
 
-  it('calls relayer to retrieve relayer health status', async () => {
-    await healthCheck({ relayer: relayerStub, logger: loggerStub }, { HealthCheckResponse })
-    expect(relayerStatusStub).to.have.been.called()
-    expect(relayerStatusStub).to.have.been.calledWith(relayerStub)
-  })
+    beforeEach(() => {
+      healthCheckStub = sinon.stub()
+      relayerStub = {
+        healthCheck: healthCheckStub
+      }
+      statusOK = healthCheck.__get__('STATUS_CODES').OK
+      getRelayerStatus = healthCheck.__get__('getRelayerStatus')
+    })
 
-  it('returns status values', async () => {
-    const res = await healthCheck({ relayer: relayerStub, logger: loggerStub }, { HealthCheckResponse })
-    expect(res).to.be.an.instanceOf(HealthCheckResponse)
-    expect(HealthCheckResponse).to.have.been.calledOnce()
-    expect(HealthCheckResponse).to.have.been.calledWith(sinon.match({ engineStatus: 'OK', relayerStatus: 'OK' }))
+    it('returns an OK if relayer#healtCheck is successful', async () => {
+      const res = await getRelayerStatus(relayerStub)
+      expect(res).to.eql(statusOK)
+    })
+
+    it('returns an error if the call to relayer fails', async () => {
+      const error = 'MY RELAYER ERROR'
+      healthCheckStub.throws(error)
+      const res = await getRelayerStatus(relayerStub)
+      expect(res).to.eql(error)
+    })
   })
 })

--- a/broker-daemon/admin-service/index.js
+++ b/broker-daemon/admin-service/index.js
@@ -4,7 +4,7 @@ const { loadProto } = require('../utils')
 const healthCheck = require('./health-check')
 
 class AdminService {
-  constructor (protoPath, { logger, relayer }) {
+  constructor (protoPath, { logger, relayer, engine }) {
     this.protoPath = protoPath
     this.proto = loadProto(this.protoPath)
     this.logger = logger
@@ -17,7 +17,7 @@ class AdminService {
     } = this.proto
 
     this.implementation = {
-      healthCheck: new GrpcUnaryMethod(healthCheck, this.messageId('healthCheck'), { logger, relayer }, { HealthCheckResponse }).register()
+      healthCheck: new GrpcUnaryMethod(healthCheck, this.messageId('healthCheck'), { logger, relayer, engine }, { HealthCheckResponse }).register()
     }
   }
 

--- a/broker-daemon/admin-service/index.spec.js
+++ b/broker-daemon/admin-service/index.spec.js
@@ -16,6 +16,7 @@ describe('AdminService', () => {
   let logger
 
   let relayer
+  let engine
 
   let server
 
@@ -33,6 +34,7 @@ describe('AdminService', () => {
     }
 
     relayer = sinon.stub()
+    engine = sinon.stub()
 
     GrpcMethod = sinon.stub()
     fakeRegistered = sinon.stub()
@@ -48,7 +50,7 @@ describe('AdminService', () => {
   })
 
   beforeEach(() => {
-    server = new AdminService(protoPath, { logger, relayer })
+    server = new AdminService(protoPath, { logger, relayer, engine })
   })
 
   it('assigns a proto path', () => {
@@ -120,9 +122,14 @@ describe('AdminService', () => {
         expect(callArgs[2].logger).to.be.equal(logger)
       })
 
-      it('relayer', () => {
+      it('passes in a relayer', () => {
         expect(callArgs[2]).to.have.property('relayer')
         expect(callArgs[2].relayer).to.be.equal(relayer)
+      })
+
+      it('passes in an engine', () => {
+        expect(callArgs[2]).to.have.property('engine')
+        expect(callArgs[2].engine).to.be.equal(engine)
       })
     })
 

--- a/broker-daemon/grpc-server.js
+++ b/broker-daemon/grpc-server.js
@@ -15,6 +15,11 @@ const {
   LND_MACAROON
 } = process.env
 
+/**
+ * @constant
+ * @type {String}
+ * @default
+ */
 const BROKER_PROTO_PATH = './broker-daemon/proto/broker.proto'
 
 /**

--- a/broker-daemon/relayer/relayer-client.js
+++ b/broker-daemon/relayer/relayer-client.js
@@ -118,11 +118,11 @@ class RelayerClient {
    * @param {Object} params
    * @returns {Promise}
    */
-  async healthCheck (params) {
+  async healthCheck () {
     const deadline = grpcDeadline()
 
     return new Promise((resolve, reject) => {
-      this.health.check(params, { deadline }, (err, res) => {
+      this.health.check({}, { deadline }, (err, res) => {
         if (err) return reject(err)
         return resolve(res)
       })


### PR DESCRIPTION
In order to prevent multiple IO events on every call, we initialize an engine in GrpcServer. This PR fixes commands to use `this.engine`

1. updated healthcheck to use `engine`\
2. updated admin-service to accept engine as an argument
3. updated admin-service to pass in engine to healthcheck implementation
4. updated tests
5. added jsdoc
6. moved functions in `health-check.js` in a 'Declare before use' pattern