### PR TITLE
FIX: add loggers to rejection for state machines

### DIFF
--- a/broker-daemon/state-machines/fill-state-machine.js
+++ b/broker-daemon/state-machines/fill-state-machine.js
@@ -169,11 +169,7 @@ const FillStateMachine = StateMachine.factory({
      * @return {void}
      */
     onBeforeReject: function (lifecycle, error) {
-      if(!error) {
-        return this.logger.error(`Rejecting transition without error`)
-      }
-
-      this.logger.error(`Encountered error during transition, rejecting`, { message: error.message, stack: error.stack })
+      this.logger.error(`Encountered error during transition, rejecting`, error)
     },
 
     /**

--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -166,11 +166,7 @@ const OrderStateMachine = StateMachine.factory({
      * @return {void}
      */
     onBeforeReject: function (lifecycle, error) {
-      if(!error) {
-        return this.logger.error(`Rejecting transition without error`)
-      }
-
-      this.logger.error(`Encountered error during transition, rejecting`, { message: error.message, stack: error.stack })
+      this.logger.error(`Encountered error during transition, rejecting`, error)
     },
 
     /**


### PR DESCRIPTION
## Description
Adds loggers to order and fill state machines so that rejection is not silent in the logs

## Related PRs
None


## Todos
- [ ] Tests 👈 not doing this for logs
- [x] Documentation
- [ ] Link to Trello
