### PR TITLE
set ordererror to undefined instead of null to prevent grpc errors an…

### DIFF
--- a/broker-daemon/models/block-order.js
+++ b/broker-daemon/models/block-order.js
@@ -191,7 +191,7 @@ class BlockOrder {
         amount: baseCommonAmount.toFixed(16),
         price: counterCommonAmount.div(baseCommonAmount).toFixed(16),
         orderStatus: state.toUpperCase(),
-        orderError: error ? error.toString() : null
+        orderError: error ? error.toString() : undefined
       }
     })
 
@@ -205,7 +205,7 @@ class BlockOrder {
         amount: baseCommonAmount.toFixed(16),
         price: counterCommonAmount.div(baseCommonAmount).toFixed(16),
         fillStatus: state.toUpperCase(),
-        fillError: error ? error.toString() : null
+        fillError: error ? error.toString() : undefined
       }
     })
 

--- a/broker-daemon/models/block-order.spec.js
+++ b/broker-daemon/models/block-order.spec.js
@@ -358,6 +358,14 @@ describe('BlockOrder', () => {
 
           expect(serialized.openOrders[0]).to.have.property('orderStatus', 'CREATED')
         })
+
+        it('returns an undefined value for orderError for a successful order', () => {
+          blockOrder.openOrders = [ osm ]
+
+          const serialized = blockOrder.serialize()
+
+          expect(serialized.openOrders[0]).to.have.property('orderError', undefined)
+        })
       })
 
       describe('fills', () => {
@@ -449,6 +457,14 @@ describe('BlockOrder', () => {
           const serialized = blockOrder.serialize()
 
           expect(serialized.fills[0]).to.have.property('fillStatus', 'CREATED')
+        })
+
+        it('returns an undefined value for fillError for a successful order', () => {
+          blockOrder.fills = [ fsm ]
+
+          const serialized = blockOrder.serialize()
+
+          expect(serialized.fills[0]).to.have.property('fillError', undefined)
         })
       })
     })

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,7 +16,7 @@ echo "It's time to BUILD! All resistance is futile."
 echo ""
 
 echo "Reinstalling dependencies"
-npm i
+npm install
 
 echo "Checking broker.proto file for issues"
 npm run broker-proto


### PR DESCRIPTION
## Description
This PR fixes an issue where looking at the summary of an order will fail due to `orderError` being set to `null` and null is then interpreted by grpc as an object.

Error Message: `Illegal value for Message.Field .Order.orderError of type string: object (proto3 field without field presence cannot be null)`

## Related PRs
List related PRs if applicable


## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
