### PR TITLE
use createRefundInvoice separately from payInvoice

### DIFF
--- a/broker-daemon/state-machines/fill-state-machine.js
+++ b/broker-daemon/state-machines/fill-state-machine.js
@@ -184,6 +184,8 @@ const FillStateMachine = StateMachine.factory({
       this.logger.debug(`Attempting to pay fees for fill: ${fillId}`)
 
       const [feeRefundPaymentRequest, depositRefundPaymentRequest] = await Promise.all([
+        this.engine.createRefundInvoice(feePaymentRequest),
+        this.engine.createRefundInvoice(depositPaymentRequest),
         this.engine.payInvoice(feePaymentRequest),
         this.engine.payInvoice(depositPaymentRequest)
       ])

--- a/broker-daemon/state-machines/fill-state-machine.spec.js
+++ b/broker-daemon/state-machines/fill-state-machine.spec.js
@@ -310,6 +310,7 @@ describe('FillStateMachine', () => {
     let fakeFill
     let fsm
     let payInvoiceStub
+    let createRefundInvoiceStub
     let fillOrderStub
     let subscribeExecuteStub
     let subscribeExecuteStream
@@ -320,7 +321,8 @@ describe('FillStateMachine', () => {
 
     beforeEach(async () => {
       invoice = '1234'
-      payInvoiceStub = sinon.stub().returns(invoice)
+      payInvoiceStub = sinon.stub()
+      createRefundInvoiceStub = sinon.stub().returns(invoice)
       fillOrderStub = sinon.stub()
       subscribeExecuteStream = {
         on: sinon.stub()
@@ -331,7 +333,7 @@ describe('FillStateMachine', () => {
       fillId = '1234'
 
       fakeFill = { feePaymentRequest, depositPaymentRequest, fillId }
-      engine = { payInvoice: payInvoiceStub }
+      engine = { payInvoice: payInvoiceStub, createRefundInvoice: createRefundInvoiceStub }
       relayer = {
         takerService: {
           fillOrder: fillOrderStub,
@@ -353,6 +355,16 @@ describe('FillStateMachine', () => {
     it('pays a deposit invoice', async () => {
       await fsm.fillOrder()
       expect(payInvoiceStub).to.have.been.calledWith(depositPaymentRequest)
+    })
+
+    it('creates a fee refund invoice', async () => {
+      await fsm.fillOrder()
+      expect(createRefundInvoiceStub).to.have.been.calledWith(feePaymentRequest)
+    })
+
+    it('creates a deposit refund invoice', async () => {
+      await fsm.fillOrder()
+      expect(createRefundInvoiceStub).to.have.been.calledWith(depositPaymentRequest)
     })
 
     it('fills an order on the relayer', async () => {

--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -187,6 +187,8 @@ const OrderStateMachine = StateMachine.factory({
       this.logger.debug(`Attempting to pay fees for order: ${orderId}`)
 
       const [feeRefundPaymentRequest, depositRefundPaymentRequest] = await Promise.all([
+        this.engine.createRefundInvoice(feePaymentRequest),
+        this.engine.createRefundInvoice(depositPaymentRequest),
         this.engine.payInvoice(feePaymentRequest),
         this.engine.payInvoice(depositPaymentRequest)
       ])

--- a/broker-daemon/state-machines/order-state-machine.spec.js
+++ b/broker-daemon/state-machines/order-state-machine.spec.js
@@ -327,6 +327,7 @@ describe('OrderStateMachine', () => {
     let fakeOrder
     let osm
     let payInvoiceStub
+    let createRefundInvoiceStub
     let placeOrderStub
     let subscribeFillStub
     let subscribeFillStreamStub
@@ -337,7 +338,8 @@ describe('OrderStateMachine', () => {
 
     beforeEach(async () => {
       invoice = '1234'
-      payInvoiceStub = sinon.stub().returns(invoice)
+      payInvoiceStub = sinon.stub()
+      createRefundInvoiceStub = sinon.stub().returns(invoice)
       placeOrderStub = sinon.stub()
       subscribeFillStreamStub = {
         on: sinon.stub()
@@ -348,7 +350,7 @@ describe('OrderStateMachine', () => {
       orderId = '1234'
 
       fakeOrder = { feePaymentRequest, depositPaymentRequest, orderId }
-      engine = { payInvoice: payInvoiceStub }
+      engine = { payInvoice: payInvoiceStub, createRefundInvoice: createRefundInvoiceStub }
       relayer = {
         makerService: {
           placeOrder: placeOrderStub,
@@ -370,6 +372,16 @@ describe('OrderStateMachine', () => {
     it('pays a deposit invoice', async () => {
       await osm.place()
       expect(payInvoiceStub).to.have.been.calledWith(depositPaymentRequest)
+    })
+
+    it('creates a deposit refund invoice', async () => {
+      await osm.place()
+      expect(createRefundInvoiceStub).to.have.been.calledWith(feePaymentRequest)
+    })
+
+    it('pays a fee refund invoice', async () => {
+      await osm.place()
+      expect(createRefundInvoiceStub).to.have.been.calledWith(depositPaymentRequest)
     })
 
     it('places an order on the relayer', async () => {


### PR DESCRIPTION
## Description
payInvoice both paid an invoice and also created a refund invoice. I am separating these out because it is not always the case that we want to create a refund invoice when we pay an invoice.

## Related PRs
https://github.com/kinesis-exchange/lnd-engine/pull/38


## Todos
- [x] Tests
- [ ] Documentation
- [ ] Link to Trello
