### PR TITLE
update createReadStream to take in updated range options

### DIFF
--- a/broker-daemon/utils/sublevel-index.js
+++ b/broker-daemon/utils/sublevel-index.js
@@ -94,7 +94,9 @@ class Index {
    * @return {Readable}    Readable stream
    */
   createReadStream (opts) {
-    const stream = this._index.createReadStream(opts)
+    const optionsToUpdate = Object.assign({}, opts)
+    const updatedOptions = this.range(optionsToUpdate)
+    const stream = this._index.createReadStream(updatedOptions)
     // through2 - the lib used below - overrides function context to provide access to `this.push` to push
     // objects into the downstream stream. In order to get access to `#_isMarkedForDeletion`, we need to
     // reference the Index context in a local variable

--- a/broker-daemon/utils/sublevel-index.spec.js
+++ b/broker-daemon/utils/sublevel-index.spec.js
@@ -190,6 +190,15 @@ describe('Index', () => {
         expect(indexStore.createReadStream).to.have.been.calledWith(opts)
       })
 
+      it('updates read stream range options before passing them to the underlying store', () => {
+        const options = { fake: 'opts', lte: '0.000001' }
+        const expectedOptions = { fake: 'opts', lte: '0.000001:\uffff' }
+
+        index.createReadStream(options)
+
+        expect(indexStore.createReadStream).to.have.been.calledWith(expectedOptions)
+      })
+
       it('returns the piped stream', () => {
         const piped = 'fake pipe'
         indexStoreStream.pipe.returns(piped)


### PR DESCRIPTION
## Description
When a user submits a limit order to the broker, it should fill any orders that are at the limit price or better. Currently, if there is an order on the book at the exact same price, the broker won't fill it.

The issue was that we were only passing the quantumPrice to createReadStream in streamOrdersAtPriceOrBetter:

```
  streamOrdersAtPriceOrBetter (quantumPrice) {
    const opts = {}

    if (quantumPrice) {
      opts.lte = this.keyForPrice(quantumPrice)
    }
    return this.createReadStream(opts)
  }
```

createReadStream in sublevel index just passed these options through instead of getting updated in the range method, which means that any orders with the same quantum price were always seen as greater than the lte value:

`opts.lte = '00000000000000000000.0010000000000000000'`

All orders with that quantumPrice look like: `00000000000000000000.0010000000000000000:asdjhfakjsdgag`

So we were making the wrong comparison.

The fix is to call this.range on the options before passing the options into createReadStream so it actually takes our new range values into account:

After calling this.range on the options
`opts.lte = '00000000000000000000.0010000000000000000:\uffff'`

So that any order with the same quantum price will be less than or equal to opts.lte.

I used object.assign so that we don't directly mutate the options. 

## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
