### PR TITLE
FIX: placeholder ids to save state machines before creation

### DIFF
--- a/broker-daemon/state-machines/fill-state-machine.js
+++ b/broker-daemon/state-machines/fill-state-machine.js
@@ -7,6 +7,15 @@ const StateMachineLogging = require('./plugins/logging')
 const { Fill } = require('../models')
 
 /**
+ * If Fills are saved in the database before they are created on the remote, they lack an ID
+ * This string indicates an order that does not have an assigned remote ID
+ * @type {String}
+ * @constant
+ * @default
+ */
+const UNASSIGNED_PREFIX = 'NO_ASSIGNED_ID_'
+
+/**
  * @class Finite State Machine for managing fill lifecycle
  */
 const FillStateMachine = StateMachine.factory({
@@ -23,7 +32,7 @@ const FillStateMachine = StateMachine.factory({
       key: function (key) {
         // this only defines a getter - it will be set by the `fill` setter
         if (!key) {
-          return this.fill.key || `NO_RELAYER_KEY_${safeid()}`
+          return this.fill.key || `${UNASSIGNED_PREFIX}${safeid()}`
         }
       },
       additionalFields: {

--- a/broker-daemon/state-machines/fill-state-machine.spec.js
+++ b/broker-daemon/state-machines/fill-state-machine.spec.js
@@ -357,7 +357,7 @@ describe('FillStateMachine', () => {
       await fsm.reject()
 
       expect(store.put).to.have.been.calledOnce()
-      expect(store.put).to.have.been.calledWith(sinon.match(/^NO_RELAYER_KEY_\S+$/))
+      expect(store.put).to.have.been.calledWith(sinon.match(/^NO_ASSIGNED_ID_\S+$/))
     })
 
     it('calls an onRejection function', async () => {

--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -7,6 +7,15 @@ const StateMachineLogging = require('./plugins/logging')
 const { Order } = require('../models')
 
 /**
+ * If Orders are saved in the database before they are created on the remote, they lack an ID
+ * This string indicates an order that does not have an assigned remote ID
+ * @type {String}
+ * @constant
+ * @default
+ */
+const UNASSIGNED_PREFIX = 'NO_ASSIGNED_ID_'
+
+/**
  * @class Finite State Machine for managing order lifecycle
  */
 const OrderStateMachine = StateMachine.factory({
@@ -23,7 +32,7 @@ const OrderStateMachine = StateMachine.factory({
       key: function (key) {
         // this only defines a getter - it will be set by the `order` setter
         if (!key) {
-          return this.order.key || `NO_RELAYER_KEY_${safeid()}`
+          return this.order.key || `${UNASSIGNED_PREFIX}${safeid()}`
         }
       },
       additionalFields: {

--- a/broker-daemon/state-machines/order-state-machine.spec.js
+++ b/broker-daemon/state-machines/order-state-machine.spec.js
@@ -392,7 +392,7 @@ describe('OrderStateMachine', () => {
       await osm.reject()
 
       expect(store.put).to.have.been.calledOnce()
-      expect(store.put).to.have.been.calledWith(sinon.match(/^NO_RELAYER_KEY_\S+$/))
+      expect(store.put).to.have.been.calledWith(sinon.match(/^NO_ASSIGNED_ID\S+$/))
     })
 
     it('calls an onRejection function', async () => {


### PR DESCRIPTION
## Description
If state machines fail during creation, they have no key because it is relayer assigned. This PR adds a placeholder key so that we can still persist these objects in a rejected state and save their errors, etc. Otherwise, they just error out and disappear, which is confusing as a user and as a developer.

## Related PRs
List related PRs if applicable


## Todos
- [x] Tests
- [x] Documentation
- [ ] Link to Trello
