### PR TITLE
Feature: get payment channel network address of your LN node for a given currency

### DIFF
--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -34,7 +34,7 @@ const SUPPORTED_COMMANDS = Object.freeze({
   BALANCE: 'balance',
   NEW_DEPOSIT_ADDRESS: 'new-deposit-address',
   COMMIT_BALANCE: 'commit-balance',
-  PUBLIC_KEY: 'public-key'
+  NETWORK_ADDRESS: 'network-address'
 })
 
 /**
@@ -174,9 +174,9 @@ async function commitBalance (args, opts, logger) {
 }
 
 /**
- * public-key
+ * network-address
  *
- * ex: `sparkswap wallet public-key BTC`
+ * ex: `sparkswap wallet network-address BTC`
  *
  * @function
  * @param {Object} args
@@ -186,16 +186,16 @@ async function commitBalance (args, opts, logger) {
  * @param {Logger} logger
  * @return {Void}
  */
-async function publicKey (args, opts, logger) {
+async function networkAddress (args, opts, logger) {
   const { symbol } = args
   const { rpcAddress = null } = opts
 
   try {
     const client = new BrokerDaemonClient(rpcAddress)
 
-    const { publicKey } = await client.walletService.getPublicKey({ symbol: symbol.toUpperCase() })
+    const { paymentChannelNetworkAddress } = await client.walletService.getPaymentChannelNetworkAddress({ symbol: symbol.toUpperCase() })
 
-    logger.info(publicKey)
+    logger.info(paymentChannelNetworkAddress)
   } catch (e) {
     logger.error(e)
   }
@@ -204,7 +204,7 @@ async function publicKey (args, opts, logger) {
 module.exports = (program) => {
   program
     .command('wallet', 'Commands to handle a wallet instance')
-    .help('Available Commands: balance, new-deposit-address, commit-balance, public-key')
+    .help('Available Commands: balance, new-deposit-address, commit-balance, network-address')
     .argument('<command>', '', Object.values(SUPPORTED_COMMANDS), null, true)
     .argument('[sub-arguments...]')
     .option('--rpc-address', 'Location of the RPC server to use.', validations.isHost)
@@ -239,7 +239,7 @@ module.exports = (program) => {
           args.amount = amount
 
           return commitBalance(args, opts, logger)
-        case SUPPORTED_COMMANDS.PUBLIC_KEY:
+        case SUPPORTED_COMMANDS.NETWORK_ADDRESS:
           symbol = symbol.toUpperCase()
 
           if (!Object.values(SUPPORTED_SYMBOLS).includes(symbol)) {
@@ -248,7 +248,7 @@ module.exports = (program) => {
 
           args.symbol = symbol
 
-          return publicKey(args, opts, logger)
+          return networkAddress(args, opts, logger)
       }
     })
     .command('wallet balance', 'Current daemon wallet balance')
@@ -257,6 +257,6 @@ module.exports = (program) => {
     .command('wallet commit-balance')
     .argument('<symbol>', `Supported currencies for the exchange: ${SUPPORTED_SYMBOLS.join('/')}`)
     .argument('[amount]', 'Amount of currency to commit to the relayer', validations.isDecimal)
-    .command('wallet public-key', 'Payment Channel Network Public key for a given currency')
+    .command('wallet network-address', 'Payment Channel Network Public key for a given currency')
     .argument('<symbol>', `Supported currencies: ${SUPPORTED_SYMBOLS.join('/')}`)
 }

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -193,7 +193,7 @@ async function networkAddress (args, opts, logger) {
   try {
     const client = new BrokerDaemonClient(rpcAddress)
 
-    const { paymentChannelNetworkAddress } = await client.walletService.getPaymentChannelNetworkAddress({ symbol: symbol.toUpperCase() })
+    const { paymentChannelNetworkAddress } = await client.walletService.getPaymentChannelNetworkAddress({ symbol })
 
     logger.info(paymentChannelNetworkAddress)
   } catch (e) {

--- a/broker-cli/commands/wallet.spec.js
+++ b/broker-cli/commands/wallet.spec.js
@@ -42,6 +42,39 @@ describe('cli wallet', () => {
     })
   })
 
+  describe('publicKey', () => {
+    let args
+    let opts
+    let logger
+    let rpcAddress
+    let publicKeyStub
+    let daemonStub
+    let symbol
+
+    const publicKey = program.__get__('publicKey')
+
+    beforeEach(() => {
+      symbol = 'BTC'
+      args = { symbol }
+      rpcAddress = 'test:1337'
+      opts = { rpcAddress }
+      logger = { info: sinon.stub(), error: sinon.stub() }
+
+      publicKeyStub = sinon.stub()
+      daemonStub = sinon.stub()
+      daemonStub.prototype.walletService = { getPublicKey: publicKeyStub }
+
+      program.__set__('BrokerDaemonClient', daemonStub)
+
+      publicKey(args, opts, logger)
+    })
+
+    it('calls broker daemon for the pub key', () => {
+      expect(daemonStub).to.have.been.calledWith(rpcAddress)
+      expect(publicKeyStub).to.have.been.calledWith({ symbol })
+    })
+  })
+
   describe('balance', () => {
     let daemonStub
     let walletBalanceStub

--- a/broker-cli/commands/wallet.spec.js
+++ b/broker-cli/commands/wallet.spec.js
@@ -42,16 +42,16 @@ describe('cli wallet', () => {
     })
   })
 
-  describe('publicKey', () => {
+  describe('networkAddress', () => {
     let args
     let opts
     let logger
     let rpcAddress
-    let publicKeyStub
+    let networkAddressStub
     let daemonStub
     let symbol
 
-    const publicKey = program.__get__('publicKey')
+    const networkAddress = program.__get__('networkAddress')
 
     beforeEach(() => {
       symbol = 'BTC'
@@ -60,18 +60,18 @@ describe('cli wallet', () => {
       opts = { rpcAddress }
       logger = { info: sinon.stub(), error: sinon.stub() }
 
-      publicKeyStub = sinon.stub()
+      networkAddressStub = sinon.stub()
       daemonStub = sinon.stub()
-      daemonStub.prototype.walletService = { getPublicKey: publicKeyStub }
+      daemonStub.prototype.walletService = { getPaymentChannelNetworkAddress: networkAddressStub }
 
       program.__set__('BrokerDaemonClient', daemonStub)
 
-      publicKey(args, opts, logger)
+      networkAddress(args, opts, logger)
     })
 
     it('calls broker daemon for the pub key', () => {
       expect(daemonStub).to.have.been.calledWith(rpcAddress)
-      expect(publicKeyStub).to.have.been.calledWith({ symbol })
+      expect(networkAddressStub).to.have.been.calledWith({ symbol })
     })
   })
 

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -878,11 +878,11 @@ service WalletService {
    * > The above command will print:
    *
    * ```javascript
-   * > "025f08036e00e38468f52d68bb83939995440b72730bfaae99ace5630630997623@relayer.testnet.sparkswap.com:10113"
+   * > "025f08036e00e38468f52d68bb83939995440b72730bfaae99ace5630630997623@your.daemon:10113"
    * ```
    *
    * ```shell
-   * 025f08036e00e38468f52d68bb83939995440b72730bfaae99ace5630630997623@relayer.testnet.sparkswap.com:10113
+   * 025f08036e00e38468f52d68bb83939995440b72730bfaae99ace5630630997623@your.daemon:10113
    * ```
    */
   rpc GetPaymentChannelNetworkAddress (GetPaymentChannelNetworkAddressRequest) returns (GetPaymentChannelNetworkAddressResponse);

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -732,6 +732,22 @@ message CommitBalanceRequest {
 }
 
 /**
+ * Get the payment channel network address for a given currency.
+ */
+message GetPaymentChannelNetworkAddressRequest {
+  // Currency for which to retrieve the address
+  Symbol symbol = 1;
+}
+
+/**
+ * Created deposit address for a given currency.
+ */
+message GetPaymentChannelNetworkAddressResponse {
+  // Network Address retrieved
+  string payment_channel_network_address = 1;
+}
+
+/**
  * The WalletService is for interacting with the wallets managed by the Broker on behalf of the user.
  *
  * It is used primarily during set up (e.g. making deposits) of a Broker.
@@ -847,4 +863,27 @@ service WalletService {
    * ```
    */
   rpc CommitBalance (CommitBalanceRequest) returns (google.protobuf.Empty);
+  /**
+   * GetPaymentChannelNetworkAddress retrieves the Payment Channel Network Address for the given currency.
+   *
+   * ```javascript
+   * const { paymentChannelNetworkAddress } = await walletService.getPaymentChannelNetworkAddress({ symbol: 'BTC' })
+   * console.log(paymentChannelNetworkAddress)
+   * ```
+   *
+   * ```shell
+   * > sparkswap wallet network-address BTC
+   * ```
+   *
+   * > The above command will print:
+   *
+   * ```javascript
+   * > "025f08036e00e38468f52d68bb83939995440b72730bfaae99ace5630630997623@relayer.testnet.sparkswap.com:10113"
+   * ```
+   *
+   * ```shell
+   * 025f08036e00e38468f52d68bb83939995440b72730bfaae99ace5630630997623@relayer.testnet.sparkswap.com:10113
+   * ```
+   */
+  rpc GetPaymentChannelNetworkAddress (GetPaymentChannelNetworkAddressRequest) returns (GetPaymentChannelNetworkAddressResponse);
 }

--- a/broker-daemon/broker-rpc/wallet-service/get-payment-channel-network-address.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-payment-channel-network-address.js
@@ -1,0 +1,27 @@
+const { PublicError } = require('grpc-methods')
+
+/**
+ * Gets the payment channel network address from the specified engine
+ *
+ * @param {GrpcUnaryMethod~request} request - request object
+ * @param {Logger} request.logger
+ * @param {Object<String>} request.params
+ * @param {Array<Engine>} request.engines
+ * @param {Object} responses
+ * @param {Function} responses.GetPaymentChannelNetworkAddressResponse constructor
+ * @return {GetPaymentChannelNetworkAddressResponse}
+ */
+async function getPaymentChannelNetworkAddress ({ logger, params, engines }, { GetPaymentChannelNetworkAddressResponse }) {
+  const { symbol } = params
+  const engine = engines.get(symbol)
+
+  if (!engine) {
+    logger.error(`Could not find engine: ${symbol}`)
+    throw new PublicError(`Unable to get network address for symbol: ${symbol}`)
+  }
+
+  const paymentChannelNetworkAddress = await engine.getPaymentChannelNetworkAddress()
+  return new GetPaymentChannelNetworkAddressResponse({ paymentChannelNetworkAddress })
+}
+
+module.exports = getPaymentChannelNetworkAddress

--- a/broker-daemon/broker-rpc/wallet-service/get-payment-channel-network-address.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-payment-channel-network-address.spec.js
@@ -1,0 +1,51 @@
+const path = require('path')
+const { expect, rewire, sinon } = require('test/test-helper')
+
+const getPaymentChannelNetworkAddress = rewire(path.resolve(__dirname, 'get-payment-channel-network-address'))
+
+describe('get-payment-channel-network-address', () => {
+  let logger
+  let params
+  let engine
+  let engines
+  let getNetworkAddressStub
+  let getNetworkAddressResponse
+  let responseStub
+
+  before(() => {
+    logger = {
+      error: sinon.stub()
+    }
+    params = {
+      symbol: 'BTC'
+    }
+    getNetworkAddressResponse = '12345'
+    getNetworkAddressStub = sinon.stub().returns(getNetworkAddressResponse)
+    responseStub = sinon.stub()
+    engine = { getPaymentChannelNetworkAddress: getNetworkAddressStub }
+    engines = new Map([['BTC', engine]])
+  })
+
+  describe('getPaymentChannelNetworkAddress', () => {
+    beforeEach(async () => {
+      await getPaymentChannelNetworkAddress({ logger, engines, params }, { GetPaymentChannelNetworkAddressResponse: responseStub })
+    })
+
+    it('calls an engine with getPaymentChannelNetworkAddress', () => {
+      expect(getNetworkAddressStub).to.have.been.called()
+    })
+
+    it('constructs a Response', () => {
+      const paymentChannelNetworkAddress = getNetworkAddressResponse
+      expect(responseStub).to.have.been.calledWith({ paymentChannelNetworkAddress })
+    })
+  })
+
+  describe('invalid engine type', () => {
+    const badParams = {symbol: 'BAD'}
+
+    it('throws an error', () => {
+      return expect(getPaymentChannelNetworkAddress({ logger, engines, params: badParams }, { GetPaymentChannelNetworkAddressResponse: responseStub })).to.eventually.be.rejectedWith('Unable to get network address')
+    })
+  })
+})

--- a/broker-daemon/broker-rpc/wallet-service/index.js
+++ b/broker-daemon/broker-rpc/wallet-service/index.js
@@ -4,6 +4,7 @@ const { loadProto } = require('../../utils')
 const newDepositAddress = require('./new-deposit-address')
 const getBalances = require('./get-balances')
 const commitBalance = require('./commit-balance')
+const getPaymentChannelNetworkAddress = require('./get-payment-channel-network-address')
 
 /**
  * WalletService provides interactions with an engine's crypto wallet
@@ -28,6 +29,7 @@ class WalletService {
     const {
       NewDepositAddressResponse,
       GetBalancesResponse,
+      GetPaymentChannelNetworkAddressResponse,
       google: {
         protobuf: {
           Empty: EmptyResponse
@@ -38,7 +40,8 @@ class WalletService {
     this.implementation = {
       newDepositAddress: new GrpcUnaryMethod(newDepositAddress, this.messageId('newDepositAddress'), { logger, engines }, { NewDepositAddressResponse }).register(),
       getBalances: new GrpcUnaryMethod(getBalances, this.messageId('getBalances'), { logger, engines }, { GetBalancesResponse }).register(),
-      commitBalance: new GrpcUnaryMethod(commitBalance, this.messageId('commitBalance'), { logger, engines, relayer }, { EmptyResponse }).register()
+      commitBalance: new GrpcUnaryMethod(commitBalance, this.messageId('commitBalance'), { logger, engines, relayer }, { EmptyResponse }).register(),
+      getPaymentChannelNetworkAddress: new GrpcUnaryMethod(getPaymentChannelNetworkAddress, this.messageId('getPaymentChannelNetworkAddress'), { logger, engines }, { GetPaymentChannelNetworkAddressResponse }).register()
     }
   }
 

--- a/broker-daemon/broker-rpc/wallet-service/index.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/index.spec.js
@@ -14,6 +14,7 @@ describe('WalletService', () => {
   let wallet
   let registerSpy
   let newDepositAddress
+  let getPaymentChannelNetworkAddress
   let balanceSpy
   let commitBalanceSpy
 
@@ -24,6 +25,7 @@ describe('WalletService', () => {
       WalletService: { service: sinon.stub() },
       NewDepositAddressResponse: responseStub,
       GetBalancesResponse: responseStub,
+      GetPaymentChannelNetworkAddressResponse: responseStub,
       google: {
         protobuf: {
           Empty: responseStub
@@ -34,6 +36,7 @@ describe('WalletService', () => {
     engines = sinon.stub()
     relayer = sinon.stub()
     newDepositAddress = sinon.spy()
+    getPaymentChannelNetworkAddress = sinon.stub()
     balanceSpy = sinon.spy()
     commitBalanceSpy = sinon.spy()
     unaryMethodStub = sinon.stub()
@@ -45,6 +48,7 @@ describe('WalletService', () => {
     WalletService.__set__('newDepositAddress', newDepositAddress)
     WalletService.__set__('getBalances', balanceSpy)
     WalletService.__set__('commitBalance', commitBalanceSpy)
+    WalletService.__set__('getPaymentChannelNetworkAddress', getPaymentChannelNetworkAddress)
 
     wallet = new WalletService(protoPath, { logger, engines, relayer })
   })
@@ -88,6 +92,17 @@ describe('WalletService', () => {
         expectedMessageId,
         { logger, engines, relayer },
         { EmptyResponse: responseStub }
+      )
+    })
+
+    it('creates a unary method for getPaymentChannelNetworkAddress', () => {
+      const expectedMessageId = '[WalletService:getPaymentChannelNetworkAddress]'
+
+      expect(unaryMethodStub).to.have.been.calledWith(
+        getPaymentChannelNetworkAddress,
+        expectedMessageId,
+        { logger, engines },
+        { GetPaymentChannelNetworkAddressResponse: responseStub }
       )
     })
   })

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -878,11 +878,11 @@ service WalletService {
    * > The above command will print:
    *
    * ```javascript
-   * > "025f08036e00e38468f52d68bb83939995440b72730bfaae99ace5630630997623@relayer.testnet.sparkswap.com:10113"
+   * > "025f08036e00e38468f52d68bb83939995440b72730bfaae99ace5630630997623@your.daemon:10113"
    * ```
    *
    * ```shell
-   * 025f08036e00e38468f52d68bb83939995440b72730bfaae99ace5630630997623@relayer.testnet.sparkswap.com:10113
+   * 025f08036e00e38468f52d68bb83939995440b72730bfaae99ace5630630997623@your.daemon:10113
    * ```
    */
   rpc GetPaymentChannelNetworkAddress (GetPaymentChannelNetworkAddressRequest) returns (GetPaymentChannelNetworkAddressResponse);

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -732,6 +732,22 @@ message CommitBalanceRequest {
 }
 
 /**
+ * Get the payment channel network address for a given currency.
+ */
+message GetPaymentChannelNetworkAddressRequest {
+  // Currency for which to retrieve the address
+  Symbol symbol = 1;
+}
+
+/**
+ * Created deposit address for a given currency.
+ */
+message GetPaymentChannelNetworkAddressResponse {
+  // Network Address retrieved
+  string payment_channel_network_address = 1;
+}
+
+/**
  * The WalletService is for interacting with the wallets managed by the Broker on behalf of the user.
  *
  * It is used primarily during set up (e.g. making deposits) of a Broker.
@@ -847,4 +863,27 @@ service WalletService {
    * ```
    */
   rpc CommitBalance (CommitBalanceRequest) returns (google.protobuf.Empty);
+  /**
+   * GetPaymentChannelNetworkAddress retrieves the Payment Channel Network Address for the given currency.
+   *
+   * ```javascript
+   * const { paymentChannelNetworkAddress } = await walletService.getPaymentChannelNetworkAddress({ symbol: 'BTC' })
+   * console.log(paymentChannelNetworkAddress)
+   * ```
+   *
+   * ```shell
+   * > sparkswap wallet network-address BTC
+   * ```
+   *
+   * > The above command will print:
+   *
+   * ```javascript
+   * > "025f08036e00e38468f52d68bb83939995440b72730bfaae99ace5630630997623@relayer.testnet.sparkswap.com:10113"
+   * ```
+   *
+   * ```shell
+   * 025f08036e00e38468f52d68bb83939995440b72730bfaae99ace5630630997623@relayer.testnet.sparkswap.com:10113
+   * ```
+   */
+  rpc GetPaymentChannelNetworkAddress (GetPaymentChannelNetworkAddressRequest) returns (GetPaymentChannelNetworkAddressResponse);
 }


### PR DESCRIPTION
## Description
This change adds a CLI and Broker RPC command for retrieving your Payment Channel Network Address (e.g. LN PubKey), which helps with debugging.

## Related PRs
List related PRs if applicable


## Todos
- [x] Tests
- [x] Documentation
- [ ] Link to Trello
