### PR TITLE
FIX - Add order authorization for cancel order

### DIFF
--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -182,7 +182,7 @@ class BlockOrderWorker extends EventEmitter {
         const orderId = order.orderId
         const authorization = this.relayer.identity.authorize(orderId)
         this.logger.debug(`Generated authorization for ${orderId}`, authorization)
-        this.relayer.makerService.cancelOrder({ orderId, authorization })
+        return this.relayer.makerService.cancelOrder({ orderId, authorization })
       }))
     } catch (e) {
       this.logger.error('Failed to cancel all orders for block order: ', { blockOrderId })

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -178,8 +178,15 @@ class BlockOrderWorker extends EventEmitter {
     this.logger.info(`Found ${openOrders.length} orders in a state to be cancelled for Block order ${blockOrder.id}`)
 
     try {
-      await Promise.all(openOrders.map(({ order }) => this.relayer.makerService.cancelOrder({ orderId: order.orderId })))
+      await Promise.all(openOrders.map(({ order }) => {
+        const orderId = order.orderId
+        const authorization = this.relayer.identity.authorize(orderId)
+        this.logger.debug(`Generated authorization for ${orderId}`, authorization)
+        this.relayer.makerService.cancelOrder({ orderId, authorization })
+      }))
     } catch (e) {
+      console.log('HERE')
+      console.log(e)
       return this.failBlockOrder(blockOrderId, e)
     }
 

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -185,9 +185,9 @@ class BlockOrderWorker extends EventEmitter {
         this.relayer.makerService.cancelOrder({ orderId, authorization })
       }))
     } catch (e) {
-      console.log('HERE')
-      console.log(e)
-      return this.failBlockOrder(blockOrderId, e)
+      this.logger.error('Failed to cancel all orders for block order: ', { blockOrderId })
+      this.failBlockOrder(blockOrderId, e)
+      throw e
     }
 
     this.logger.info(`Cancelled ${orders.length} underlying orders for ${blockOrder.id}`)

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -4,7 +4,7 @@ const { expect, rewire, sinon, delay } = require('test/test-helper')
 
 const BlockOrderWorker = rewire(path.resolve(__dirname))
 
-describe.only('BlockOrderWorker', () => {
+describe('BlockOrderWorker', () => {
   let eventsOn
   let eventsEmit
   let safeid


### PR DESCRIPTION
## Description
When a user tries to cancel an order, they are met with an ID and a statement saying the cancellation was successful, however the relayer still keeps the order on the orderbook. This is due to the broker not passing correct authorization creds to the relayer for a specific order during cancellation.

This PR adds authorization to the `sparkswap order cancel` command.

## Related PRs
List related PRs if applicable


## Todos
- [x] Tests
- [n/a] Documentation
- [x] Link to Trello
