### PR TITLE
FIX - Change convert balance conversion to 60

### DIFF
--- a/broker-daemon/utils/convert-balance.spec.js
+++ b/broker-daemon/utils/convert-balance.spec.js
@@ -4,23 +4,30 @@ const convertBalance = require('./convert-balance')
 
 describe('convertBalance', () => {
   let balance
+  let convertedBalance
   let firstCurrency
   let secondCurrency
 
   beforeEach(() => {
-    balance = '10'
+    balance = '60'
+    convertedBalance = '3600'
     firstCurrency = 'BTC'
     secondCurrency = 'LTC'
   })
 
   it('returns the converted balance if the original balance is in the base currency', () => {
     const res = convertBalance(balance, firstCurrency, secondCurrency)
-    expect(res).to.eql('600')
+    expect(res).to.eql(convertedBalance)
   })
 
   it('returns the converted balance if the original balance is in the counter currency', () => {
-    const res = convertBalance(balance, secondCurrency, firstCurrency)
-    expect(res).to.eql('0.16666666666666666')
+    const res = convertBalance(convertedBalance, secondCurrency, firstCurrency)
+    expect(res).to.eql(balance)
+  })
+
+  it('rounds a converted balance down', () => {
+    const res = convertBalance('3659', secondCurrency, firstCurrency)
+    expect(res).to.eql(balance)
   })
 
   it('throws an error if the market conversion is not defined', () => {


### PR DESCRIPTION
## Description
We have been receiving errors for `channel to large` when relayer tried to create an LTC channel back to the broker, however this change was fixed with https://github.com/kinesis-exchange/broker/pull/176

This PR changes the MarketConversion rate of BTC/LTC to 60

## Related PRs
 https://github.com/kinesis-exchange/broker/pull/176


## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
