### PR TITLE
Feature: Add Interchain Router service

### DIFF
--- a/broker-daemon/bin/kbd
+++ b/broker-daemon/bin/kbd
@@ -19,7 +19,8 @@ const {
   DATA_DIR,
   ENGINE_TYPE,
   EXCHANGE_RPC_HOST,
-  MARKETS
+  MARKETS,
+  INTERCHAIN_ROUTER_ADDRESS
 } = process.env
 
 // LND Specific ENV variables. ONLY used if ENGINE_TYPE is LND
@@ -34,8 +35,9 @@ const {
 // TODO: Add validations to ./bin/kbd when they become available
 program
   .version(CLI_VERSION)
-  .option('--rpc-address <server>', 'Host and port to set up the RPC server on.', validations.isHost, RPC_ADDRESS)
-  .option('--data-dir <path>', 'Location to store kinesis data.', validations.isFormattedPath, DATA_DIR)
+  .option('--rpc-address <server>', 'Add a host/port to listen for daemon RPC connections', validations.isHost, RPC_ADDRESS)
+  .option('--interchain-router-address <server>', 'Add a host/port to listen for interchain router RPC connections', validations.isHost, INTERCHAIN_ROUTER_ADDRESS)
+  .option('--data-dir <path>', 'Location to store kinesis data', validations.isFormattedPath, DATA_DIR)
   .option('--markets <markets>', 'Comma-separated market names to track on startup', validations.areValidMarketNames, MARKETS)
   .option('--engine-type', 'The type of Kinesis engine. Example: lnd', null, ENGINE_TYPE)
   .option('--exchange-host', 'The host address for the Kinesis Relayer', validations.isHost, EXCHANGE_RPC_HOST)
@@ -49,7 +51,8 @@ program
     const {
       rpcAddress,
       dataDir,
-      markets
+      markets,
+      interchainRouterAddress
       // engineType,
       // exchangeHost,
       // lndRpc,
@@ -57,7 +60,7 @@ program
       // lndMacaroon
     } = opts
 
-    return new BrokerDaemon(rpcAddress, dataDir, markets)
+    return new BrokerDaemon(rpcAddress, dataDir, markets, interchainRouterAddress)
   })
 
 program.parse(process.argv)

