### PR TITLE
FIX: remove listeners if the stream breaks

### DIFF
--- a/broker-daemon/orderbook-service/watch-market.js
+++ b/broker-daemon/orderbook-service/watch-market.js
@@ -24,7 +24,7 @@ async function watchMarket ({ params, send, onCancel, onError, logger, orderbook
   const { market } = params
   const orderbook = orderbooks.get(market)
 
-  if(!orderbook) {
+  if (!orderbook) {
     throw new Error(`${market} is not being tracked as a market.`)
   }
 

--- a/broker-daemon/orderbook-service/watch-market.spec.js
+++ b/broker-daemon/orderbook-service/watch-market.spec.js
@@ -47,6 +47,12 @@ describe('watchMarket', () => {
     revertFunction()
   })
 
+  it('throws if there is no orderbook', () => {
+    params.market = 'ABC/XYZ'
+
+    return expect(watchMarket({ params, send: sendStub, onCancel: onCancelStub, onError: onErrorStub, logger, orderbooks }, { WatchMarketResponse })).to.eventually.be.rejectedWith('not being tracked as a market')
+  })
+
   it('creates a liveStream from the store', () => {
     watchMarket({ params, send: sendStub, onCancel: onCancelStub, onError: onErrorStub, logger, orderbooks }, { WatchMarketResponse })
 


### PR DESCRIPTION
## Description
When orderbook listeners die (either by closing the stream or erroring) or event emitter keeps triggering and trying to send data to streams that are closed.

This is problematic for two reasons:
- grpc doesn't like when you send data to dead streams
- it's a memory leak

This PR fixes that issue.

## Related PRs
Parallel to https://github.com/kinesis-exchange/relayer/pull/76


## Todos
- [x] Tests
- [x] Documentation
- [ ] Link to Trello
