### PR TITLE
Feature: respond to preimage requests with permanent errors

### DIFF
--- a/broker-daemon/interchain-router/get-preimage.js
+++ b/broker-daemon/interchain-router/get-preimage.js
@@ -117,7 +117,13 @@ async function getPreimage ({ params, send, onCancel, onError, ordersByHash, eng
   }
 
   logger.debug(`Sending payment to ${takerAddress} to translate swap ${swapHash}`)
-  const paymentPreimage = await outboundEngine.translateSwap(takerAddress, swapHash, outboundAmount, timeLockDelta)
+  const { paymentPreimage, permanentError } = await outboundEngine.translateSwap(takerAddress, swapHash, outboundAmount, timeLockDelta)
+
+  if (permanentError) {
+    logger.error(permanentError)
+    return send({ permanentError })
+  }
+
   logger.debug(`Completed payment to ${takerAddress} for swap ${swapHash}`)
 
   // Note: we do NOT save the order here. The Interchain Router should treat orders as Read-only routing entries

--- a/broker-daemon/interchain-router/get-preimage.spec.js
+++ b/broker-daemon/interchain-router/get-preimage.spec.js
@@ -70,40 +70,57 @@ describe('getPreimage', () => {
     expect(getRecords).to.have.been.calledWith(sinon.match.any, sinon.match.any, fakeRange)
   })
 
-  it('throws if too many orders match the hash', () => {
+  it('returns permanent error if too many orders match the hash', async () => {
     getRecords.resolves([ order, order ])
 
-    return expect(getPreimage({ params, send, ordersByHash, engines })).to.eventually.be.rejectedWith('Too many routing entries')
+    await getPreimage({ params, send, ordersByHash, engines })
+
+    expect(send).to.have.been.calledOnce()
+    expect(send).to.have.been.calledWith(sinon.match({ permanentError: sinon.match('Too many routing entries') }))
   })
 
-  it('throws if no orders match the hash', () => {
+  it('returns permanent error if no orders match the hash', async () => {
     getRecords.resolves([ ])
+    await getPreimage({ params, send, ordersByHash, engines })
 
-    return expect(getPreimage({ params, send, ordersByHash, engines })).to.eventually.be.rejectedWith('No routing entry available')
+    expect(send).to.have.been.calledOnce()
+    expect(send).to.have.been.calledWith(sinon.match({ permanentError: sinon.match('No routing entry available') }))
   })
 
-  it('throws if the amount is not at least as much as on the order', () => {
+  it('returns permanent error if the amount is not at least as much as on the order', async () => {
     params.amount = '10'
 
-    return expect(getPreimage({ params, send, ordersByHash, engines })).to.eventually.be.rejectedWith('Insufficient currency')
+    await getPreimage({ params, send, ordersByHash, engines })
+
+    expect(send).to.have.been.calledOnce()
+    expect(send).to.have.been.calledWith(sinon.match({ permanentError: sinon.match('Insufficient currency') }))
   })
 
-  it('throws if the symbol does not match the inbound symbol on the order', () => {
+  it('returns permanent error if the symbol does not match the inbound symbol on the order', async () => {
     order.inboundSymbol = 'LTC'
 
-    return expect(getPreimage({ params, send, ordersByHash, engines })).to.eventually.be.rejectedWith('Wrong currency')
+    await getPreimage({ params, send, ordersByHash, engines })
+
+    expect(send).to.have.been.calledOnce()
+    expect(send).to.have.been.calledWith(sinon.match({ permanentError: sinon.match('Wrong currency') }))
   })
 
-  it('throws if the current block height is too high for the time lock', () => {
+  it('returns permanent error if the current block height is too high for the time lock', async () => {
     params.bestHeight = '10000'
 
-    return expect(getPreimage({ params, send, ordersByHash, engines })).to.eventually.be.rejectedWith('is higher than')
+    await getPreimage({ params, send, ordersByHash, engines })
+
+    expect(send).to.have.been.calledOnce()
+    expect(send).to.have.been.calledWith(sinon.match({ permanentError: sinon.match('is higher than') }))
   })
 
-  it('throws if the outbound engine is unavailable', () => {
+  it('returns permanent error if the outbound engine is unavailable', async () => {
     order.outboundSymbol = 'XYZ'
 
-    return expect(getPreimage({ params, send, ordersByHash, engines })).to.eventually.be.rejectedWith('No engine')
+    await getPreimage({ params, send, ordersByHash, engines })
+
+    expect(send).to.have.been.calledOnce()
+    expect(send).to.have.been.calledWith(sinon.match({ permanentError: sinon.match('No engine') }))
   })
 
   it('makes a payment to the outbound engine', async () => {

--- a/broker-daemon/interchain-router/rpc.proto
+++ b/broker-daemon/interchain-router/rpc.proto
@@ -25,6 +25,8 @@ message GetPreimageRequest {
 message GetPreimageResponse {
   // preimage for the requested payment
   bytes payment_preimage = 1;
+  // permanent error that should cancel the upstream HTLC
+  string permanent_error = 2;
 }
 
 service ExternalPreimageService {


### PR DESCRIPTION
## Description
If a payment channel network node requests a preimage, but the request can never be fulfilled, we should inform that node so it can cancel the accompanying htlc.

## Related PRs
https://github.com/sparkswap/lnd-engine/pull/85
https://github.com/sparkswap/lnd/pull/11


## Todos
- [x] Tests
- [x] Documentation
- [ ] Link to Trello
