### PR TITLE
Feature/add prod docker compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,10 +16,11 @@ services:
       - lnd_btc
       - lnd_ltc
     volumes:
-      # block order and other sparkswap storage
-      - 'sparkswapd:/data'
-      # This is populated externally w/ an engine
-      - 'shared:/shared'
+      - './broker-daemon:/home/app/broker-daemon/'
+      # TODO: This can be removed once utils are moved to a shared repo or into
+      # the broker-daemon itself. broker-daemon relies on these utils for ./broker-daemon/bin/sparkswapd
+      - './broker-cli:/home/app/broker-cli/'
+      - './proto:/home/app/proto/'
 
 volumes:
   shared:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,26 @@
+##########################################
+#
+# sparkswap Broker-CLI and Broker-Daemon
+# https://sparkswap.com
+#
+# Production file to remove volume mounts from docker-compose
+#
+##########################################
+
+version: '2.4'
+
+services:
+  sparkswapd:
+    image: sparkswap_sparkswapd:latest
+    depends_on:
+      - lnd_btc
+      - lnd_ltc
+    volumes:
+      # block order and other sparkswap storage
+      - 'sparkswapd:/data'
+      # This is populated externally w/ an engine
+      - 'shared:/shared'
+
+volumes:
+  shared:
+  sparkswapd:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
     environment:
       - RPC_USER=${LTC_RPC_USER}
       - RPC_PASS=${LTC_RPC_PASS}
-      - NETWORK=simnet
+      - NETWORK=${NETWORK}
       - DEBUG=info
       - DATA_DIR=/data
       - LOG_DIR=/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,11 +21,6 @@ services:
       - lnd_btc
       - lnd_ltc
     volumes:
-      - './broker-daemon:/home/app/broker-daemon/'
-      # TODO: This can be removed once utils are moved to a shared repo or into
-      # the broker-daemon itself. broker-daemon relies on these utils for ./broker-daemon/bin/sparkswapd
-      - './broker-cli:/home/app/broker-cli/'
-      - './proto:/home/app/proto/'
       # block order and other sparkswap storage
       - 'sparkswapd:/data'
       # This is populated externally w/ an engine


### PR DESCRIPTION
## Description
Changed docker-compose.prod to dev and removed volume mounting for regular docker-compose to allow users to setup daemons w/ out receiving errors.

This PR also fixes a merge error where ltcd was hardcoded to simnet

## Related PRs
List related PRs if applicable


## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
