### PR TITLE
FIX - remove unused code related to default currency configuration

### DIFF
--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -8,9 +8,6 @@ require('colors')
 const BrokerDaemonClient = require('../broker-daemon-client')
 const { ENUMS, validations, askQuestion, Big } = require('../utils')
 const { currencies: currencyConfig } = require('../configuration')
-const {
-  config: { default_currency_symbol: DEFAULT_CURRENCY_SYMBOL }
-} = require('../package.json')
 
 /**
  * @constant
@@ -125,10 +122,6 @@ async function newDepositAddress (args, opts, logger) {
 async function commitBalance (args, opts, logger) {
   const { symbol } = args
   const { rpcAddress = null } = opts
-
-  if (DEFAULT_CURRENCY_SYMBOL !== symbol) {
-    return logger.info('Please switch the daemon to another supported currency.')
-  }
 
   try {
     const client = new BrokerDaemonClient(rpcAddress)

--- a/broker-cli/commands/wallet.spec.js
+++ b/broker-cli/commands/wallet.spec.js
@@ -156,7 +156,6 @@ describe('cli wallet', () => {
 
       program.__set__('BrokerDaemonClient', daemonStub)
       program.__set__('askQuestion', askQuestionStub)
-      program.__set__('DEFAULT_CURRENCY_SYMBOL', symbol)
     })
 
     beforeEach(async () => {

--- a/broker-cli/package.json
+++ b/broker-cli/package.json
@@ -1,12 +1,8 @@
 {
   "name": "broker-cli",
   "version": "0.1.0-alpha-preview",
-  "description": "",
+  "description": "Broker CLI utility to interact with the Broker Daemon on the Kinesis Exchange",
   "main": "./bin/kcli",
-  "config": {
-    "daemon": "kbd",
-    "default_currency_symbol": "BTC"
-  },
   "scripts": {
     "format": "standard --fix",
     "pretest": "npm run format; exit 0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
   "name": "broker",
   "version": "0.1.0-alpha-preview",
-  "description": "",
+  "description": "Broker software to interact with the Kinesis Exchange",
   "main": "index.js",
   "config": {
     "project_name": "broker",
-    "daemon": "kbd",
-    "default_currency_symbol": "BTC"
+    "daemon": "kbd"
   },
   "scripts": {
     "prebuild": "bash ./scripts/prebuild.sh",
@@ -18,8 +17,6 @@
     "pretest": "npm run format; exit 0",
     "test": "NODE_PATH=. mocha 'broker-cli/**/*.spec.js' 'broker-daemon/**/*.spec.js'",
     "coverage": "nyc npm test",
-    "docker-coverage": "docker-compose exec $npm_package_config_daemon npm run coverage",
-    "docker-test": "docker-compose exec $npm_package_config_daemon npm test",
     "ci-test": "bash ./scripts/ci-test.sh",
     "start-kbd": "pm2-docker pm2.json --watch",
     "fund": "bash ./scripts/fund-simnet-wallet.local.sh",


### PR DESCRIPTION
## Description
Our private-alpha release used a concept for `default_currency_symbol` to allow us to control BTC/LTC channels on a per user basis (self hosted daemons).

As long as we check SUPPORTED_SYMBOLS on all commands, we do not need a default symbol.

This PR removes default currency code.

## Related PRs
List related PRs if applicable


## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
