### PR TITLE
pass logger to insecure identity

### DIFF
--- a/broker-daemon/relayer/relayer-client.js
+++ b/broker-daemon/relayer/relayer-client.js
@@ -19,10 +19,10 @@ const RELAYER_PROTO_PATH = './proto/relayer.proto'
  * Insecure stub of Identity to be used when auth is disabled
  * @return {Object}
  */
-function insecureIdentity () {
+function insecureIdentity (logger = console) {
   return {
     authorize (id) {
-      this.logger.warn(`Not signing authorization for access to ${id}: DISABLE_AUTH is set`)
+      logger.warn(`Not signing authorization for access to ${id}: DISABLE_AUTH is set`)
       return {}
     }
   }
@@ -54,7 +54,7 @@ class RelayerClient {
 
     if (disableAuth) {
       this.logger.warn('WARNING: SSL is not enabled and no credentials will be passed to the Relayer. This is only suitable for use in development.')
-      this.identity = insecureIdentity()
+      this.identity = insecureIdentity(this.logger)
       this.credentials = credentials.createInsecure()
     } else {
       this.identity = Identity.load(privKeyPath, pubKeyPath)


### PR DESCRIPTION
## Description
This change fixes a bug when working with auth disabled where the insecure identity did not have access to a logger.

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests (skipping since this is a dev only function)
- [ ] Documentation
- [ ] Link to Trello
