### PR TITLE
Fix/add timestamps block

### DIFF
--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -296,8 +296,10 @@ message BlockOrder {
   TimeInForce time_in_force = 5;
   // Current status of the block order.
   BlockOrderStatus status = 6;
-  // Timestamp in nano-seconds
+  // BlockOrder creation unix timestamp in nanoseconds
   string timestamp = 7;
+  // BlockOrder creation ISO8601 datetime in nanoseconds
+  string datetime = 8;
 }
 
 /**

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -331,6 +331,10 @@ message GetBlockOrderResponse {
   }
   // Time restriction for this block order.
   TimeInForce time_in_force = 15;
+  // BlockOrder creation unix timestamp in nanoseconds
+  string timestamp = 16;
+  // BlockOrder creation ISO8601 datetime in nanoseconds
+  string datetime = 17;
 
   // Amount of the block order that has been filled, in common units for a currency (e.g. bitcoins for BTC) represented as a decimal string (e.g. `'0.10'`)
   string fill_amount = 20;

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -296,6 +296,8 @@ message BlockOrder {
   TimeInForce time_in_force = 5;
   // Current status of the block order.
   BlockOrderStatus status = 6;
+  // Timestamp in nano-seconds
+  string timestamp = 7;
 }
 
 /**
@@ -480,6 +482,8 @@ service OrderService {
    *   "amount": "0.0001",
    *   "isMarketOrder": true,
    *   "timeInForce": "GTC",
+   *   "timestamp": "1538676318030164300",
+   *   "datetime": "2018-09-21T10:40:31.8342339Z",
    *   "open_orders": [],
    *   "fills": []
    * }
@@ -494,6 +498,8 @@ service OrderService {
    *   isMarketOrder: true,
    *   limitPrice: '',
    *   timeInForce: 'GTC',
+   *   timestamp: '1538676318030164300',
+   *   datetime: '2018-09-21T10:40:31.8342339Z',
    *   fillAmount: '',
    *   openOrders: [],
    *   fills: [] }

--- a/broker-daemon/models/block-order.js
+++ b/broker-daemon/models/block-order.js
@@ -149,7 +149,15 @@ class BlockOrder {
    * @return {String} Stringified JSON object
    */
   get value () {
-    const { marketName, side, amount, price, timeInForce, status } = this
+    const {
+      marketName,
+      side,
+      amount,
+      price,
+      timeInForce,
+      timestamp,
+      status
+    } = this
 
     return JSON.stringify({
       marketName,
@@ -157,6 +165,7 @@ class BlockOrder {
       amount: amount.toString(),
       price: price ? price.toString() : null,
       timeInForce,
+      timestamp,
       status
     })
   }

--- a/broker-daemon/models/block-order.spec.js
+++ b/broker-daemon/models/block-order.spec.js
@@ -174,6 +174,7 @@ describe('BlockOrder', () => {
         amount: '10000',
         price: '100',
         timeInForce: 'GTC',
+        timestamp: 'timestamp',
         status: 'ACTIVE'
       }
       CONFIG = {

--- a/broker-daemon/models/block-order.spec.js
+++ b/broker-daemon/models/block-order.spec.js
@@ -5,7 +5,7 @@ const { Big } = require('../utils')
 const BlockOrder = rewire(path.resolve(__dirname, 'block-order'))
 const { OrderStateMachine, FillStateMachine } = require('../state-machines')
 
-describe('BlockOrder', () => {
+describe.only('BlockOrder', () => {
   describe('::fromStorage', () => {
     it('defines a static method for creating block orders from storage', () => {
       expect(BlockOrder).itself.to.respondTo('fromStorage')
@@ -18,6 +18,7 @@ describe('BlockOrder', () => {
         amount: '10000',
         price: '100',
         timeInForce: 'GTC',
+        timestamp: '1234',
         status: 'ACTIVE'
       }
       const id = 'myid'
@@ -33,6 +34,7 @@ describe('BlockOrder', () => {
       expect(blockOrder.price.toString()).to.be.equal(params.price)
       expect(blockOrder).to.have.property('timeInForce', params.timeInForce)
       expect(blockOrder).to.have.property('status', params.status)
+      expect(blockOrder).to.have.property('timestamp', params.timestamp)
     })
 
     it('throws if it has an invalid status', () => {
@@ -70,8 +72,13 @@ describe('BlockOrder', () => {
 
   describe('new', () => {
     let params
+    let nanoStub
+    let timestamp
+    let revert
 
     beforeEach(() => {
+      timestamp = 'timestamp'
+      nanoStub = sinon.stub().returns(timestamp)
       params = {
         id: 'myid',
         marketName: 'BTC/LTC',
@@ -80,6 +87,11 @@ describe('BlockOrder', () => {
         price: '100',
         timeInForce: 'GTC'
       }
+      revert = BlockOrder.__set__('nano', { toString: nanoStub })
+    })
+
+    afterEach(() => {
+      revert()
     })
 
     it('assigns an id', () => {
@@ -158,15 +170,35 @@ describe('BlockOrder', () => {
 
       expect(blockOrder).to.have.property('status', 'ACTIVE')
     })
+
+    it('creates a timestamp', () => {
+      const blockOrder = new BlockOrder(params)
+      expect(blockOrder).to.have.property('timestamp', timestamp)
+      expect(nanoStub).to.have.been.calledOnce()
+    })
+
+    it('creates a timestamp from a property passed in through params', () => {
+      const newTimestamp = 'newtimestamp'
+      params.timestamp = newTimestamp
+      const blockOrder = new BlockOrder(params)
+      expect(blockOrder).to.not.have.property('timestamp', timestamp)
+      expect(blockOrder).to.have.property('timestamp', newTimestamp)
+      expect(nanoStub).to.not.have.been.calledOnce()
+    })
   })
 
   describe('instance', () => {
     let params
     let blockOrder
     let CONFIG
-    let revert
+    let nanoToDatetimeStub
+    let timestamp
+
+    let reverts = []
 
     beforeEach(() => {
+      timestamp = 'timestamp'
+      nanoToDatetimeStub = sinon.stub().returns(timestamp)
       params = {
         id: 'myid',
         marketName: 'BTC/LTC',
@@ -174,7 +206,7 @@ describe('BlockOrder', () => {
         amount: '10000',
         price: '100',
         timeInForce: 'GTC',
-        timestamp: 'timestamp',
+        timestamp,
         status: 'ACTIVE'
       }
       CONFIG = {
@@ -194,13 +226,14 @@ describe('BlockOrder', () => {
         ]
       }
 
-      revert = BlockOrder.__set__('CONFIG', CONFIG)
+      reverts.push(BlockOrder.__set__('CONFIG', CONFIG))
+      reverts.push(BlockOrder.__set__('nanoToDatetime', nanoToDatetimeStub))
 
       blockOrder = new BlockOrder(params)
     })
 
     afterEach(() => {
-      revert()
+      reverts.forEach(r => r())
     })
 
     describe('#fail', () => {
@@ -529,6 +562,13 @@ describe('BlockOrder', () => {
         const serialized = blockOrder.serializeSummary()
 
         expect(serialized).to.have.property('status', params.status)
+      })
+    })
+
+    describe('get datetime', () => {
+      it('defines a datetime', () => {
+        expect(blockOrder).to.have.property('datetime')
+        expect(nanoToDatetimeStub).to.have.been.calledWith(timestamp)
       })
     })
 

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -296,8 +296,10 @@ message BlockOrder {
   TimeInForce time_in_force = 5;
   // Current status of the block order.
   BlockOrderStatus status = 6;
-  // Timestamp in nano-seconds
+  // BlockOrder creation unix timestamp in nanoseconds
   string timestamp = 7;
+  // BlockOrder creation ISO8601 datetime in nanoseconds
+  string datetime = 8;
 }
 
 /**

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -331,6 +331,10 @@ message GetBlockOrderResponse {
   }
   // Time restriction for this block order.
   TimeInForce time_in_force = 15;
+  // BlockOrder creation unix timestamp in nanoseconds
+  string timestamp = 16;
+  // BlockOrder creation ISO8601 datetime in nanoseconds
+  string datetime = 17;
 
   // Amount of the block order that has been filled, in common units for a currency (e.g. bitcoins for BTC) represented as a decimal string (e.g. `'0.10'`)
   string fill_amount = 20;

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -296,6 +296,8 @@ message BlockOrder {
   TimeInForce time_in_force = 5;
   // Current status of the block order.
   BlockOrderStatus status = 6;
+  // Timestamp in nano-seconds
+  string timestamp = 7;
 }
 
 /**
@@ -480,6 +482,8 @@ service OrderService {
    *   "amount": "0.0001",
    *   "isMarketOrder": true,
    *   "timeInForce": "GTC",
+   *   "timestamp": "1538676318030164300",
+   *   "datetime": "2018-09-21T10:40:31.8342339Z",
    *   "open_orders": [],
    *   "fills": []
    * }
@@ -494,6 +498,8 @@ service OrderService {
    *   isMarketOrder: true,
    *   limitPrice: '',
    *   timeInForce: 'GTC',
+   *   timestamp: '1538676318030164300',
+   *   datetime: '2018-09-21T10:40:31.8342339Z',
    *   fillAmount: '',
    *   openOrders: [],
    *   fills: [] }


### PR DESCRIPTION
## Description
This PR adds BlockOrder (order) creation timestamps to give the user an idea of when a blockorder was created on the broker.

This timestamp was added due to information needed in the CCXT `fetchOrder` command, however this is a good addition to our API for other users as well.

## Related PRs
List related PRs if applicable


## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