--- a/broker-daemon/index.spec.js
+++ b/broker-daemon/index.spec.js
@@ -5,12 +5,14 @@ const BrokerDaemon = rewire(path.resolve('broker-daemon', 'index'))
 
 describe('broker daemon', () => {
   let grpcServer
+  let interchainRouter
   let eventEmitter
   let level
   let sublevel
   let logger
   let brokerDaemon
   let grpcServerListenSpy
+  let interchainRouterListenSpy
   let initializeMarketsSpy
 
   beforeEach(() => {
@@ -21,6 +23,9 @@ describe('broker daemon', () => {
     grpcServer = sinon.stub()
     grpcServer.prototype.listen = grpcServerListenSpy
     grpcServer.prototype.initializeMarkets = initializeMarketsSpy
+    interchainRouterListenSpy = sinon.stub()
+    interchainRouter = sinon.stub()
+    interchainRouter.prototype.listen = interchainRouterListenSpy
     eventEmitter = sinon.stub()
     logger = {
       error: sinon.spy(),
@@ -31,6 +36,7 @@ describe('broker daemon', () => {
     BrokerDaemon.__set__('sublevel', sublevel)
     BrokerDaemon.__set__('events', eventEmitter)
     BrokerDaemon.__set__('GrpcServer', grpcServer)
+    BrokerDaemon.__set__('InterchainRouter', interchainRouter)
     BrokerDaemon.__set__('logger', logger)
 
     brokerDaemon = new BrokerDaemon()
@@ -38,35 +44,63 @@ describe('broker daemon', () => {
 
   describe('grpc server', () => {
     it('starts a grpc server', async () => {
-      await brokerDaemon
       expect(grpcServerListenSpy).to.have.been.calledWith(brokerDaemon.rpcAddress)
     })
   })
 
   describe('rpcAddress', () => {
     let defaultAddress
-    let rpcAddress
 
     beforeEach(() => {
       defaultAddress = '0.0.0.0:27492'
-      rpcAddress = 'rpcAddress'
-      BrokerDaemon.__set__('RPC_ADDRESS', rpcAddress)
     })
 
     it('sets a default address if parameter and env is not set', async () => {
-      await brokerDaemon
       expect(brokerDaemon.rpcAddress).to.be.eql(defaultAddress)
     })
 
     it('sets an rpc address from an ENV variable', async () => {
-      await brokerDaemon
+      const rpcAddress = 'rpcAddress'
+      BrokerDaemon.__set__('RPC_ADDRESS', rpcAddress)
+      brokerDaemon = new BrokerDaemon()
       expect(brokerDaemon.rpcAddress).to.be.eql(rpcAddress)
     })
 
     it('sets an RPC address from parameters', async () => {
       let customRpcAddress = '127.0.0.1'
-      brokerDaemon = await new BrokerDaemon(customRpcAddress)
+      brokerDaemon = new BrokerDaemon(customRpcAddress)
       expect(brokerDaemon.rpcAddress).to.be.eql(customRpcAddress)
+    })
+  })
+
+  describe('interchain router', () => {
+    it('starts the interchain router', async () => {
+      expect(interchainRouterListenSpy).to.have.been.calledWith(brokerDaemon.interchainRouterAddress)
+    })
+  })
+
+  describe('interchainRouterAddress', () => {
+    let defaultAddress
+
+    beforeEach(() => {
+      defaultAddress = '0.0.0.0:40369'
+    })
+
+    it('sets a default address if parameter and env is not set', async () => {
+      expect(brokerDaemon.interchainRouterAddress).to.be.eql(defaultAddress)
+    })
+
+    it('sets an rpc address from an ENV variable', async () => {
+      const customIRAddress = '127.0.0.1'
+      BrokerDaemon.__set__('INTERCHAIN_ROUTER_ADDRESS', customIRAddress)
+      brokerDaemon = new BrokerDaemon()
+      expect(brokerDaemon.interchainRouterAddress).to.be.eql(customIRAddress)
+    })
+
+    it('sets an RPC address from parameters', async () => {
+      let customIRAddress = '127.0.0.1'
+      brokerDaemon = new BrokerDaemon(null, null, null, customIRAddress)
+      expect(brokerDaemon.interchainRouterAddress).to.be.eql(customIRAddress)
     })
   })
 })

--- a/broker-daemon/interchain-router/external-preimage-service.js
+++ b/broker-daemon/interchain-router/external-preimage-service.js
@@ -1,0 +1,37 @@
+const { GrpcServerStreamingMethod } = require('grpc-methods')
+const { loadProto } = require('../utils')
+const getPreimage = require('./get-preimage')
+
+/**
+ * @class gRPC service for retrieving preimages stored externally
+ */
+class ExternalPreimageService {
+  /**
+   * @param  {String} protoPath full file path to the .proto file for the ExternalPreimageService definition
+   * @param  {Object} options
+   * @param  {Object} options.logger Logger to be used in methods
+   * @return {ExternalPreimageService}
+   */
+  constructor (protoPath, { logger }) {
+    this.protoPath = protoPath
+    this.proto = loadProto(this.protoPath)
+
+    this.definition = this.proto.ExternalPreimageService.service
+    this.serviceName = 'ExternalPreimageService'
+
+    this.implementation = {
+      getPreimage: new GrpcServerStreamingMethod(getPreimage, this.messageId('getPreimage'), { logger }).register()
+    }
+  }
+
+  /**
+   * Create a logging string specific to this service and method
+   * @param  {String} methodName
+   * @return {String}
+   */
+  messageId (methodName) {
+    return `[${this.serviceName}:${methodName}]`
+  }
+}
+
+module.exports = ExternalPreimageService

--- a/broker-daemon/interchain-router/external-preimage-service.spec.js
+++ b/broker-daemon/interchain-router/external-preimage-service.spec.js
@@ -1,0 +1,112 @@
+const path = require('path')
+const { expect, rewire, sinon } = require('test/test-helper')
+
+const ExternalPreimageService = rewire(path.resolve(__dirname, 'external-preimage-service'))
+
+describe('ExternalPreimageService', () => {
+  let getPreimageStub
+  let GrpcMethod
+  let register
+  let fakeRegistered
+  let loadProto
+  let proto
+
+  let protoPath
+  let logger
+
+  let server
+
+  beforeEach(() => {
+    protoPath = 'fakePath'
+    proto = {
+      ExternalPreimageService: {
+        service: 'fakeService'
+      }
+    }
+    logger = {
+      info: sinon.stub(),
+      error: sinon.stub()
+    }
+
+    GrpcMethod = sinon.stub()
+    fakeRegistered = sinon.stub()
+    register = sinon.stub().returns(fakeRegistered)
+    GrpcMethod.prototype.register = register
+    ExternalPreimageService.__set__('GrpcServerStreamingMethod', GrpcMethod)
+
+    loadProto = sinon.stub().returns(proto)
+    ExternalPreimageService.__set__('loadProto', loadProto)
+
+    getPreimageStub = sinon.stub()
+    ExternalPreimageService.__set__('getPreimage', getPreimageStub)
+  })
+
+  beforeEach(() => {
+    server = new ExternalPreimageService(protoPath, { logger })
+  })
+
+  it('assigns a proto path', () => {
+    expect(server).to.have.property('protoPath')
+    expect(server.protoPath).to.be.equal(protoPath)
+  })
+
+  it('loads the proto', () => {
+    expect(loadProto).to.have.been.calledOnce()
+    expect(loadProto).to.have.been.calledWith(protoPath)
+  })
+
+  it('assigns the proto', () => {
+    expect(server).to.have.property('proto')
+    expect(server.proto).to.be.equal(proto)
+  })
+
+  it('assigns the definition', () => {
+    expect(server).to.have.property('definition')
+    expect(server.definition).to.be.equal(proto.ExternalPreimageService.service)
+  })
+
+  it('creates a name', () => {
+    expect(server).to.have.property('serviceName')
+    expect(server.serviceName).to.be.a('string')
+    expect(server.serviceName).to.be.eql('ExternalPreimageService')
+  })
+
+  it('exposes an implementation', () => {
+    expect(server).to.have.property('implementation')
+    expect(server.implementation).to.be.an('object')
+  })
+
+  describe('#getPreimage', () => {
+    let callOrder = 0
+    let callArgs
+
+    beforeEach(() => {
+      callArgs = GrpcMethod.args[callOrder]
+    })
+
+    it('exposes an implementation', () => {
+      expect(server.implementation).to.have.property('getPreimage')
+      expect(server.implementation.getPreimage).to.be.a('function')
+    })
+
+    it('creates a GrpcMethod', () => {
+      expect(GrpcMethod).to.have.been.called()
+      expect(GrpcMethod).to.have.been.calledWithNew()
+      expect(server.implementation.getPreimage).to.be.equal(fakeRegistered)
+    })
+
+    it('provides the method', () => {
+      expect(callArgs[0]).to.be.equal(getPreimageStub)
+    })
+
+    it('provides a message id', () => {
+      expect(callArgs[1]).to.be.equal('[ExternalPreimageService:getPreimage]')
+    })
+
+    describe('request options', () => {
+      it('passes in the logger', () => {
+        expect(callArgs[2]).to.have.property('logger', logger)
+      })
+    })
+  })
+})

--- a/broker-daemon/interchain-router/get-preimage.js
+++ b/broker-daemon/interchain-router/get-preimage.js
@@ -1,0 +1,20 @@
+
+/**
+ * Gets a preimage from another chain by making a payment if the
+ * inbound preimage meets its criteria.
+ *
+ * CURRENTLY UNIMPLEMENTED
+ *
+ * @param  {Object}   request.params   Parameters of the request
+ * @param  {Function} request.send     Send responses back to the client
+ * @param  {Function} request.onCancel Handle cancellations of the stream by the client
+ * @param  {Function} request.onError  Handle errors in the stream with the client
+ * @param  {Object}   request.logger
+ * @return {String}   base64 encoded string of the preimage
+ * @throws {Error} If it is called, as the method is currently unimplemented
+ */
+async function getPreimage ({ params, send, onCancel, onError, logger }) {
+  throw new Error('getPreimage is unimplemented')
+}
+
+module.exports = getPreimage

--- a/broker-daemon/interchain-router/get-preimage.spec.js
+++ b/broker-daemon/interchain-router/get-preimage.spec.js
@@ -1,0 +1,22 @@
+const path = require('path')
+const { expect, rewire } = require('test/test-helper')
+
+const getPreimage = rewire(path.resolve(__dirname, 'get-preimage'))
+
+describe('getPreimage', () => {
+  let params
+
+  beforeEach(() => {
+    params = {
+      paymentHash: 'as09fdjasdf09ja0dsf==',
+      amount: '1000000',
+      symbol: 'BTC',
+      timeLock: '1000000',
+      bestHeight: '900000'
+    }
+  })
+
+  it('throws an Error', () => {
+    return expect(getPreimage({ params })).to.eventually.be.rejectedWith(Error)
+  })
+})

--- a/broker-daemon/interchain-router/index.js
+++ b/broker-daemon/interchain-router/index.js
@@ -1,0 +1,42 @@
+const grpc = require('grpc')
+const path = require('path')
+const ExternalPreimageService = require('./external-preimage-service')
+
+/**
+ * @constant
+ * @type {String}
+ * @default
+ */
+const PROTO_PATH = path.resolve(__dirname, 'rpc.proto')
+
+/**
+ * Interchain Router for retriving preimages from other payment channel networks
+ *
+ * @author kinesis
+ */
+class InterchainRouter {
+  /**
+   * Create a new Interchain Router instance
+   * @param  {Object} logger
+   * @return {InterchainRouter}
+   */
+  constructor (logger) {
+    this.logger = logger
+    this.server = new grpc.Server()
+    this.externalPreimageService = new ExternalPreimageService(PROTO_PATH, this)
+    this.server.addService(this.externalPreimageService.definition, this.externalPreimageService.implementation)
+  }
+
+  /**
+   * Binds a given rpc address for our grpc server
+   *
+   * @param {String} host Hostname and port to listen on
+   * @returns {void}
+   */
+  listen (host) {
+    this.server.bind(host, grpc.ServerCredentials.createInsecure())
+    this.server.start()
+  }
+}
+
+module.exports = InterchainRouter

--- a/broker-daemon/interchain-router/index.spec.js
+++ b/broker-daemon/interchain-router/index.spec.js
@@ -1,0 +1,86 @@
+const path = require('path')
+const { expect, rewire, sinon } = require('test/test-helper')
+
+const InterchainRouter = rewire(path.resolve(__dirname))
+
+describe('InterchainRouter', () => {
+  let grpc
+  let grpcServer
+  let ExternalPreimageService
+  let logger
+  let router
+  let PROTO_PATH = InterchainRouter.__get__('PROTO_PATH')
+
+  beforeEach(() => {
+    grpcServer = {
+      addService: sinon.stub(),
+      bind: sinon.stub(),
+      start: sinon.stub()
+    }
+    grpc = {
+      Server: sinon.stub(),
+      ServerCredentials: {
+        createInsecure: sinon.stub()
+      }
+    }
+    Object.assign(grpc.Server.prototype, grpcServer)
+    InterchainRouter.__set__('grpc', grpc)
+
+    ExternalPreimageService = sinon.stub()
+    Object.assign(ExternalPreimageService.prototype, {
+      implementation: sinon.stub(),
+      definition: sinon.stub()
+    })
+    InterchainRouter.__set__('ExternalPreimageService', ExternalPreimageService)
+
+    logger = {
+      info: sinon.stub(),
+      error: sinon.stub(),
+      log: sinon.stub()
+    }
+
+    router = new InterchainRouter(logger)
+  })
+
+  describe('#constructor', () => {
+    it('assigns a logger', () => {
+      expect(router).to.have.property('logger', logger)
+    })
+
+    it('creates a grpc server', () => {
+      expect(grpc.Server).to.have.been.calledOnce()
+      expect(grpc.Server).to.have.been.calledWithNew()
+      expect(router.server).to.be.instanceOf(grpc.Server)
+    })
+
+    it('creates an ExternalPreimageService', () => {
+      expect(ExternalPreimageService).to.have.been.calledOnce()
+      expect(ExternalPreimageService).to.have.been.calledWithNew()
+      expect(ExternalPreimageService).to.have.been.calledWith(PROTO_PATH, router)
+      expect(router.externalPreimageService).to.be.instanceOf(ExternalPreimageService)
+    })
+
+    it('adds the ExternalPreimageService to the grpc server', () => {
+      expect(grpcServer.addService).to.have.been.calledOnce()
+      expect(grpcServer.addService).to.have.been.calledWith(ExternalPreimageService.prototype.definition, ExternalPreimageService.prototype.implementation)
+    })
+  })
+
+  describe('#listen', () => {
+    let host
+
+    beforeEach(() => {
+      host = '0.0.0.0:12345'
+      router.listen(host)
+    })
+
+    it('binds to the host', () => {
+      expect(grpcServer.bind).to.have.been.calledOnce()
+      expect(grpcServer.bind).to.have.been.calledWith(host)
+    })
+
+    it('starts the server', () => {
+      expect(grpcServer.start).to.have.been.calledOnce()
+    })
+  })
+})

--- a/broker-daemon/interchain-router/rpc.proto
+++ b/broker-daemon/interchain-router/rpc.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+enum Symbol {
+  BTC = 0;
+  LTC = 1;
+}
+
+message GetPreimageRequest {
+ // Hash of the payment for which we want to retrieve the preimage
+ bytes payment_hash = 1;
+
+ // The amount of the payment, in integer units (e.g. Satoshis)
+ int64 amount = 5;
+ // Symbol of the amount
+ Symbol symbol = 6;
+
+ // time lock of the payment extended to us
+ int64 time_lock = 10;
+ // current height of the blockchain
+ int64 best_height = 11;
+}
+
+message GetPreimageResponse {
+  // preimage for the requested payment
+  bytes payment_preimage = 1;
+}
+
+service ExternalPreimageService {
+  rpc GetPreimage (GetPreimageRequest) returns (stream GetPreimageResponse);
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       # - GRPC_TRACE=all
       - NODE_PATH=.
       - RPC_ADDRESS=0.0.0.0:27492
+      - INTERCHAIN_ROUTER_ADDRESS=0.0.0.0:40369
       - DATA_DIR=/data
       - LND_HOST=lnd_btc:10009
       - LND_TLS_CERT=/shared/lnd-engine-tls.cert


### PR DESCRIPTION
## Description
This change adds the skeleton of an Interchain Router that exposes
a gRPC service for retrieving an external preimage.

It creates the basic proto file for the ExternalPreimageService,
and adds a placeholder function for retrieving the preimage, which
currently throws an error as it is unimplemented.

It also initializes the Interchain Router on BrokerDaemon startup,
using the same pattern established by `GrpcServer`.

## Related PRs
None yet.

## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
