### PR TITLE
Feature: Prepare for swaps and execute

### DIFF
--- a/broker-daemon/models/order.js
+++ b/broker-daemon/models/order.js
@@ -95,6 +95,23 @@ class Order {
   }
 
   /**
+   * Params required to prepare a swap in  an engine
+   * @return {Object} Object of parameters the engine expects
+   */
+  get paramsForPrepareSwap () {
+    const { swapHash, inboundSymbol, inboundAmount, outboundSymbol, outboundAmount } = this
+
+    if (![ swapHash, inboundSymbol, inboundAmount, outboundSymbol, outboundAmount ].every(param => !!param)) {
+      throw new Error('orderId, swapHash, inboundSymbol, inboundAmount, outboundSymbol, outboundAmount are required to prepare a swap.')
+    }
+
+    const outbound = { symbol: outboundSymbol, amount: outboundAmount }
+    const inbound = { symbol: inboundSymbol, amount: inboundAmount }
+
+    return { swapHash, inbound, outbound }
+  }
+
+  /**
    * Price of the order
    * @return {String} Number, rounded to 16 decimal places, represented as a string
    */

--- a/broker-daemon/models/order.spec.js
+++ b/broker-daemon/models/order.spec.js
@@ -261,6 +261,30 @@ describe('Order', () => {
       })
     })
 
+    describe('get paramsForPrepareSwap', () => {
+      it('defines a getter for params required to prepare a swap in an engine', () => {
+        const swapHash = 'asoifdjaofj02309832'
+        Object.assign(order, { swapHash })
+
+        expect(order).to.have.property('paramsForPrepareSwap')
+        expect(order.paramsForPrepareSwap).to.be.eql({
+          swapHash: swapHash,
+          inbound: {
+            symbol: params.baseSymbol,
+            amount: params.baseAmount
+          },
+          outbound: {
+            symbol: params.counterSymbol,
+            amount: params.counterAmount
+          }
+        })
+      })
+
+      it('throws an error if a param is missing', () => {
+        expect(() => order.paramsForPrepareSwap).to.throw()
+      })
+    })
+
     describe('#setCreatedParams', () => {
       let createdParams = {
         orderId: 'myid',

--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -246,11 +246,10 @@ const OrderStateMachine = StateMachine.factory({
      * @return {Promise}          Promise that rejects if execution prep or notification fails
      */
     onBeforeExecute: async function (lifecycle) {
-      const { orderId, swapHash, inboundSymbol, inboundAmount, outboundSymbol, outboundAmount } = this.order
-      const outbound = { symbol: outboundSymbol, amount: outboundAmount }
-      const inbound = { symbol: inboundSymbol, amount: inboundAmount }
+      const { swapHash, inbound, outbound } = this.order.paramsForPrepareSwap
       await this.engine.prepareSwap(swapHash, inbound, outbound)
 
+      const { orderId } = this.order
       return this.relayer.makerService.executeOrder({ orderId })
     },
 

--- a/broker-daemon/state-machines/order-state-machine.spec.js
+++ b/broker-daemon/state-machines/order-state-machine.spec.js
@@ -464,7 +464,25 @@ describe('OrderStateMachine', () => {
       outboundSymbol = 'BTC'
       outboundAmount = '100'
 
-      fakeOrder = { orderId, swapHash, inboundAmount, inboundSymbol, outboundSymbol, outboundAmount }
+      fakeOrder = {
+        orderId,
+        swapHash,
+        inboundAmount,
+        inboundSymbol,
+        outboundSymbol,
+        outboundAmount,
+        paramsForPrepareSwap: {
+          swapHash,
+          inbound: {
+            symbol: inboundSymbol,
+            amount: inboundAmount
+          },
+          outbound: {
+            symbol: outboundSymbol,
+            amount: outboundAmount
+          }
+        }
+      }
       engine = { prepareSwap: prepareSwapStub }
       relayer = {
         makerService: {


### PR DESCRIPTION
## Description
From the maker's perspective, this PR represents the end of the line (except for redeeming for deposits).

The maker prepares the swap on the engine and notifies the Relayer that they are ready to execute.

## Related PRs
https://github.com/kinesis-exchange/lnd-engine/pull/28/files creates the engine stub that this PR uses


## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
