### PR TITLE
FIX: use the raw pubkey when doing the swap, not the payTo

### DIFF
--- a/broker-daemon/models/fill.js
+++ b/broker-daemon/models/fill.js
@@ -85,7 +85,7 @@ class Fill {
       throw new Error('payTo, swapHash, inboundSymbol, inboundAmount, outboundSymbol, outboundAmount are required params for execution')
     }
 
-    const counterpartyPubKey = payTo
+    const counterpartyPubKey = payTo.split(':')[1]
     const inbound = { symbol: inboundSymbol, amount: inboundAmount }
     const outbound = { symbol: outboundSymbol, amount: outboundAmount }
 

--- a/broker-daemon/models/fill.spec.js
+++ b/broker-daemon/models/fill.spec.js
@@ -295,7 +295,7 @@ describe('Fill', () => {
 
         expect(fill).to.have.property('paramsForSwap')
         expect(fill.paramsForSwap).to.be.eql({
-          counterpartyPubKey: fakePayTo,
+          counterpartyPubKey: 'asd0f9uasf09u',
           swapHash: fakeSwapHash,
           inbound: {
             symbol: fill.inboundSymbol,


### PR DESCRIPTION
## Description
We were passing the entire `payTo` as the `counterpartyPubKey`, when really the pubkey is the part after `ln:`. This PR fixes that bug.

## Related PRs
List related PRs if applicable


## Todos
- [x] Tests
- [ ] Documentation
- [ ] Link to Trello
