### PR TITLE
Fix: install dependencies to publish cli

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,9 @@ jobs:
 # for info on workflows, see: https://circleci.com/docs/2.0/workflows/
 workflows:
   version: 2
+  build-and-test:
+    jobs:
+      - build
   master-publish-cli:
     jobs:
       - publish-cli:


### PR DESCRIPTION
## Description
We need to install dependencies in order to publish broker-cli

## Related PRs
#127 
