### PR TITLE
Fix: better handling for sparkswapd failing to start

### DIFF
--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -151,7 +151,11 @@ class BrokerDaemon {
         })(),
         ...Array.from(this.engines, async ([ symbol, engine ]) => {
           this.logger.info(`Validating engine configuration for ${symbol}`)
-          await engine.validateNodeConfig()
+          try {
+            await engine.validateNodeConfig()
+          } catch (e) {
+            throw new Error(`Engine for ${symbol} failed to validate: ${e.message || e.details}`)
+          }
           this.logger.info(`Validated engine configuration for ${symbol}`)
         })
       ])
@@ -163,7 +167,9 @@ class BrokerDaemon {
       this.logger.info(`Interchain Router server started: gRPC Server listening on ${this.interchainRouterAddress}`)
     } catch (e) {
       this.logger.error('BrokerDaemon failed to initialize', { error: e.toString() })
-      this.logger.error(e)
+      this.logger.error(e.toString(), e)
+      this.logger.info('BrokerDaemon shutting down...')
+      process.exit(1)
     }
   }
 

--- a/broker-daemon/utils/logger.js
+++ b/broker-daemon/utils/logger.js
@@ -28,6 +28,7 @@ if (process.env.NODE_ENV !== 'production') {
   logger.add(new winston.transports.Console({
     format: winston.format.combine(
       winston.format.timestamp(),
+      winston.format.colorize(),
       winston.format.simple()
     )
   }))


### PR DESCRIPTION
## Description
This change shuts down the sparkswapd process if it fails to start so that pm2 can restart it.

It also improves logging from these failures to make it more clear what the issue is - particularly from the most common issue of lnd not being ready.

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
