### PR TITLE
fixes for dev setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .git
 node_modules
+broker-cli/node_modules
 proto/
 *.tar.gz

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,7 +19,7 @@ services:
       - './broker-daemon:/home/app/broker-daemon/'
       # TODO: This can be removed once utils are moved to a shared repo or into
       # the broker-daemon itself. broker-daemon relies on these utils for ./broker-daemon/bin/sparkswapd
-      - './broker-cli:/home/app/broker-cli/'
+      - './broker-cli/utils:/home/app/broker-cli/utils/'
       - './proto:/home/app/proto/'
       - './scripts:/home/app/scripts/'
     environment:


### PR DESCRIPTION
## Description
This change prevents an overly large build context for `npm run build local` and stops `sparkswapd` from erroring out due to an incorrect grpc binary.

## Related PRs
List related PRs if applicable


## Todos
- [n/a] Tests
- [n/a] Documentation
- [x] Link to Trello
