### PR TITLE
add more information to individual commands help screen

### DIFF
--- a/broker-cli/commands/order/index.js
+++ b/broker-cli/commands/order/index.js
@@ -56,7 +56,13 @@ module.exports = (program) => {
     })
     .command(`order ${SUPPORTED_COMMANDS.STATUS}`, 'Get the status of a block order')
     .argument('<blockOrderId>', 'Block order to get status of.', validations.isBlockOrderId)
+    .option('--rpc-address', 'Location of the RPC server to use.', validations.isHost)
+    .option('--market [marketName]', 'Relevant market name', validations.isMarketName)
     .command(`order ${SUPPORTED_COMMANDS.CANCEL}`, 'Cancel a block order')
     .argument('<blockOrderId>', 'Block Order to cancel.', validations.isBlockOrderId)
+    .option('--rpc-address', 'Location of the RPC server to use.', validations.isHost)
+    .option('--market [marketName]', 'Relevant market name', validations.isMarketName)
     .command(`order ${SUPPORTED_COMMANDS.SUMMARY}`, 'View your orders.')
+    .option('--rpc-address', 'Location of the RPC server to use.', validations.isHost)
+    .option('--market [marketName]', 'Relevant market name', validations.isMarketName)
 }


### PR DESCRIPTION
## Description
This PR adds additionally information to all `order` commands. `sparkswap orders` showed the different options, however individual commands like `sparkswap order summary` did not.

## Related PRs
List related PRs if applicable


## Todos
- [n/a] Tests
- [n/a] Documentation
- [n/a] Link to Trello
