### PR TITLE
amountInSat needs to be a string

### DIFF
--- a/broker-daemon/broker-rpc/wallet-service/withdraw-funds.js
+++ b/broker-daemon/broker-rpc/wallet-service/withdraw-funds.js
@@ -30,7 +30,7 @@ async function withdrawFunds ({ params, relayer, logger, engines }, { WithdrawFu
 
   try {
     logger.info(`Attempting to withdraw ${amount} ${symbol} from wallet to ${address}`)
-    const txid = await engine.withdrawFunds(address, amountInSat)
+    const txid = await engine.withdrawFunds(address, amountInSat.toString())
     logger.info(`Successfully withdrew ${amount} ${symbol} from wallet to ${address}, transaction id: ${txid}`)
     return new WithdrawFundsResponse({txid})
   } catch (err) {

--- a/broker-daemon/broker-rpc/wallet-service/withdraw-funds.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/withdraw-funds.spec.js
@@ -61,7 +61,7 @@ describe('withdrawFunds', () => {
     it('makes a request to the engine to withdrawFunds to the address specified', () => {
       expect(btcEngine.withdrawFunds).to.have.been.calledWith(
         params.address,
-        Big(params.amount).times(100000000)
+        Big(params.amount).times(100000000).toString()
       )
     })
 


### PR DESCRIPTION
## Description
Noticed this bug while testing ccxt, amountinsat needs to be a string!! or we will receive errors from LND RPC stating that `amount` is of the incorrect type

## Related PRs
List related PRs if applicable


## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
