### PR TITLE
FIX: rename EXCHANGE_RPC to the more appropriate RELAYER_RPC

### DIFF
--- a/broker-daemon/bin/kbd.js
+++ b/broker-daemon/bin/kbd.js
@@ -16,7 +16,7 @@ const { version: CLI_VERSION } = require('../../package.json')
 const {
   RPC_ADDRESS,
   DATA_DIR,
-  EXCHANGE_RPC_HOST,
+  RELAYER_RPC_HOST,
   MARKETS,
   INTERCHAIN_ROUTER_ADDRESS
 } = process.env
@@ -28,7 +28,7 @@ program
   .option('--interchain-router-address <server>', 'Add a host/port to listen for interchain router RPC connections', validations.isHost, INTERCHAIN_ROUTER_ADDRESS)
   .option('--data-dir <path>', 'Location to store kinesis data', validations.isFormattedPath, DATA_DIR)
   .option('--markets <markets>', 'Comma-separated market names to track on startup', validations.areValidMarketNames, MARKETS)
-  .option('--relayer-host', 'The host address for the Kinesis Relayer', validations.isHost, EXCHANGE_RPC_HOST)
+  .option('--relayer-host', 'The host address for the Kinesis Relayer', validations.isHost, RELAYER_RPC_HOST)
 
 for (let currency of currencies) {
   let lowerSymbol = currency.symbol.toLowerCase()

--- a/broker-daemon/broker-rpc/admin-service/get-daemon-config.js
+++ b/broker-daemon/broker-rpc/admin-service/get-daemon-config.js
@@ -13,7 +13,7 @@ async function getDaemonConfig ({ logger, engine }, { GetDaemonConfigResponse })
 
   const {
     MARKETS: daemonDefaultMarkets,
-    EXCHANGE_RPC_HOST: relayerRpcHost,
+    RELAYER_RPC_HOST: relayerRpcHost,
     EXCHANGE_LND_HOST: relayerLndHost,
     LND_EXTERNAL_ADDRESS: daemonLndHost,
     EXTERNAL_ADDRESS: daemonRpcHost

--- a/broker-daemon/broker-rpc/admin-service/get-daemon-config.spec.js
+++ b/broker-daemon/broker-rpc/admin-service/get-daemon-config.spec.js
@@ -34,7 +34,7 @@ describe('get-daemon-config', () => {
 
     revert = getDaemonConfig.__set__('process', {
       env: {
-        EXCHANGE_RPC_HOST: rpcHost,
+        RELAYER_RPC_HOST: rpcHost,
         EXCHANGE_LND_HOST: lndHost,
         MARKETS: markets,
         EXTERNAL_ADDRESS: daemonExternal,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       # This address is specifically tied to the relayer network
       # This is a temporary workaround for preventing the use of external networks
       # for the relayer. In a testnet/mainnet setting, this will be a public IP.
-      - EXCHANGE_RPC_HOST=docker.for.mac.host.internal:28492
+      - RELAYER_RPC_HOST=docker.for.mac.host.internal:28492
       - EXCHANGE_LND_HOST=docker.for.mac.host.internal:10111
       - LND_EXTERNAL_ADDRESS=docker.for.mac.host.internal:10112
       - EXTERNAL_ADDRESS=docker.for.mac.host.internal:27492


### PR DESCRIPTION
## Description
Gets rid of the old description of the Relayer as "EXCHANGE".

There is one hanging reference, but it is used on `getDaemonConfig`, which needs close to a complete re-write if we still need it.

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [x] Link to Trello
