### PR TITLE
FEATURE: add engines to the blockorderworker

### DIFF
--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -12,14 +12,15 @@ const { Big, getRecords, SublevelIndex } = require('../utils')
 class BlockOrderWorker extends EventEmitter {
   /**
    * Create a new BlockOrderWorker instance
-   * @param  {Map} options.orderbooks         Collection of all active Orderbooks
-   * @param  {sublevel} options.store         Sublevel in which to store block orders and child orders
-   * @param  {Object} options.logger
-   * @param  {RelayerClient} options.relayer
-   * @param  {Engine} options.engine
+   * @param  {Map<String, Orderbook>} options.orderbooks Collection of all active Orderbooks
+   * @param  {sublevel}               options.store      Sublevel in which to store block orders and child orders
+   * @param  {Object}                 options.logger
+   * @param  {RelayerClient}          options.relayer
+   * @param  {Map<String, Engine>}    options.engines    Collection of all available engines
+   * @param  {Engine}                 options.engine     Single engine, kept for backward compatibility until all dependencies use `engines`
    * @return {BlockOrderWorker}
    */
-  constructor ({ orderbooks, store, logger, relayer, engine }) {
+  constructor ({ orderbooks, store, logger, relayer, engines, engine }) {
     super()
     this.orderbooks = orderbooks
     this.store = store
@@ -27,6 +28,7 @@ class BlockOrderWorker extends EventEmitter {
     this.fillsStore = store.sublevel('fills')
     this.logger = logger
     this.relayer = relayer
+    this.engines = engines
     this.engine = engine
 
     const filterOrdersWithHash = (key, value) => !!Order.fromStorage(key, value).swapHash

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -20,6 +20,7 @@ describe('BlockOrderWorker', () => {
   let logger
   let relayer
   let engine
+  let engines
 
   let secondLevel
 
@@ -102,12 +103,13 @@ describe('BlockOrderWorker', () => {
     }
     relayer = sinon.stub()
     engine = sinon.stub()
+    engines = new Map([ ['BTC', sinon.stub()] ])
   })
 
   describe('new', () => {
     let worker
     beforeEach(() => {
-      worker = new BlockOrderWorker({ orderbooks, store, logger, relayer, engine })
+      worker = new BlockOrderWorker({ orderbooks, store, logger, relayer, engines, engine })
     })
 
     it('assigns the orderbooks', () => {
@@ -140,6 +142,10 @@ describe('BlockOrderWorker', () => {
 
     it('assigns the engine', () => {
       expect(worker).to.have.property('engine', engine)
+    })
+
+    it('assigns the engines', () => {
+      expect(worker).to.have.property('engines', engines)
     })
 
     it('creates an index for the orders store', async () => {

--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -99,6 +99,7 @@ class BrokerDaemon {
 
     this.blockOrderWorker = new BlockOrderWorker({
       relayer: this.relayer,
+      engines: this.engines,
       engine: this.engine,
       orderbooks: this.orderbooks,
       store: this.store.sublevel('block-orders'),

--- a/broker-daemon/index.spec.js
+++ b/broker-daemon/index.spec.js
@@ -171,6 +171,11 @@ describe('broker daemon', () => {
       expect(BlockOrderWorker).to.have.been.calledWith(sinon.match({ engine: sinon.match.instanceOf(LndEngine) }))
     })
 
+    it('provides the engines to the BlockOrderWorker', () => {
+      expect(BlockOrderWorker).to.have.been.calledWith(sinon.match({ engines: sinon.match.instanceOf(Map) }))
+      expect(BlockOrderWorker.args[0][0].engines.values().next().value).to.be.an.instanceOf(LndEngine)
+    })
+
     it('provides the orderbooks to the BlockOrderWorker', () => {
       expect(BlockOrderWorker).to.have.been.calledWith(sinon.match({ orderbooks: sinon.match.instanceOf(Map) }))
     })


### PR DESCRIPTION
## Description
This change makes the multi-engine map available in the BlockOrderWorker. It keeps the single engine in place for backward compatibility until the various parts can be upgraded to add engine selection.

## Related PRs
#144 

## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
