### PR TITLE
Fix: Kill the broker if relayer breaks the stream

### DIFF
--- a/broker-daemon/relayer/relayer-client.js
+++ b/broker-daemon/relayer/relayer-client.js
@@ -89,6 +89,7 @@ class RelayerClient {
 
         watcher.on('error', (err) => {
           this.logger.error('Relayer watchMarket grpc failed', err)
+          process.exit(1)
           reject(err)
         })
       } catch (e) {


### PR DESCRIPTION
## Description
When we no longer have an orderbook stream from the relayer we can get our local orderbook into a bad state, and it is frequently hard to debug.

In the long run, we want to handle this gracefully (https://trello.com/c/d6ZCDQrL/284-graceful-handling-of-relayer-offline-watchmarket-failure-during-startup-or-operation) for now though, we just exit the process and let pm2 take care of it.


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
