### PR TITLE
Fix: add config for ext preimage for lnd

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ services:
       # This address is for development only. You must change this to a
       # tld to use in a production setting
       - EXTERNAL_ADDRESS=docker.for.mac.host.internal:10113
+      - EXTPREIMAGE_HOST=kbd:40369
       - REST_LISTEN=0.0.0.0:8101
       - DATA_DIR=/data
       - LOG_DIR=/data
@@ -136,6 +137,7 @@ services:
       # This address is for development only. You must change this to a
       # tld to use in a production setting
       - EXTERNAL_ADDRESS=docker.for.mac.host.internal:10114
+      - EXTPREIMAGE_HOST=kbd:40369
       - REST_LISTEN=0.0.0.0:8101
       - DATA_DIR=/data
       - LOG_DIR=/data


### PR DESCRIPTION
## Description
Sets up missing config for lnd engine to have an external preimage service that is the Interchain Router.

## Related PRs
https://github.com/sparkswap/lnd-engine/pull/72


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
