### PR TITLE
Feature: remove the existing orderbook when receiving a signal from the relayer

### DIFF
--- a/broker-daemon/relayer/relayer-client.spec.js
+++ b/broker-daemon/relayer/relayer-client.spec.js
@@ -3,7 +3,7 @@ const { sinon, rewire, delay, expect } = require('test/test-helper')
 
 const RelayerClient = rewire(path.resolve('broker-daemon', 'relayer', 'relayer-client'))
 
-describe('RelayerClient', () => {
+describe.only('RelayerClient', () => {
   let createSslStub
   let createFromMetadataGeneratorStub
   let combineChannelCredentialsStub
@@ -22,7 +22,8 @@ describe('RelayerClient', () => {
   let ResponseType = {
     EXISTING_EVENT: 'EXISTING_EVENT',
     EXISTING_EVENTS_DONE: 'EXISTING_EVENTS_DONE',
-    NEW_EVENT: 'NEW_EVENT'
+    NEW_EVENT: 'NEW_EVENT',
+    START_OF_EVENTS: 'START_OF_EVENTS'
   }
   let fakeConsole
   let callerStub
@@ -205,6 +206,7 @@ describe('RelayerClient', () => {
     let params
     let watchMarket
     let stream
+    let migrateStore
 
     beforeEach(() => {
       stream = {
@@ -226,6 +228,10 @@ describe('RelayerClient', () => {
 
       MarketEvent.prototype.key = 'key'
       MarketEvent.prototype.value = 'value'
+
+      migrateStore = sinon.stub().resolves()
+
+      RelayerClient.__set__('migrateStore', migrateStore)
     })
 
     it('returns a promise', () => {
@@ -278,6 +284,54 @@ describe('RelayerClient', () => {
       })
 
       return relayer.watchMarket(store, params)
+    })
+
+    it('deletes the store when facing the start of events', async () => {
+      const fakeNew = { type: ResponseType.START_OF_EVENTS }
+      const fakeDone = { type: ResponseType.EXISTING_EVENTS_DONE }
+
+      stream.on.withArgs('data').callsFake(async (evt, fn) => {
+        await delay(10)
+        fn(fakeNew)
+        await delay(10)
+        fn(fakeDone)
+      })
+
+      await relayer.watchMarket(store, params)
+
+      expect(migrateStore).to.have.been.calledOnce()
+      expect(migrateStore).to.have.been.calledWith(store, store, sinon.match.func)
+
+      const migrator = migrateStore.args[0][2]
+
+      expect(migrator('hello')).to.be.eql({ type: 'del', key: 'hello' })
+    })
+
+    it('waits for migrating to be done before processing more events', async () => {
+      const fakeNew = { type: ResponseType.START_OF_EVENTS }
+      const fakeResponse = { type: ResponseType.EXISTING_EVENT, marketEvent: 'fakeEvent' }
+      const fakeDone = { type: ResponseType.EXISTING_EVENTS_DONE }
+
+      let callCount
+
+      migrateStore.callsFake(() => { return delay(15) })
+
+      stream.on.withArgs('data').callsFake(async (evt, fn) => {
+        await delay(10)
+        fn(fakeNew)
+        await delay(10)
+        fn(fakeResponse)
+        await delay(1)
+
+        callCount = store.put.callCount
+
+        fn(fakeDone)
+      })
+
+      await relayer.watchMarket(store, params)
+
+      expect(callCount).to.be.a('number')
+      expect(callCount).to.be.eql(0)
     })
 
     it('puts existing events into the store', async () => {


### PR DESCRIPTION
## Description
This change allows the broker to reset its orderbook when indicated by the Relayer. This avoids problems where old events get stuck in the broker's orderbook with no way to remove them.

The Relayer's associated change should be deployed before this one, since it depends on changes to the Relayer proto definition.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Link to Trello
