### PR TITLE
Docs: remove hanging paren in docs

### DIFF
--- a/broker-cli/docs/usage-notes.md
+++ b/broker-cli/docs/usage-notes.md
@@ -8,4 +8,4 @@ These block orders are then "worked" by the broker, meaning split up into indivi
 
 This structure allows the end user to submit specific desires (e.g. market price, immediate-or-cancel) without relying on the Relayer to honor it -- instead the broker is responsible for interpreting and acting on user instructions.
 
-See [Brokers Perform Self-matching]((https://sparkswap.com/docs/network-concepts#brokers-perform-self-matching)) for more information.
+See [Brokers Perform Self-matching](https://sparkswap.com/docs/network-concepts#brokers-perform-self-matching) for more information.


### PR DESCRIPTION
## Description
Extra parentheses in markdown for docs led to a bad link.

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
