### PR TITLE
edit build script to define dynamic github private key

### DIFF
--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -17,4 +17,4 @@ GITHUB_KEY_PATH=${GITHUB_PRIVATE_KEY_PATH:-~/.ssh/id_rsa}
 
 # NOTE: The names specified with `-t` directly map to the service names in
 # the applicable services docker-compose file
-docker build -t kinesis_kbd ./docker/kbd/ --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)"
+docker build -t kinesis_kbd ./docker/kbd/ --build-arg SSH_PRIVATE_KEY="$(cat $GITHUB_KEY_PATH)"


### PR DESCRIPTION
## Description
This PR adds the ability to set a `GITHUB_PRIVATE_KEY_PATH` on the host machine that will be used to build docker images for the broker.
