### PR TITLE
Feature/supported markets

### DIFF
--- a/broker-cli/broker-daemon-client/index.js
+++ b/broker-cli/broker-daemon-client/index.js
@@ -73,6 +73,7 @@ class BrokerDaemonClient {
     this.orderService = caller(this.address, this.proto.OrderService, this.credentials)
     this.orderBookService = caller(this.address, this.proto.OrderBookService, this.credentials)
     this.walletService = caller(this.address, this.proto.WalletService, this.credentials)
+    this.infoService = caller(this.address, this.proto.InfoService, this.credentials)
   }
 }
 

--- a/broker-cli/broker-daemon-client/index.spec.js
+++ b/broker-cli/broker-daemon-client/index.spec.js
@@ -21,6 +21,7 @@ describe('BrokerDaemonClient', () => {
   let certPath
   let certFile
   let credentialStub
+  let infoStub
 
   beforeEach(() => {
     address = '172.0.0.1:27492'
@@ -33,11 +34,14 @@ describe('BrokerDaemonClient', () => {
     orderStub = sinon.stub()
     orderbookStub = sinon.stub()
     walletStub = sinon.stub()
+    infoStub = sinon.stub()
+
     protoStub = sinon.stub().returns({
       AdminService: adminStub,
       OrderService: orderStub,
       OrderBookService: orderbookStub,
-      WalletService: walletStub
+      WalletService: walletStub,
+      InfoService: infoStub
     })
     readFileSyncStub = sinon.stub().returns(certFile)
     createInsecureStub = sinon.stub().returns(true)
@@ -99,6 +103,7 @@ describe('BrokerDaemonClient', () => {
     it('creates an orderService', () => expect(callerStub).to.have.been.calledWith(broker.address, orderStub, credentialStub))
     it('creates an orderBookService', () => expect(callerStub).to.have.been.calledWith(broker.address, orderbookStub, credentialStub))
     it('creates an walletService', () => expect(callerStub).to.have.been.calledWith(broker.address, walletStub, credentialStub))
+    it('creates an infoService', () => expect(callerStub).to.have.been.calledWith(broker.address, infoStub, credentialStub))
   })
 
   describe('address', () => {

--- a/broker-cli/commands/index.js
+++ b/broker-cli/commands/index.js
@@ -11,6 +11,7 @@ const orderbookCommand = require('./orderbook')
 const healthCheckCommand = require('./health-check')
 const walletCommand = require('./wallet')
 const orderCommand = require('./order')
+const infoCommand = require('./info')
 
 module.exports = {
   buyCommand,
@@ -18,5 +19,6 @@ module.exports = {
   orderbookCommand,
   healthCheckCommand,
   walletCommand,
-  orderCommand
+  orderCommand,
+  infoCommand
 }

--- a/broker-cli/commands/index.spec.js
+++ b/broker-cli/commands/index.spec.js
@@ -6,7 +6,8 @@ const {
   orderbookCommand,
   healthCheckCommand,
   walletCommand,
-  orderCommand
+  orderCommand,
+  infoCommand
 } = require('./index')
 
 describe('broker index', () => {
@@ -38,5 +39,10 @@ describe('broker index', () => {
   it('defines orderCommand', () => {
     expect(orderCommand).to.not.be.null()
     expect(orderCommand).to.not.be.undefined()
+  })
+
+  it('defines infoCommand', () => {
+    expect(infoCommand).to.not.be.null()
+    expect(infoCommand).to.not.be.undefined()
   })
 })

--- a/broker-cli/commands/info/index.js
+++ b/broker-cli/commands/info/index.js
@@ -1,0 +1,37 @@
+const { validations } = require('../../utils')
+/**
+ * Order
+ * @module broker-cli/order
+ */
+
+/**
+ * Supported commands for `sparkswap info`
+ *
+ * @constant
+ * @type {Object<key, String>}
+ * @default
+ */
+const SUPPORTED_COMMANDS = Object.freeze({
+  SUPPORTED_MARKETS: 'supported-markets'
+})
+
+const supportedMarkets = require('./supported-markets')
+
+module.exports = (program) => {
+  program
+    .command('info', 'Commands to get market, trading, and fee information')
+    .help('Available Commands: supported-markets')
+    .argument('<command>', '', Object.values(SUPPORTED_COMMANDS), null, true)
+    .argument('[sub-arguments...]')
+    .option('--rpc-address', 'Location of the RPC server to use.', validations.isHost)
+    .action(async (args, opts, logger) => {
+      const { command } = args
+
+      switch (command) {
+        case SUPPORTED_COMMANDS.SUPPORTED_MARKETS:
+          return supportedMarkets(opts, logger)
+      }
+    })
+    .command(`info ${SUPPORTED_COMMANDS.SUPPORTED_MARKETS}`, 'Get the markets currently supported')
+    .option('--rpc-address', 'Location of the RPC server to use.', validations.isHost)
+}

--- a/broker-cli/commands/info/supported-markets.js
+++ b/broker-cli/commands/info/supported-markets.js
@@ -5,6 +5,7 @@ const { handleError } = require('../../utils')
  *
  * ex: `sparkswap info supported-markets'
  *
+ * @param {Object} opts
  * @param {String} [rpcaddress] opts.rpcaddress
  * @param {Logger} logger
  */

--- a/broker-cli/commands/info/supported-markets.js
+++ b/broker-cli/commands/info/supported-markets.js
@@ -13,7 +13,7 @@ async function supportedMarkets (opts, logger) {
 
   try {
     const client = new BrokerDaemonClient(rpcAddress)
-    const supportedMarkets = await client.infoService.getSupportedMarkets()
+    const supportedMarkets = await client.infoService.getSupportedMarkets({})
     logger.info(supportedMarkets)
   } catch (e) {
     logger.error(handleError(e))

--- a/broker-cli/commands/info/supported-markets.js
+++ b/broker-cli/commands/info/supported-markets.js
@@ -1,0 +1,23 @@
+const BrokerDaemonClient = require('../../broker-daemon-client')
+const { handleError } = require('../../utils')
+
+/**
+ *
+ * ex: `sparkswap info supported-markets'
+ *
+ * @param {String} [rpcaddress] opts.rpcaddress
+ * @param {Logger} logger
+ */
+async function supportedMarkets (opts, logger) {
+  const { rpcAddress = null } = opts
+
+  try {
+    const client = new BrokerDaemonClient(rpcAddress)
+    const supportedMarkets = await client.infoService.getSupportedMarkets()
+    logger.info(supportedMarkets)
+  } catch (e) {
+    logger.error(handleError(e))
+  }
+};
+
+module.exports = supportedMarkets

--- a/broker-cli/commands/info/supported-markets.spec.js
+++ b/broker-cli/commands/info/supported-markets.spec.js
@@ -1,0 +1,34 @@
+const path = require('path')
+const {
+  sinon,
+  rewire,
+  expect
+} = require('test/test-helper')
+
+const supportedMarkets = rewire(path.resolve(__dirname, 'supported-markets'))
+
+describe('cli info supported-markets', () => {
+  let opts
+  let logger
+  let rpcAddress
+  let getSupportedMarketsStub
+  let daemonStub
+
+  beforeEach(() => {
+    rpcAddress = 'test:1337'
+    opts = { rpcAddress }
+    logger = { info: sinon.stub(), error: sinon.stub() }
+
+    getSupportedMarketsStub = sinon.stub()
+    daemonStub = sinon.stub()
+    daemonStub.prototype.infoService = { getSupportedMarkets: getSupportedMarketsStub }
+
+    supportedMarkets.__set__('BrokerDaemonClient', daemonStub)
+
+    supportedMarkets(opts, logger)
+  })
+  it('calls broker daemon for the info supported-markets', () => {
+    expect(daemonStub).to.have.been.calledWith(rpcAddress)
+    expect(getSupportedMarketsStub).to.have.been.calledOnce()
+  })
+})

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -1036,3 +1036,33 @@ service WalletService {
   rpc GetTradingCapacities (GetTradingCapacitiesRequest) returns (GetTradingCapacitiesResponse);
 
 }
+
+/**
+ * Supported markets expose all relevant information about a market that is supported by sparkswap
+ */
+message SupportedMarket {
+  // unique id for the market
+  string id = 1;
+  // symbol of the market `BTC/LTC`
+  string symbol = 2;
+  // symbol of base currency
+  string base = 3;
+  // symbol of counter currency
+  string counter = 4;
+  // if the market is active or not
+  bool active = 5;
+  // number of digits for the balances in the market
+  int64 precision = 16;
+}
+
+/**
+ * Contains information about all supported markets on sparkswap
+ */
+message GetSupportedMarketsResponse {
+  // a list of all supported markets on sparkswap
+  repeated SupportedMarket supported_markets = 1;
+}
+
+service InfoService {
+  rpc getSupportedMarkets (google.protobuf.Empty) returns (GetSupportedMarketsResponse);
+}

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -1063,6 +1063,56 @@ message GetSupportedMarketsResponse {
   repeated SupportedMarket supported_markets = 1;
 }
 
+/**
+ * The InfoService gets information about the state of the markets, currencies, transactions.
+ *
+ * ```javascript
+ * const address = 'localhost:27492'
+ * const infoService = new brokerProto.InfoService(address, grpc.credentials.createInsecure())
+ * ```
+ */
 service InfoService {
+  /**
+   * getSupportedMarkets returns detailed information about markets currently supported on sparkswap.
+   *
+   * ```javascript
+   * const deadline = new Date().setSeconds(new Date().getSeconds() + 5)
+   * infoService.getSupportedMarkets({}, { deadline }, (err, { supportedMarkets }) => {
+   *   if (err) return console.error(err)
+   *   console.log({ supportedMarkets })
+   * })
+   * ```
+   *
+   * ```shell
+   * > sparkswap info supported-markets
+   * ```
+   *
+   * > The above command will print:
+   *
+   * ```javascript
+   * {
+   *   "supportedMarkets": [
+   *     {
+   *       "id": "BTC/LTC",
+   *       "symbol": "BTC/LTC",
+   *       "base": "BTC",
+   *       "counter": "LTC",
+   *       "active": true,
+   *       "precision": '16'
+   *     }
+   *   ]
+   * }
+   * ```
+   *
+   * ```shell
+   * { supportedMarkets:
+   *   [ { id: 'BTC/LTC',
+   *       symbol: 'BTC/LTC',
+   *       base: 'BTC',
+   *       counter: 'LTC',
+   *       active: true,
+   *       precision: '16' } ] }
+   * ```
+   */
   rpc getSupportedMarkets (google.protobuf.Empty) returns (GetSupportedMarketsResponse);
 }

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -1052,7 +1052,7 @@ message SupportedMarket {
   // if the market is active or not
   bool active = 5;
   // number of digits for the balances in the market
-  int64 precision = 16;
+  int64 precision = 6;
 }
 
 /**

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -1051,8 +1051,6 @@ message SupportedMarket {
   string counter = 4;
   // if the market is active or not
   bool active = 5;
-  // number of digits for the balances in the market
-  int64 precision = 6;
 }
 
 /**
@@ -1098,7 +1096,6 @@ service InfoService {
    *       "base": "BTC",
    *       "counter": "LTC",
    *       "active": true,
-   *       "precision": '16'
    *     }
    *   ]
    * }
@@ -1110,8 +1107,7 @@ service InfoService {
    *       symbol: 'BTC/LTC',
    *       base: 'BTC',
    *       counter: 'LTC',
-   *       active: true,
-   *       precision: '16' } ] }
+   *       active: true } ] }
    * ```
    */
   rpc getSupportedMarkets (google.protobuf.Empty) returns (GetSupportedMarketsResponse);

--- a/broker-daemon/broker-rpc/broker-rpc-server.js
+++ b/broker-daemon/broker-rpc/broker-rpc-server.js
@@ -6,6 +6,7 @@ const AdminService = require('./admin-service')
 const OrderService = require('./order-service')
 const OrderBookService = require('./orderbook-service')
 const WalletService = require('./wallet-service')
+const InfoService = require('./info-service')
 
 /**
  * @constant
@@ -95,6 +96,9 @@ class BrokerRPCServer {
 
     this.walletService = new WalletService(this.protoPath, { logger, engines, relayer, orderbooks })
     this.server.addService(this.walletService.definition, this.walletService.implementation)
+
+    this.infoService = new InfoService(this.protoPath, { logger, engines, relayer, orderbooks })
+    this.server.addService(this.infoService.definition, this.infoService.implementation)
   }
 
   /**

--- a/broker-daemon/broker-rpc/broker-rps-server.spec.js
+++ b/broker-daemon/broker-rpc/broker-rps-server.spec.js
@@ -14,6 +14,8 @@ describe('BrokerRPCServer', () => {
   let orderBookService
   let WalletService
   let walletService
+  let InfoService
+  let infoService
   let pathResolve
   let protoPath
   let engines
@@ -46,6 +48,13 @@ describe('BrokerRPCServer', () => {
     }
     WalletService = sinon.stub().returns(walletService)
     BrokerRPCServer.__set__('WalletService', WalletService)
+
+    infoService = {
+      definition: 'mydef',
+      implementation: 'myimp'
+    }
+    InfoService = sinon.stub().returns(infoService)
+    BrokerRPCServer.__set__('InfoService', InfoService)
 
     addService = sinon.stub()
     rpcServer = sinon.stub().returns({
@@ -180,6 +189,27 @@ describe('BrokerRPCServer', () => {
       expect(WalletService).to.have.been.calledWithNew()
       expect(server).to.have.property('walletService')
       expect(server.walletService).to.be.equal(walletService)
+    })
+
+    it('adds the info service', () => {
+      const server = new BrokerRPCServer()
+
+      expect(server).to.have.property('server')
+      expect(server.server.addService).to.be.equal(addService)
+      expect(addService).to.have.been.calledWith(infoService.definition, infoService.implementation)
+    })
+
+    it('creates a info service', () => {
+      const logger = 'mylogger'
+      const engines = 'myengines'
+
+      const server = new BrokerRPCServer({ logger, engines })
+
+      expect(InfoService).to.have.been.calledOnce()
+      expect(InfoService).to.have.been.calledWith(protoPath, sinon.match({ logger, engines }))
+      expect(InfoService).to.have.been.calledWithNew()
+      expect(server).to.have.property('infoService')
+      expect(server.infoService).to.be.equal(infoService)
     })
 
     it('adds the orderBook service', () => {

--- a/broker-daemon/broker-rpc/info-service/get-supported-markets.js
+++ b/broker-daemon/broker-rpc/info-service/get-supported-markets.js
@@ -1,40 +1,13 @@
-const { PublicError } = require('grpc-methods')
-const { convertBalance, Big } = require('../../utils')
-const { currencies } = require('../../config')
 /**
- * @constant
- * @type {Long}
- * @default
- */
-const MINIMUM_FUNDING_AMOUNT = 400000
-
-/**
- * This is the max allowed balance for a channel for LND while software is currently
- * in beta
- *
- * Maximum channel balance (no inclusive) is 2^32 or 16777216
- * More info: https://github.com/lightningnetwork/lnd/releases/tag/v0.3-alpha
- *
- * @todo make this engine agnostic (non-LND)
- * @constant
- * @type {Long}
- * @default
- */
-const MAX_CHANNEL_BALANCE = 16777215
-
-const SUPPORTED_SYMBOLS = currencies.reduce((obj, currency) => {
-  obj[currency.symbol] = currency.symbol
-  return obj
-}, {})
-
-/**
- * Grabs public lightning network information from relayer and opens a channel
+ * Gets valid markets from the relayer and populates market information for these markets
  *
  * @param {Object} request - request object
  * @param {Object} request.params
  * @param {RelayerClient} request.relayer
  * @param {Logger} request.logger
  * @param {Engine} request.engines
+ * @param {Map<Orderbook>} request.orderbooks
+
  * @param {Object} responses
  * @param {function} responses.EmptyResponse
  * @return {responses.EmptyResponse}
@@ -44,18 +17,18 @@ async function getSupportedMarkets ({ params, relayer, logger, engines, orderboo
 
   let supportedMarkets = []
   markets.forEach((market) => {
-    // if orderbooks.get(market) {
-    //   const [base, counter] = market.split('/')
-    //   const marketInfo = {
-    //     id: market,
-    //     symbol: market,
-    //     base,
-    //     counter,
-    //     active: true,
-    //     precision: 16
-    //   }
-    //   supportedMarkets << marketInfo
-    // }
+    if (orderbooks.get(market)) {
+      const [base, counter] = market.split('/')
+      const marketInfo = {
+        id: market,
+        symbol: market,
+        base,
+        counter,
+        active: true,
+        precision: 16
+      }
+      supportedMarkets.push(marketInfo)
+    }
   })
   return new GetSupportedMarketsResponse({supportedMarkets})
 }

--- a/broker-daemon/broker-rpc/info-service/get-supported-markets.js
+++ b/broker-daemon/broker-rpc/info-service/get-supported-markets.js
@@ -1,0 +1,63 @@
+const { PublicError } = require('grpc-methods')
+const { convertBalance, Big } = require('../../utils')
+const { currencies } = require('../../config')
+/**
+ * @constant
+ * @type {Long}
+ * @default
+ */
+const MINIMUM_FUNDING_AMOUNT = 400000
+
+/**
+ * This is the max allowed balance for a channel for LND while software is currently
+ * in beta
+ *
+ * Maximum channel balance (no inclusive) is 2^32 or 16777216
+ * More info: https://github.com/lightningnetwork/lnd/releases/tag/v0.3-alpha
+ *
+ * @todo make this engine agnostic (non-LND)
+ * @constant
+ * @type {Long}
+ * @default
+ */
+const MAX_CHANNEL_BALANCE = 16777215
+
+const SUPPORTED_SYMBOLS = currencies.reduce((obj, currency) => {
+  obj[currency.symbol] = currency.symbol
+  return obj
+}, {})
+
+/**
+ * Grabs public lightning network information from relayer and opens a channel
+ *
+ * @param {Object} request - request object
+ * @param {Object} request.params
+ * @param {RelayerClient} request.relayer
+ * @param {Logger} request.logger
+ * @param {Engine} request.engines
+ * @param {Object} responses
+ * @param {function} responses.EmptyResponse
+ * @return {responses.EmptyResponse}
+ */
+async function getSupportedMarkets ({ params, relayer, logger, engines, orderbooks }, { GetSupportedMarketsResponse }) {
+  const { markets } = await relayer.infoService.getMarkets({})
+
+  let supportedMarkets = []
+  markets.forEach((market) => {
+    // if orderbooks.get(market) {
+    //   const [base, counter] = market.split('/')
+    //   const marketInfo = {
+    //     id: market,
+    //     symbol: market,
+    //     base,
+    //     counter,
+    //     active: true,
+    //     precision: 16
+    //   }
+    //   supportedMarkets << marketInfo
+    // }
+  })
+  return new GetSupportedMarketsResponse({supportedMarkets})
+}
+
+module.exports = getSupportedMarkets

--- a/broker-daemon/broker-rpc/info-service/get-supported-markets.js
+++ b/broker-daemon/broker-rpc/info-service/get-supported-markets.js
@@ -7,29 +7,27 @@
  * @param {Logger} request.logger
  * @param {Engine} request.engines
  * @param {Map<Orderbook>} request.orderbooks
-
+ *
  * @param {Object} responses
- * @param {function} responses.EmptyResponse
- * @return {responses.EmptyResponse}
+ * @param {function} responses.GetSupportedMarketsResponse - constructor for GetSupportedMarketsResponse messages
+ * @return {responses.GetSupportedMarketsResponse}
  */
 async function getSupportedMarkets ({ params, relayer, logger, engines, orderbooks }, { GetSupportedMarketsResponse }) {
   const { markets } = await relayer.infoService.getMarkets({})
 
-  let supportedMarkets = []
-  markets.forEach((market) => {
-    if (orderbooks.get(market)) {
-      const [base, counter] = market.split('/')
-      const marketInfo = {
-        id: market,
-        symbol: market,
-        base,
-        counter,
-        active: true,
-        precision: 16
-      }
-      supportedMarkets.push(marketInfo)
+  const supportedMarkets = markets.reduce((acc, market) => {
+    if (!orderbooks.get(market)) return acc
+    const [base, counter] = market.split('/')
+    const marketInfo = {
+      id: market,
+      symbol: market,
+      base,
+      counter,
+      active: true
     }
-  })
+    acc.push(marketInfo)
+    return acc
+  }, [])
   return new GetSupportedMarketsResponse({supportedMarkets})
 }
 

--- a/broker-daemon/broker-rpc/info-service/get-supported-markets.spec.js
+++ b/broker-daemon/broker-rpc/info-service/get-supported-markets.spec.js
@@ -42,7 +42,6 @@ describe.only('getSupportedMarkets', () => {
         base: 'BTC',
         counter: 'LTC',
         id: 'BTC/LTC',
-        precision: 16,
         symbol: 'BTC/LTC'
       }]
     })
@@ -65,7 +64,6 @@ describe.only('getSupportedMarkets', () => {
         base: 'BTC',
         counter: 'LTC',
         id: 'BTC/LTC',
-        precision: 16,
         symbol: 'BTC/LTC'
       }]
     })

--- a/broker-daemon/broker-rpc/info-service/get-supported-markets.spec.js
+++ b/broker-daemon/broker-rpc/info-service/get-supported-markets.spec.js
@@ -1,0 +1,73 @@
+const path = require('path')
+const { expect, rewire, sinon } = require('test/test-helper')
+
+const getSupportedMarkets = rewire(path.resolve(__dirname, 'get-supported-markets'))
+
+describe.only('getSupportedMarkets', () => {
+  let logger
+  let engineStub
+  let engines
+  let GetSupportedMarketsResponse
+  let relayer
+  let markets
+  let orderbooks
+
+  beforeEach(() => {
+    logger = {
+      info: sinon.stub()
+    }
+    engineStub = sinon.stub()
+    engines = [ engineStub ]
+    orderbooks = new Map([['BTC/LTC', {}], ['ABC/XYZ', {}]])
+    markets = ['BTC/LTC']
+    GetSupportedMarketsResponse = sinon.stub()
+    relayer = {
+      infoService: {
+        getMarkets: sinon.stub().resolves({markets})
+      }
+    }
+  })
+
+  it('gets the balances from a particular engine', async () => {
+    await getSupportedMarkets({ logger, engines, relayer, orderbooks }, { GetSupportedMarketsResponse })
+    expect(relayer.infoService.getMarkets).to.have.been.calledOnce()
+  })
+
+  it('adds market information for supported markets from the relayer', async () => {
+    orderbooks = new Map([['BTC/LTC', {}]])
+    await getSupportedMarkets({ logger, engines, relayer, orderbooks }, { GetSupportedMarketsResponse })
+    expect(GetSupportedMarketsResponse).to.have.been.calledWith({
+      supportedMarkets: [{
+        active: true,
+        base: 'BTC',
+        counter: 'LTC',
+        id: 'BTC/LTC',
+        precision: 16,
+        symbol: 'BTC/LTC'
+      }]
+    })
+  })
+
+  it('does not add market information if the market did not come from the relayer', async () => {
+    orderbooks = new Map([['ABC/XYZ', {}]])
+    await getSupportedMarkets({ logger, engines, relayer, orderbooks }, { GetSupportedMarketsResponse })
+    expect(GetSupportedMarketsResponse).to.have.been.calledWith({
+      supportedMarkets: []
+    })
+  })
+
+  it('adds market information for supported markets from the relayer but not for others', async () => {
+    orderbooks = new Map([['BTC/LTC', {}], ['ABC/XYZ', {}]])
+    await getSupportedMarkets({ logger, engines, relayer, orderbooks }, { GetSupportedMarketsResponse })
+    expect(GetSupportedMarketsResponse).to.have.been.calledWith({
+      supportedMarkets: [{
+        active: true,
+        base: 'BTC',
+        counter: 'LTC',
+        id: 'BTC/LTC',
+        precision: 16,
+        symbol: 'BTC/LTC'
+      }]
+    })
+  })
+})

--- a/broker-daemon/broker-rpc/info-service/index.js
+++ b/broker-daemon/broker-rpc/info-service/index.js
@@ -1,0 +1,29 @@
+const { GrpcUnaryMethod } = require('grpc-methods')
+const { loadProto } = require('../../utils')
+
+const getSupportedMarkets = require('./get-supported-markets')
+
+class InfoService {
+  constructor (protoPath, { logger, relayer, orderbooks }) {
+    this.protoPath = protoPath
+    this.proto = loadProto(this.protoPath)
+    this.logger = logger
+
+    this.definition = this.proto.InfoService.service
+    this.serviceName = 'InfoService'
+
+    const {
+      GetSupportedMarketsResponse
+    } = this.proto
+
+    this.implementation = {
+      getSupportedMarkets: new GrpcUnaryMethod(getSupportedMarkets, this.messageId('getSupportedMarkets'), { logger, relayer, orderbooks }, { GetSupportedMarketsResponse }).register()
+    }
+  }
+
+  messageId (methodName) {
+    return `[${this.serviceName}:${methodName}]`
+  }
+}
+
+module.exports = InfoService

--- a/broker-daemon/broker-rpc/info-service/index.spec.js
+++ b/broker-daemon/broker-rpc/info-service/index.spec.js
@@ -1,0 +1,139 @@
+const path = require('path')
+const { expect, rewire, sinon } = require('test/test-helper')
+
+const InfoService = rewire(path.resolve(__dirname))
+
+describe('InfoService', () => {
+  let getSupportedMarketsStub
+
+  let GrpcMethod
+  let register
+  let fakeRegistered
+  let loadProto
+  let proto
+
+  let protoPath
+  let logger
+  let relayer
+  let orderbooks
+
+  let server
+
+  beforeEach(() => {
+    protoPath = 'fakePath'
+    proto = {
+      InfoService: {
+        service: 'fakeService'
+      },
+      GetSupportedMarketsResponse: sinon.stub()
+    }
+    logger = {
+      info: sinon.stub(),
+      error: sinon.stub()
+    }
+    relayer = sinon.stub()
+    orderbooks = sinon.stub()
+
+    GrpcMethod = sinon.stub()
+    fakeRegistered = sinon.stub()
+    register = sinon.stub().returns(fakeRegistered)
+    GrpcMethod.prototype.register = register
+    InfoService.__set__('GrpcUnaryMethod', GrpcMethod)
+
+    loadProto = sinon.stub().returns(proto)
+    InfoService.__set__('loadProto', loadProto)
+
+    getSupportedMarketsStub = sinon.stub()
+    InfoService.__set__('getSupportedMarkets', getSupportedMarketsStub)
+  })
+
+  beforeEach(() => {
+    server = new InfoService(protoPath, { logger, relayer, orderbooks })
+  })
+
+  it('assigns a proto path', () => {
+    expect(server).to.have.property('protoPath')
+    expect(server.protoPath).to.be.equal(protoPath)
+  })
+
+  it('loads the proto', () => {
+    expect(loadProto).to.have.been.calledOnce()
+    expect(loadProto).to.have.been.calledWith(protoPath)
+  })
+
+  it('assigns the proto', () => {
+    expect(server).to.have.property('proto')
+    expect(server.proto).to.be.equal(proto)
+  })
+
+  it('assigns a logger', () => {
+    expect(server).to.have.property('logger')
+    expect(server.logger).to.be.equal(logger)
+  })
+
+  it('assigns the definition', () => {
+    expect(server).to.have.property('definition')
+    expect(server.definition).to.be.equal(proto.InfoService.service)
+  })
+
+  it('creates a name', () => {
+    expect(server).to.have.property('serviceName')
+    expect(server.serviceName).to.be.a('string')
+    expect(server.serviceName).to.be.eql('InfoService')
+  })
+
+  it('exposes an implementation', () => {
+    expect(server).to.have.property('implementation')
+    expect(server.implementation).to.be.an('object')
+  })
+
+  describe('#getSupportedMarkets', () => {
+    let callOrder = 0
+    let callArgs
+
+    beforeEach(() => {
+      callArgs = GrpcMethod.args[callOrder]
+    })
+
+    it('exposes an implementation', () => {
+      expect(server.implementation).to.have.property('getSupportedMarkets')
+      expect(server.implementation.getSupportedMarkets).to.be.a('function')
+    })
+
+    it('creates a GrpcMethod', () => {
+      expect(GrpcMethod).to.have.been.called()
+      expect(GrpcMethod).to.have.been.calledWithNew()
+      expect(server.implementation.getSupportedMarkets).to.be.equal(fakeRegistered)
+    })
+
+    it('provides the method', () => {
+      expect(callArgs[0]).to.be.equal(getSupportedMarketsStub)
+    })
+
+    it('provides a message id', () => {
+      expect(callArgs[1]).to.be.equal('[InfoService:getSupportedMarkets]')
+    })
+
+    describe('request options', () => {
+      it('passes in the logger', () => {
+        expect(callArgs[2]).to.have.property('logger', logger)
+        expect(callArgs[2].logger).to.be.equal(logger)
+      })
+
+      it('passes in the relayer', () => {
+        expect(callArgs[2]).to.have.property('relayer')
+        expect(callArgs[2].relayer).to.be.equal(relayer)
+      })
+
+      it('passes in the orderbooks', () => {
+        expect(callArgs[2]).to.have.property('orderbooks')
+        expect(callArgs[2].orderbooks).to.be.equal(orderbooks)
+      })
+    })
+
+    it('passes in the response', () => {
+      expect(callArgs[3]).to.be.an('object')
+      expect(callArgs[3]).to.have.property('GetSupportedMarketsResponse', proto.GetSupportedMarketsResponse)
+    })
+  })
+})

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -1036,3 +1036,33 @@ service WalletService {
   rpc GetTradingCapacities (GetTradingCapacitiesRequest) returns (GetTradingCapacitiesResponse);
 
 }
+
+/**
+ * Supported markets expose all relevant information about a market that is supported by sparkswap
+ */
+message SupportedMarket {
+  // unique id for the market
+  string id = 1;
+  // symbol of the market `BTC/LTC`
+  string symbol = 2;
+  // symbol of base currency
+  string base = 3;
+  // symbol of counter currency
+  string counter = 4;
+  // if the market is active or not
+  bool active = 5;
+  // number of digits for the balances in the market
+  int64 precision = 16;
+}
+
+/**
+ * Contains information about all supported markets on sparkswap
+ */
+message GetSupportedMarketsResponse {
+  // a list of all supported markets on sparkswap
+  repeated SupportedMarket supported_markets = 1;
+}
+
+service InfoService {
+  rpc getSupportedMarkets (google.protobuf.Empty) returns (GetSupportedMarketsResponse);
+}

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -1063,6 +1063,56 @@ message GetSupportedMarketsResponse {
   repeated SupportedMarket supported_markets = 1;
 }
 
+/**
+ * The InfoService gets information about the state of the markets, currencies, transactions.
+ *
+ * ```javascript
+ * const address = 'localhost:27492'
+ * const infoService = new brokerProto.InfoService(address, grpc.credentials.createInsecure())
+ * ```
+ */
 service InfoService {
+  /**
+   * getSupportedMarkets returns detailed information about markets currently supported on sparkswap.
+   *
+   * ```javascript
+   * const deadline = new Date().setSeconds(new Date().getSeconds() + 5)
+   * infoService.getSupportedMarkets({}, { deadline }, (err, { supportedMarkets }) => {
+   *   if (err) return console.error(err)
+   *   console.log({ supportedMarkets })
+   * })
+   * ```
+   *
+   * ```shell
+   * > sparkswap info supported-markets
+   * ```
+   *
+   * > The above command will print:
+   *
+   * ```javascript
+   * {
+   *   "supportedMarkets": [
+   *     {
+   *       "id": "BTC/LTC",
+   *       "symbol": "BTC/LTC",
+   *       "base": "BTC",
+   *       "counter": "LTC",
+   *       "active": true,
+   *       "precision": '16'
+   *     }
+   *   ]
+   * }
+   * ```
+   *
+   * ```shell
+   * { supportedMarkets:
+   *   [ { id: 'BTC/LTC',
+   *       symbol: 'BTC/LTC',
+   *       base: 'BTC',
+   *       counter: 'LTC',
+   *       active: true,
+   *       precision: '16' } ] }
+   * ```
+   */
   rpc getSupportedMarkets (google.protobuf.Empty) returns (GetSupportedMarketsResponse);
 }

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -1052,7 +1052,7 @@ message SupportedMarket {
   // if the market is active or not
   bool active = 5;
   // number of digits for the balances in the market
-  int64 precision = 16;
+  int64 precision = 6;
 }
 
 /**

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -1051,8 +1051,6 @@ message SupportedMarket {
   string counter = 4;
   // if the market is active or not
   bool active = 5;
-  // number of digits for the balances in the market
-  int64 precision = 6;
 }
 
 /**
@@ -1098,7 +1096,6 @@ service InfoService {
    *       "base": "BTC",
    *       "counter": "LTC",
    *       "active": true,
-   *       "precision": '16'
    *     }
    *   ]
    * }
@@ -1110,8 +1107,7 @@ service InfoService {
    *       symbol: 'BTC/LTC',
    *       base: 'BTC',
    *       counter: 'LTC',
-   *       active: true,
-   *       precision: '16' } ] }
+   *       active: true } ] }
    * ```
    */
   rpc getSupportedMarkets (google.protobuf.Empty) returns (GetSupportedMarketsResponse);

--- a/broker-daemon/relayer/relayer-client.js
+++ b/broker-daemon/relayer/relayer-client.js
@@ -74,6 +74,7 @@ class RelayerClient {
     this.healthService = caller(this.address, this.proto.HealthService, this.credentials)
     this.orderbookService = caller(this.address, this.proto.OrderBookService, this.credentials)
     this.paymentChannelNetworkService = caller(this.address, this.proto.PaymentChannelNetworkService, this.credentials)
+    this.infoService = caller(this.address, this.proto.InfoService, this.credentials)
   }
 
   /**

--- a/broker-daemon/relayer/relayer-client.spec.js
+++ b/broker-daemon/relayer/relayer-client.spec.js
@@ -18,6 +18,7 @@ describe('RelayerClient', () => {
   let TakerService
   let OrderBookService
   let HealthService
+  let InfoService
   let PaymentChannelNetworkService
   let ResponseType = {
     EXISTING_EVENT: 'EXISTING_EVENT',
@@ -52,6 +53,7 @@ describe('RelayerClient', () => {
     OrderBookService = sinon.stub()
     HealthService = sinon.stub()
     PaymentChannelNetworkService = sinon.stub()
+    InfoService = sinon.stub()
 
     pathResolve = sinon.stub()
     RelayerClient.__set__('path', { resolve: pathResolve })
@@ -65,6 +67,7 @@ describe('RelayerClient', () => {
       OrderBookService,
       HealthService,
       PaymentChannelNetworkService,
+      InfoService,
       WatchMarketResponse: {
         ResponseType
       }
@@ -186,10 +189,11 @@ describe('RelayerClient', () => {
         relayer = new RelayerClient(idKeyPath, { host: relayerHost })
       })
 
-      it('creates an makerService', () => expect(callerStub).to.have.been.calledWith(relayer.address, MakerService, fakeCreds))
-      it('creates an takerService', () => expect(callerStub).to.have.been.calledWith(relayer.address, TakerService, fakeCreds))
+      it('creates a makerService', () => expect(callerStub).to.have.been.calledWith(relayer.address, MakerService, fakeCreds))
+      it('creates a takerService', () => expect(callerStub).to.have.been.calledWith(relayer.address, TakerService, fakeCreds))
       it('creates an orderBookService', () => expect(callerStub).to.have.been.calledWith(relayer.address, OrderBookService, fakeCreds))
-      it('creates an healthService', () => expect(callerStub).to.have.been.calledWith(relayer.address, HealthService, fakeCreds))
+      it('creates a healthService', () => expect(callerStub).to.have.been.calledWith(relayer.address, HealthService, fakeCreds))
+      it('creates an infoService', () => expect(callerStub).to.have.been.calledWith(relayer.address, InfoService, fakeCreds))
     })
   })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3820,7 +3820,7 @@
       }
     },
     "lnd-engine": {
-      "version": "github:sparkswap/lnd-engine#77a885c451e59060c652735b9d2542b20fa1f47f",
+      "version": "github:sparkswap/lnd-engine#aac01a422f52e94f6a60e7e1f78a153bba3d4d54",
       "from": "github:sparkswap/lnd-engine",
       "requires": {
         "big.js": "5.1.2",


### PR DESCRIPTION
## Description
This adds a cli command for supported markets primarily to be used for CCXT. It involves getting the source of truth from the relayer (markets the relayer currently supports) and then supplying information from the broker about those markets. 

CCXT Docs: https://github.com/ccxt/ccxt/wiki/Manual#markets

## Related PRs
https://github.com/sparkswap/relayer/pull/158


## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
