### PR TITLE
adds default port to sparkswap

### DIFF
--- a/broker-cli/broker-daemon-client/index.js
+++ b/broker-cli/broker-daemon-client/index.js
@@ -10,18 +10,38 @@ const { loadProto } = require('../utils')
  */
 const PROTO_PATH = path.resolve(__dirname, '..', 'proto', 'broker.proto')
 
+/**
+ * @constant
+ * @type {Number}
+ * @default
+ */
+const DEFAULT_RPC_PORT = 27492
+
 class BrokerDaemonClient {
   /**
    * @param {String} address grpc host address
    */
-  constructor (address) {
+  constructor (rpcAddress) {
     /**
      * Broker Daemon grpc host address
+     *
      * If not set, defaults to the user settings at ~/.sparkswap.js
      * or the installation settings at ../sparkswap.js
+     *
+     * Port defaults to DEFAULT_RPC_PORT if tld is passed in
+     *
+     * @see {DEFAULT_RPC_PORT}
      * @type {String}
      */
-    this.address = address || CONFIG.rpcAddress
+    this.address = rpcAddress || CONFIG.rpcAddress
+
+    const [host, port] = this.address.split(':')
+
+    // Set a default port if a TLD is used
+    if (!port) {
+      this.address = `${host}:${DEFAULT_RPC_PORT}`
+    }
+
     this.proto = loadProto(PROTO_PATH)
 
     // TODO: Change this to use npm instead of a relative path to the daemon

--- a/broker-cli/broker-daemon-client/index.spec.js
+++ b/broker-cli/broker-daemon-client/index.spec.js
@@ -50,15 +50,22 @@ describe('BrokerDaemonClient', () => {
     let address
 
     beforeEach(() => {
-      address = '172.0.0.1'
+      address = '172.0.0.1:27492'
     })
 
-    it('defaults to CONFIG is address is not passed in', () => {
+    it('defaults to CONFIG if an address is not passed in', () => {
       BrokerDaemonClient.__set__('CONFIG', {
         rpcAddress: address
       })
       broker = new BrokerDaemonClient()
       expect(broker.address).to.eql(address)
+    })
+
+    it('defaults the port number if no port number is specified', () => {
+      const providedHost = '127.1.1.5'
+      const defaultPort = BrokerDaemonClient.__get__('DEFAULT_RPC_PORT')
+      broker = new BrokerDaemonClient(providedHost)
+      expect(broker.address).to.eql(`${providedHost}:${defaultPort}`)
     })
 
     it('uses a provided address', () => {


### PR DESCRIPTION
## Description
This PR adds a default port to rpc addresses specified on the cli.

Example:

`sparkswap wallet balance --rpc-address my.address.com` is the equivelant as `sparkswap wallet balance --rpc-address my.address.com:27492`

If a port is specified in the url, we will use that specific port. This change is also applicable to the address used in the configuration file. A port must be explicitly specified in configuration.

## Related PRs
List related PRs if applicable


## Todos
- [x] Tests
- [n/a] Documentation
- [x] Link to Trello
