### PR TITLE
FIX: Store block order id directly on fills and orders

### DIFF
--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -1,7 +1,7 @@
 const EventEmitter = require('events')
 const { promisify } = require('util')
 const safeid = require('generate-safe-id')
-const { BlockOrder, Order } = require('../models')
+const { BlockOrder, Order, Fill } = require('../models')
 const { OrderStateMachine, FillStateMachine } = require('../state-machines')
 const { BlockOrderNotFoundError } = require('./errors')
 const { Big, getRecords } = require('../utils')
@@ -23,6 +23,8 @@ class BlockOrderWorker extends EventEmitter {
     super()
     this.orderbooks = orderbooks
     this.store = store
+    this.ordersStore = store.sublevel('orders')
+    this.fillsStore = store.sublevel('fills')
     this.logger = logger
     this.relayer = relayer
     this.engine = engine
@@ -88,8 +90,18 @@ class BlockOrderWorker extends EventEmitter {
     const blockOrder = BlockOrder.fromStorage(blockOrderId, value)
 
     const { relayer, engine, logger } = this
-    const openOrders = await OrderStateMachine.getAll({ store: this.store.sublevel(blockOrder.id).sublevel('orders'), relayer, engine, logger })
-    const fills = await FillStateMachine.getAll({ store: this.store.sublevel(blockOrder.id).sublevel('fills'), relayer, engine, logger })
+    const openOrders = await OrderStateMachine.getAll(
+      { store: this.ordersStore, relayer, engine, logger },
+      // limit the orders we retrieve to those that belong to this blockOrder, i.e. those that are in
+      // its prefix range.
+      Order.rangeForBlockOrder(blockOrder.id)
+    )
+    const fills = await FillStateMachine.getAll(
+      { store: this.fillsStore, relayer, engine, logger },
+      // limit the fills we retrieve to those that belong to this blockOrder, i.e. those that are in
+      // its prefix range.
+      Fill.rangeForBlockOrder(blockOrder.id)
+    )
 
     blockOrder.openOrders = openOrders
     blockOrder.fills = fills
@@ -116,12 +128,17 @@ class BlockOrderWorker extends EventEmitter {
     }
 
     const blockOrder = BlockOrder.fromStorage(blockOrderId, value)
-    const orderStore = this.store.sublevel(blockOrder.id).sublevel('orders')
 
-    const orders = await getRecords(orderStore, (key, value) => {
-      const { order, state } = JSON.parse(value)
-      return { order: Order.fromObject(key, order), state }
-    })
+    const orders = await getRecords(
+      this.ordersStore,
+      (key, value) => {
+        const { order, state } = JSON.parse(value)
+        return { order: Order.fromObject(key, order), state }
+      },
+      // limit the orders we retrieve to those that belong to this blockOrder, i.e. those that are in
+      // its prefix range.
+      Order.rangeForBlockOrder(blockOrder.id)
+    )
 
     this.logger.info(`Found ${orders.length} orders associated with Block Order ${blockOrder.id}`)
 
@@ -189,6 +206,7 @@ class BlockOrderWorker extends EventEmitter {
 
     const blockOrder = BlockOrder.fromStorage(blockOrderId, value)
 
+    // TODO: fail the remaining orders that are tied to this block order in the ordersStore?
     blockOrder.fail()
 
     await promisify(this.store.put)(blockOrder.key, blockOrder.value)
@@ -274,7 +292,7 @@ class BlockOrderWorker extends EventEmitter {
 
     // state machine params
     const { relayer, engine, logger } = this
-    const store = this.store.sublevel(blockOrder.id).sublevel('orders')
+    const store = this.ordersStore
 
     this.logger.info('Creating order for BlockOrder', { blockOrderId: blockOrder.id })
 
@@ -288,6 +306,7 @@ class BlockOrderWorker extends EventEmitter {
           this.failBlockOrder(blockOrder.id, err)
         }
       },
+      blockOrder.id,
       { side, baseSymbol, counterSymbol, baseAmount, counterAmount }
     )
 
@@ -309,7 +328,7 @@ class BlockOrderWorker extends EventEmitter {
 
     // state machine params
     const { relayer, engine, logger } = this
-    const store = this.store.sublevel(blockOrder.id).sublevel('fills')
+    const store = this.fillsStore
 
     const promisedFills = orders.map((order, index) => {
       const depthRemaining = targetDepth.minus(currentDepth)
@@ -336,6 +355,7 @@ class BlockOrderWorker extends EventEmitter {
             this.failBlockOrder(blockOrder.id, err)
           }
         },
+        blockOrder.id,
         order,
         { fillAmount }
       )

--- a/broker-daemon/models/block-order.spec.js
+++ b/broker-daemon/models/block-order.spec.js
@@ -294,7 +294,7 @@ describe('BlockOrder', () => {
               put: sinon.stub(),
               createReadStream: sinon.stub()
             }
-          }, { key: 'mykey',
+          }, { key: 'blockid:mykey',
             value: JSON.stringify({
               order: {
                 baseSymbol: 'BTC',
@@ -376,7 +376,7 @@ describe('BlockOrder', () => {
               put: sinon.stub(),
               createReadStream: sinon.stub()
             }
-          }, { key: 'mykey',
+          }, { key: 'blockid:mykey',
             value: JSON.stringify({
               fill: {
                 order: {

--- a/broker-daemon/models/fill.spec.js
+++ b/broker-daemon/models/fill.spec.js
@@ -35,10 +35,13 @@ describe('Fill', () => {
         fillAmount: '9000',
         swapHash: 'asdfasdf'
       }
+      const blockOrderId = 'blockid'
       const fillId = 'myid'
+      const key = `${blockOrderId}:${fillId}`
 
-      const fill = Fill.fromStorage(fillId, JSON.stringify(params))
+      const fill = Fill.fromStorage(key, JSON.stringify(params))
 
+      expect(fill).to.have.property('blockOrderId', blockOrderId)
       expect(fill).to.have.property('fillId', fillId)
       expect(fill).to.have.property('fillAmount', params.fillAmount)
       expect(fill).to.have.property('swapHash', params.swapHash)
@@ -65,9 +68,11 @@ describe('Fill', () => {
         feePaymentRequest: 'myrequest',
         depositPaymentRequest: 'yourrequest'
       }
+      const blockOrderId = 'blockid'
       const fillId = 'myid'
+      const key = `${blockOrderId}:${fillId}`
 
-      const fill = Fill.fromStorage(fillId, JSON.stringify(params))
+      const fill = Fill.fromStorage(key, JSON.stringify(params))
 
       expect(fill).to.have.property('fillId', fillId)
       expect(fill).to.have.property('feePaymentRequest', params.feePaymentRequest)
@@ -93,10 +98,13 @@ describe('Fill', () => {
         fillAmount: '9000',
         swapHash: 'asdfasdf'
       }
+      const blockOrderId = 'blockid'
       const fillId = 'myid'
+      const key = `${blockOrderId}:${fillId}`
 
-      const fill = Fill.fromObject(fillId, params)
+      const fill = Fill.fromObject(key, params)
 
+      expect(fill).to.have.property('blockOrderId', blockOrderId)
       expect(fill).to.have.property('fillId', fillId)
       expect(fill).to.have.property('fillAmount', params.fillAmount)
       expect(fill).to.have.property('swapHash', params.swapHash)
@@ -123,9 +131,11 @@ describe('Fill', () => {
         feePaymentRequest: 'myrequest',
         depositPaymentRequest: 'yourrequest'
       }
+      const blockOrderId = 'blockid'
       const fillId = 'myid'
+      const key = `${blockOrderId}:${fillId}`
 
-      const fill = Fill.fromObject(fillId, params)
+      const fill = Fill.fromObject(key, params)
 
       expect(fill).to.have.property('fillId', fillId)
       expect(fill).to.have.property('feePaymentRequest', params.feePaymentRequest)
@@ -133,8 +143,20 @@ describe('Fill', () => {
     })
   })
 
+  describe('::rangeForBlockOrder', () => {
+    it('creates a range for block orders', () => {
+      const blockOrderId = 'blockid'
+
+      expect(Fill.rangeForBlockOrder(blockOrderId)).to.be.eql({
+        gte: 'blockid:' + '\x00',
+        lte: 'blockid:' + '\uffff'
+      })
+    })
+  })
+
   describe('new', () => {
     it('creates an fill', () => {
+      const blockOrderId = 'blockid'
       const order = {
         orderId: 'fakeId',
         baseSymbol: 'BTC',
@@ -147,8 +169,9 @@ describe('Fill', () => {
         fillAmount: '9000'
       }
 
-      const fill = new Fill(order, params)
+      const fill = new Fill(blockOrderId, order, params)
 
+      expect(fill).to.have.property('blockOrderId', blockOrderId)
       expect(fill).to.have.property('fillAmount', params.fillAmount)
       expect(fill).to.have.property('order')
       expect(fill.order).to.have.property('orderId', order.orderId)
@@ -160,6 +183,7 @@ describe('Fill', () => {
     })
 
     it('throws if using an invalid side', () => {
+      const blockOrderId = 'blockid'
       const order = {
         orderId: '1asdf',
         baseSymbol: 'BTC',
@@ -174,7 +198,7 @@ describe('Fill', () => {
       }
 
       expect(() => {
-        new Fill(order, params) // eslint-disable-line
+        new Fill(blockOrderId, order, params) // eslint-disable-line
       }).to.throw()
     })
   })
@@ -183,8 +207,10 @@ describe('Fill', () => {
     let params
     let fill
     let order
+    let blockOrderId
 
     beforeEach(() => {
+      blockOrderId = 'blockid'
       order = {
         orderId: 'fakeId',
         baseSymbol: 'BTC',
@@ -198,7 +224,7 @@ describe('Fill', () => {
         takerPayTo: 'ln:asdfasdf'
       }
 
-      fill = new Fill(order, params)
+      fill = new Fill(blockOrderId, order, params)
     })
 
     describe('inbound/outbound getters', () => {
@@ -234,7 +260,7 @@ describe('Fill', () => {
         const fakeId = 'fakeId'
         fill.fillId = fakeId
 
-        expect(fill).to.have.property('key', fakeId)
+        expect(fill).to.have.property('key', `${blockOrderId}:${fakeId}`)
       })
     })
 

--- a/broker-daemon/models/order.spec.js
+++ b/broker-daemon/models/order.spec.js
@@ -39,10 +39,13 @@ describe('Order', () => {
         ownerId: 'fakeID',
         payTo: 'ln:123019230jasofdij'
       }
+      const blockOrderId = 'blockid'
       const orderId = 'myid'
+      const key = `${blockOrderId}:${orderId}`
 
-      const order = Order.fromStorage(orderId, JSON.stringify(params))
+      const order = Order.fromStorage(key, JSON.stringify(params))
 
+      expect(order).to.have.property('blockOrderId', blockOrderId)
       expect(order).to.have.property('orderId', orderId)
       expect(order).to.have.property('baseSymbol', params.baseSymbol)
       expect(order).to.have.property('counterSymbol', params.counterSymbol)
@@ -65,10 +68,13 @@ describe('Order', () => {
         feePaymentRequest: 'myrequest',
         depositPaymentRequest: 'yourrequest'
       }
+      const blockOrderId = 'blockid'
       const orderId = 'myid'
+      const key = `${blockOrderId}:${orderId}`
 
-      const order = Order.fromStorage(orderId, JSON.stringify(params))
+      const order = Order.fromStorage(key, JSON.stringify(params))
 
+      expect(order).to.have.property('blockOrderId', blockOrderId)
       expect(order).to.have.property('orderId', orderId)
       expect(order).to.have.property('feePaymentRequest', params.feePaymentRequest)
       expect(order).to.have.property('depositPaymentRequest', params.depositPaymentRequest)
@@ -90,10 +96,13 @@ describe('Order', () => {
         ownerId: 'fakeID',
         payTo: 'ln:123019230jasofdij'
       }
+      const blockOrderId = 'blockid'
       const orderId = 'myid'
+      const key = `${blockOrderId}:${orderId}`
 
-      const order = Order.fromObject(orderId, params)
+      const order = Order.fromObject(key, params)
 
+      expect(order).to.have.property('blockOrderId', blockOrderId)
       expect(order).to.have.property('orderId', orderId)
       expect(order).to.have.property('baseSymbol', params.baseSymbol)
       expect(order).to.have.property('counterSymbol', params.counterSymbol)
@@ -116,18 +125,33 @@ describe('Order', () => {
         feePaymentRequest: 'myrequest',
         depositPaymentRequest: 'yourrequest'
       }
+      const blockOrderId = 'blockid'
       const orderId = 'myid'
+      const key = `${blockOrderId}:${orderId}`
 
-      const order = Order.fromObject(orderId, params)
+      const order = Order.fromObject(key, params)
 
+      expect(order).to.have.property('blockOrderId', blockOrderId)
       expect(order).to.have.property('orderId', orderId)
       expect(order).to.have.property('feePaymentRequest', params.feePaymentRequest)
       expect(order).to.have.property('depositPaymentRequest', params.depositPaymentRequest)
     })
   })
 
+  describe('::rangeForBlockOrder', () => {
+    it('creates a range for block orders', () => {
+      const blockOrderId = 'blockid'
+
+      expect(Order.rangeForBlockOrder(blockOrderId)).to.be.eql({
+        gte: 'blockid:' + '\x00',
+        lte: 'blockid:' + '\uffff'
+      })
+    })
+  })
+
   describe('new', () => {
     it('creates an order', () => {
+      const blockOrderId = 'blockid'
       const params = {
         baseSymbol: 'BTC',
         counterSymbol: 'LTC',
@@ -138,7 +162,7 @@ describe('Order', () => {
         payTo: 'ln:123019230jasofdij'
       }
 
-      const order = new Order(params)
+      const order = new Order(blockOrderId, params)
 
       expect(order).to.have.property('baseSymbol', params.baseSymbol)
       expect(order).to.have.property('counterSymbol', params.counterSymbol)
@@ -150,6 +174,7 @@ describe('Order', () => {
     })
 
     it('creates an ask', () => {
+      const blockOrderId = 'blockid'
       const params = {
         baseSymbol: 'BTC',
         counterSymbol: 'LTC',
@@ -160,12 +185,13 @@ describe('Order', () => {
         payTo: 'ln:123019230jasofdij'
       }
 
-      const order = new Order(params)
+      const order = new Order(blockOrderId, params)
 
       expect(order).to.have.property('side', 'ASK')
     })
 
     it('throws if using an invalid side', () => {
+      const blockOrderId = 'blockid'
       const params = {
         baseSymbol: 'BTC',
         counterSymbol: 'LTC',
@@ -177,7 +203,7 @@ describe('Order', () => {
       }
 
       expect(() => {
-        new Order(params) // eslint-disable-line
+        new Order(blockOrderId, params) // eslint-disable-line
       }).to.throw()
     })
   })
@@ -185,8 +211,10 @@ describe('Order', () => {
   describe('instance', () => {
     let params
     let order
+    let blockOrderId
 
     beforeEach(() => {
+      blockOrderId = 'blockid'
       params = {
         baseSymbol: 'BTC',
         counterSymbol: 'LTC',
@@ -197,7 +225,7 @@ describe('Order', () => {
         payTo: 'ln:123019230jasofdij'
       }
 
-      order = new Order(params)
+      order = new Order(blockOrderId, params)
     })
 
     describe('inbound/outbound getters', () => {
@@ -223,7 +251,7 @@ describe('Order', () => {
         const fakeId = 'fakeId'
         order.orderId = fakeId
 
-        expect(order).to.have.property('key', fakeId)
+        expect(order).to.have.property('key', `${blockOrderId}:${fakeId}`)
       })
     })
 

--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -131,6 +131,7 @@ const OrderStateMachine = StateMachine.factory({
      * on the Relayer fails.
      *
      * @param  {Object} lifecycle             Lifecycle object passed by javascript-state-machine
+     * @param  {String} blockOrderid          Id of the block order that the order belongs to
      * @param  {String} options.side          Side of the market being taken (i.e. BID or ASK)
      * @param  {String} options.baseSymbol    Base symbol (e.g. BTC)
      * @param  {String} options.counterSymbol Counter symbol (e.g. LTC)
@@ -138,13 +139,13 @@ const OrderStateMachine = StateMachine.factory({
      * @param  {String} options.counterAmount Amount of counter currency (in base units) to be traded
      * @return {void}
      */
-    onBeforeCreate: async function (lifecycle, { side, baseSymbol, counterSymbol, baseAmount, counterAmount }) {
+    onBeforeCreate: async function (lifecycle, blockOrderId, { side, baseSymbol, counterSymbol, baseAmount, counterAmount }) {
       // TODO: move payTo translation somewhere else
       // TODO: figure out a way to cache the publicKey instead of making a request
       const payTo = `ln:${await this.engine.getPublicKey()}`
       const ownerId = 'TODO: create real owner ids'
 
-      this.order = new Order({ baseSymbol, counterSymbol, side, baseAmount, counterAmount, payTo, ownerId })
+      this.order = new Order(blockOrderId, { baseSymbol, counterSymbol, side, baseAmount, counterAmount, payTo, ownerId })
 
       const { orderId, feePaymentRequest, depositPaymentRequest } = await this.relayer.makerService.createOrder(this.order.paramsForCreate)
       this.order.setCreatedParams({ orderId, feePaymentRequest, depositPaymentRequest })
@@ -287,13 +288,15 @@ const OrderStateMachine = StateMachine.factory({
 
 /**
  * Instantiate and create an order
+ * This method is a pure pass through to the state machine, so any parameter checking should happen in
+ * `data` and `onBeforeCreate`, respectively.
  * @param  {Object} initParams   Params to pass to the OrderStateMachine constructor (also to the `data` function)
  * @param  {Object} createParams Params to pass to the create method (also to the `onBeforeCreate` method)
  * @return {Promise<OrderStateMachine>}
  */
-OrderStateMachine.create = async function (initParams, createParams) {
+OrderStateMachine.create = async function (initParams, ...createParams) {
   const osm = new OrderStateMachine(initParams)
-  await osm.tryTo('create', createParams)
+  await osm.tryTo('create', ...createParams)
 
   return osm
 }

--- a/broker-daemon/state-machines/plugins/persistence.js
+++ b/broker-daemon/state-machines/plugins/persistence.js
@@ -234,16 +234,17 @@ class StateMachinePersistence extends StateMachinePlugin {
        * Retrieve and instantiate all state machines from a given store
        * @param  {StateMachinePersistence~Store} options[storeName] Store that contains the saved state machines
        * @param  {...Object}                     initParams         Other parameters to initialize the state machines with
+       * @param  {Object}                        readStreamOpts     Options to pass to createReadStream to filter the set
        * @return {Promise<Array<StateMachine>>}
        */
-      getAll: async function (initParams) {
+      getAll: async function (initParams, readStreamOpts = {}) {
         const store = initParams[plugin.storeName]
 
         if (!store || typeof store.createReadStream !== 'function') {
           throw new Error(`A store must be present at ${plugin.storeName} in order to use the persistence plugin`)
         }
 
-        return getRecords(store, (key, value) => this.fromStore(initParams, { key, value }))
+        return getRecords(store, (key, value) => this.fromStore(initParams, { key, value }), readStreamOpts)
       }
 
     }

--- a/broker-daemon/state-machines/plugins/persistence.spec.js
+++ b/broker-daemon/state-machines/plugins/persistence.spec.js
@@ -236,6 +236,14 @@ describe('StateMachinePersistence', () => {
       expect(store.createReadStream).to.have.been.calledOnce()
     })
 
+    it('passes readStream options to the store', async () => {
+      const opts = { gte: '0000' }
+      await Machine.getAll({ store }, opts)
+
+      expect(store.createReadStream).to.have.been.calledOnce()
+      expect(store.createReadStream).to.have.been.calledWith(opts)
+    })
+
     it('instantiates an Machine for each record', async () => {
       const machines = await Machine.getAll({ store })
 


### PR DESCRIPTION
## Description
This change gives responsibility for tracking which block order a fill/order belongs to directly to that fill/order.

Rather than relying on sublevels prefixed by block order id, we instead have a flat hierarchy with all fills and orders comingled. Each fill and order stores their block order as a prefix to their id, allowing the block order worker to retrieve them with a ranged query.

This should have no impact on performance, since it's the same operation that sublevel was performing under the hood, but it gives us more flexibility to apply indexes to the fill and order stores.

## Related PRs
List related PRs if applicable


## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
