### PR TITLE
Bugfix: use a named volume to persist sparkswapd data between restarts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ services:
       - './proto:/home/app/proto/'
       - '/home/app/node_modules'
       - './node_modules/lnd-engine:/home/app/node_modules/lnd-engine'
-      - '/data'
+      # block order and other sparkswap storage
+      - 'sparkswapd:/data'
       # This is populated externally w/ an engine
       - 'shared:/shared'
     environment:
@@ -181,6 +182,7 @@ volumes:
   lnd_ltc:
   bitcoin:
   litecoin:
+  sparkswapd:
 
 networks:
   broker:


### PR DESCRIPTION
## Description
We had an issue where we were losing block orders when we `down`ed containers on `sparkswapd`. This is because we weren't using a named volume, so docker compose was creating a new volume when the service came back `up`. Notably, this wasn't a problem when recreating containers, only when explicitly `down`ing them.

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
