### PR TITLE
fix fromStorage methods to parse order and fill objects out of statemachine records

### DIFF
--- a/broker-daemon/models/fill.js
+++ b/broker-daemon/models/fill.js
@@ -244,13 +244,13 @@ class Fill {
   }
 
   /**
-   * Create an instance of an order from a stored copy
-   * @param  {String} key   Unique key for the order, i.e. its `orderId`
-   * @param  {String} value Stringified representation of the order
-   * @return {Order}        Inflated order object
+   * Create an instance of an fill object from a stored copy
+   * @param  {String} key   Unique key for the order, i.e. its `fillId`
+   * @param  {String} fillStateMachineRecord Stringified representation of the order
+   * @return {Object} Inflated fill object
    */
-  static fromStorage (key, value) {
-    return this.fromObject(key, JSON.parse(value))
+  static fromStorage (key, fillStateMachineRecord) {
+    return this.fromObject(key, JSON.parse(fillStateMachineRecord).fill)
   }
 
   /**

--- a/broker-daemon/models/fill.spec.js
+++ b/broker-daemon/models/fill.spec.js
@@ -24,16 +24,18 @@ describe('Fill', () => {
 
     it('creates orders from a key and value', () => {
       const params = {
-        order: {
-          orderId: 'fakeID',
-          baseSymbol: 'BTC',
-          counterSymbol: 'LTC',
-          side: 'BID',
-          baseAmount: '10000',
-          counterAmount: '100000'
-        },
-        fillAmount: '9000',
-        swapHash: 'asdfasdf'
+        fill: {
+          order: {
+            orderId: 'fakeID',
+            baseSymbol: 'BTC',
+            counterSymbol: 'LTC',
+            side: 'BID',
+            baseAmount: '10000',
+            counterAmount: '100000'
+          },
+          fillAmount: '9000',
+          swapHash: 'asdfasdf'
+        }
       }
       const blockOrderId = 'blockid'
       const fillId = 'myid'
@@ -43,30 +45,32 @@ describe('Fill', () => {
 
       expect(fill).to.have.property('blockOrderId', blockOrderId)
       expect(fill).to.have.property('fillId', fillId)
-      expect(fill).to.have.property('fillAmount', params.fillAmount)
-      expect(fill).to.have.property('swapHash', params.swapHash)
+      expect(fill).to.have.property('fillAmount', params.fill.fillAmount)
+      expect(fill).to.have.property('swapHash', params.fill.swapHash)
       expect(fill).to.have.property('order')
-      expect(fill.order).to.have.property('baseSymbol', params.order.baseSymbol)
-      expect(fill.order).to.have.property('counterSymbol', params.order.counterSymbol)
-      expect(fill.order).to.have.property('side', params.order.side)
-      expect(fill.order).to.have.property('baseAmount', params.order.baseAmount)
-      expect(fill.order).to.have.property('counterAmount', params.order.counterAmount)
+      expect(fill.order).to.have.property('baseSymbol', params.fill.order.baseSymbol)
+      expect(fill.order).to.have.property('counterSymbol', params.fill.order.counterSymbol)
+      expect(fill.order).to.have.property('side', params.fill.order.side)
+      expect(fill.order).to.have.property('baseAmount', params.fill.order.baseAmount)
+      expect(fill.order).to.have.property('counterAmount', params.fill.order.counterAmount)
     })
 
     it('assigns parameters from after fill creation to the fill object', () => {
       const params = {
-        order: {
-          orderId: 'fakeID',
-          baseSymbol: 'BTC',
-          counterSymbol: 'LTC',
-          side: 'BID',
-          baseAmount: '10000',
-          counterAmount: '100000'
-        },
-        fillAmount: '9000',
-        swapHash: 'asdfasdf',
-        feePaymentRequest: 'myrequest',
-        depositPaymentRequest: 'yourrequest'
+        fill: {
+          order: {
+            orderId: 'fakeID',
+            baseSymbol: 'BTC',
+            counterSymbol: 'LTC',
+            side: 'BID',
+            baseAmount: '10000',
+            counterAmount: '100000'
+          },
+          fillAmount: '9000',
+          swapHash: 'asdfasdf',
+          feePaymentRequest: 'myrequest',
+          depositPaymentRequest: 'yourrequest'
+        }
       }
       const blockOrderId = 'blockid'
       const fillId = 'myid'
@@ -75,8 +79,8 @@ describe('Fill', () => {
       const fill = Fill.fromStorage(key, JSON.stringify(params))
 
       expect(fill).to.have.property('fillId', fillId)
-      expect(fill).to.have.property('feePaymentRequest', params.feePaymentRequest)
-      expect(fill).to.have.property('depositPaymentRequest', params.depositPaymentRequest)
+      expect(fill).to.have.property('feePaymentRequest', params.fill.feePaymentRequest)
+      expect(fill).to.have.property('depositPaymentRequest', params.fill.depositPaymentRequest)
     })
   })
 

--- a/broker-daemon/models/order.js
+++ b/broker-daemon/models/order.js
@@ -209,11 +209,11 @@ class Order {
   /**
    * Create an instance of an order from a stored copy
    * @param  {String} key   Unique key for the order, i.e. its `orderId`
-   * @param  {String} value Stringified representation of the order
+   * @param  {String} orderStateMachineRecord Stringified representation of the order state machine record
    * @return {Order}        Inflated order object
    */
-  static fromStorage (key, value) {
-    return this.fromObject(key, JSON.parse(value))
+  static fromStorage (key, orderStateMachineRecord) {
+    return this.fromObject(key, JSON.parse(orderStateMachineRecord).order)
   }
 
   /**

--- a/broker-daemon/models/order.spec.js
+++ b/broker-daemon/models/order.spec.js
@@ -31,13 +31,15 @@ describe('Order', () => {
 
     it('creates orders from a key and value', () => {
       const params = {
-        baseSymbol: 'BTC',
-        counterSymbol: 'LTC',
-        side: 'BID',
-        baseAmount: '10000',
-        counterAmount: '100000',
-        ownerId: 'fakeID',
-        payTo: 'ln:123019230jasofdij'
+        order: {
+          baseSymbol: 'BTC',
+          counterSymbol: 'LTC',
+          side: 'BID',
+          baseAmount: '10000',
+          counterAmount: '100000',
+          ownerId: 'fakeID',
+          payTo: 'ln:123019230jasofdij'
+        }
       }
       const blockOrderId = 'blockid'
       const orderId = 'myid'
@@ -47,26 +49,28 @@ describe('Order', () => {
 
       expect(order).to.have.property('blockOrderId', blockOrderId)
       expect(order).to.have.property('orderId', orderId)
-      expect(order).to.have.property('baseSymbol', params.baseSymbol)
-      expect(order).to.have.property('counterSymbol', params.counterSymbol)
-      expect(order).to.have.property('side', params.side)
-      expect(order).to.have.property('baseAmount', params.baseAmount)
-      expect(order).to.have.property('counterAmount', params.counterAmount)
-      expect(order).to.have.property('ownerId', params.ownerId)
-      expect(order).to.have.property('payTo', params.payTo)
+      expect(order).to.have.property('baseSymbol', params.order.baseSymbol)
+      expect(order).to.have.property('counterSymbol', params.order.counterSymbol)
+      expect(order).to.have.property('side', params.order.side)
+      expect(order).to.have.property('baseAmount', params.order.baseAmount)
+      expect(order).to.have.property('counterAmount', params.order.counterAmount)
+      expect(order).to.have.property('ownerId', params.order.ownerId)
+      expect(order).to.have.property('payTo', params.order.payTo)
     })
 
     it('assigns parameters from after order creation to the order object', () => {
       const params = {
-        baseSymbol: 'BTC',
-        counterSymbol: 'LTC',
-        side: 'BID',
-        baseAmount: '10000',
-        counterAmount: '100000',
-        ownerId: 'fakeID',
-        payTo: 'ln:123019230jasofdij',
-        feePaymentRequest: 'myrequest',
-        depositPaymentRequest: 'yourrequest'
+        order: {
+          baseSymbol: 'BTC',
+          counterSymbol: 'LTC',
+          side: 'BID',
+          baseAmount: '10000',
+          counterAmount: '100000',
+          ownerId: 'fakeID',
+          payTo: 'ln:123019230jasofdij',
+          feePaymentRequest: 'myrequest',
+          depositPaymentRequest: 'yourrequest'
+        }
       }
       const blockOrderId = 'blockid'
       const orderId = 'myid'
@@ -76,8 +80,8 @@ describe('Order', () => {
 
       expect(order).to.have.property('blockOrderId', blockOrderId)
       expect(order).to.have.property('orderId', orderId)
-      expect(order).to.have.property('feePaymentRequest', params.feePaymentRequest)
-      expect(order).to.have.property('depositPaymentRequest', params.depositPaymentRequest)
+      expect(order).to.have.property('feePaymentRequest', params.order.feePaymentRequest)
+      expect(order).to.have.property('depositPaymentRequest', params.order.depositPaymentRequest)
     })
   })
 


### PR DESCRIPTION
## Description
The Order and Fill ::fromStorage methods actually pull statemachine objects from the db, so the order and fill objects needed to be extracted out of the full statemachine object.

## Related PRs
List related PRs if applicable


## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
