### PR TITLE
FIX - Resolve for proto file

### DIFF
--- a/broker-cli/broker-daemon-client/index.js
+++ b/broker-cli/broker-daemon-client/index.js
@@ -8,7 +8,7 @@ const { loadProto } = require('../utils')
  * @type {String}
  * @default
  */
-const PROTO_PATH = path.resolve('broker-cli/proto/broker.proto')
+const PROTO_PATH = path.resolve(__dirname, '..', 'proto', 'broker.proto')
 
 class BrokerDaemonClient {
   /**


### PR DESCRIPTION
## Description
`path.resolve` does not check the correct directory for our proto file. 

`path.resolve('../proto/broker.proto')` resolves to `workspace/proto` on our machines (unless NODE_PATH is set)

`const PROTO_PATH = path.resolve('broker-cli/proto/broker.proto')` resolves to the correct directory

