### PR TITLE
FIX: re-install lnd dependencies to ensure that we have access to them

### DIFF
--- a/docker/kbd/Dockerfile
+++ b/docker/kbd/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /home/app
 
 RUN npm i --production
 
+# install lnd-engine and its dependencies
 RUN mkdir "./node_modules/lnd-engine"
 COPY node_modules/lnd-engine ./node_modules/lnd-engine
 WORKDIR ./node_modules/lnd-engine


### PR DESCRIPTION
## Description
If LND Engine has a dependency that is not shared by the broker, our current method of installation (cloning and copying) leaves those dependencies out, preventing the application from working.

This PR fixes that problem in the simplest way possible - running npm install inside of the lnd-engine directory in node_modules.

This is a naive fix - it gets rid of the advantages of de-duplication of dependencies, etc, but it will work until we install lnd-engine as a regular dependency.

## Todos
- [ ] Tests
- [x] Documentation
- [ ] Link to Trello
