### PR TITLE
add cli path to allow broker to start

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
       - lnd_ltc
     volumes:
       - './broker-daemon:/home/app/broker-daemon/'
+      # TODO: This can be removed once utils are moved to a shared repo or into
+      # the broker-daemon itself. broker-daemon relies on these utils for ./broker-daemon/bin/kbd
+      - './broker-cli:/home/app/broker-cli/'
       - './proto:/home/app/proto/'
       - '/home/app/node_modules'
       - './node_modules/lnd-engine:/home/app/node_modules/lnd-engine'


### PR DESCRIPTION
## Description
This PR mounts broker-cli to the host to allow `./broker-daemon/bin/kbd` to use validations on startup.

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
