### PR TITLE
grab relayer.proto from relayer-proto repo

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,8 +15,8 @@ npm run broker-proto
 
 echo "Downloading relayer proto files"
 rm -rf ./proto/relayer
-git clone git@github.com:kinesis-exchange/relayer.git ./proto/relayer
-cp ./proto/relayer/proto/relayer.proto ./proto/
+git clone git@github.com:kinesis-exchange/relayer-proto.git ./proto/relayer
+cp ./proto/relayer/relayer.proto ./proto/
 rm -rf ./proto/relayer
 
 echo "Installing lnd-engine"


### PR DESCRIPTION
## Description
The relayer.proto now gets pushed from the relayer to the relayer-proto public repo, and the broker should now read from the relayer.proto located on the relayer-proto.

## Related PRs
https://github.com/kinesis-exchange/relayer/pull/95


## Todos
- [ ] Tests
- [ ] Documentation
- [x] Link to Trello
