### PR TITLE
remove anywhere that still has notion of singular engine

### DIFF
--- a/broker-daemon/broker-rpc/broker-rpc-server.js
+++ b/broker-daemon/broker-rpc/broker-rpc-server.js
@@ -20,16 +20,15 @@ const BROKER_PROTO_PATH = './broker-daemon/proto/broker.proto'
  */
 class BrokerRPCServer {
   /**
-   * @param  {Logger}           opts.logger
-   * @param  {Engine}           opts.engine
-   * @param  {RelayerClient}    opts.relayer
-   * @param  {BlockOrderWorker} opts.blockOrderWorker
-   * @param  {Map<Orderbook>}   opts.orderbooks
+   * @param  {Logger}              opts.logger
+   * @param  {Map<String, Engine>} opts.engines
+   * @param  {RelayerClient}       opts.relayer
+   * @param  {BlockOrderWorker}    opts.blockOrderWorker
+   * @param  {Map<Orderbook>}      opts.orderbooks
    * @return {BrokerRPCServer}
    */
-  constructor ({ logger, engines, engine, relayer, blockOrderWorker, orderbooks } = {}) {
+  constructor ({ logger, engines, relayer, blockOrderWorker, orderbooks } = {}) {
     this.logger = logger
-    this.engine = engine
     this.engines = engines
     this.relayer = relayer
     this.blockOrderWorker = blockOrderWorker
@@ -39,7 +38,7 @@ class BrokerRPCServer {
 
     this.server = new grpc.Server()
 
-    this.adminService = new AdminService(this.protoPath, { logger, relayer, engine, engines })
+    this.adminService = new AdminService(this.protoPath, { logger, relayer, engines })
     this.server.addService(this.adminService.definition, this.adminService.implementation)
 
     this.orderService = new OrderService(this.protoPath, { logger, blockOrderWorker })

--- a/broker-daemon/broker-rpc/broker-rps-server.spec.js
+++ b/broker-daemon/broker-rpc/broker-rps-server.spec.js
@@ -16,7 +16,6 @@ describe('BrokerRPCServer', () => {
   let walletService
   let pathResolve
   let protoPath
-  let engine
   let engines
 
   beforeEach(() => {
@@ -56,7 +55,6 @@ describe('BrokerRPCServer', () => {
       Server: rpcServer
     })
 
-    engine = sinon.stub()
     engines = new Map()
 
     protoPath = 'mypath'
@@ -112,10 +110,10 @@ describe('BrokerRPCServer', () => {
       const logger = 'mylogger'
       const relayer = 'myrelayer'
 
-      const server = new BrokerRPCServer({ logger, relayer, engine, engines })
+      const server = new BrokerRPCServer({ logger, relayer, engines })
 
       expect(AdminService).to.have.been.calledOnce()
-      expect(AdminService).to.have.been.calledWith(protoPath, sinon.match({ logger, relayer, engine, engines }))
+      expect(AdminService).to.have.been.calledWith(protoPath, sinon.match({ logger, relayer, engines }))
       expect(AdminService).to.have.been.calledWithNew()
       expect(server).to.have.property('adminService')
       expect(server.adminService).to.be.equal(adminService)

--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -92,8 +92,6 @@ class BrokerDaemon {
     this.engines = new Map(Object.entries(engines || {}).map(([ symbol, engineConfig ]) => {
       return [ symbol, createEngineFromConfig(symbol, engines[symbol], { logger: this.logger }) ]
     }))
-    // REMOVE THIS WHEN WE IMPLEMENT ENGINE ID: temporary mapping to not break the broker
-    this.engine = this.engines.values().next().value
 
     this.orderbooks = new Map()
 
@@ -108,7 +106,6 @@ class BrokerDaemon {
     this.rpcServer = new BrokerRPCServer({
       logger: this.logger,
       engines: this.engines,
-      engine: this.engine,
       relayer: this.relayer,
       orderbooks: this.orderbooks,
       blockOrderWorker: this.blockOrderWorker

--- a/broker-daemon/index.spec.js
+++ b/broker-daemon/index.spec.js
@@ -124,11 +124,6 @@ describe('broker daemon', () => {
       expect(LndEngine).to.have.been.calledOnce()
       expect(LndEngine).to.have.been.calledWith(engines.BTC.lndRpc, 'BTC', { logger, tlsCertPath: engines.BTC.lndTls, macaroonPath: engines.BTC.lndMacaroon })
     })
-
-    it('TEMPORARILY aliases the first engine', () => {
-      expect(brokerDaemon).to.have.property('engine')
-      expect(brokerDaemon.engine).to.be.equal(brokerDaemon.engines.get('BTC'))
-    })
   })
 
   describe('InterchainRouter', () => {


### PR DESCRIPTION
## Description
Now that we use multiple engines that are identified by symbol, we do not have a notion of one singular engine to call. This PR just removes any remaining places that we use the legacy engine. 

## Todos
- [x] Tests
- [x] Documentation
- [ ] Link to Trello
