### PR TITLE
use crypto library instead of generate-safe-id

### DIFF
--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -1,13 +1,13 @@
 const EventEmitter = require('events')
 const { promisify } = require('util')
-const safeid = require('generate-safe-id')
 
 const { BlockOrder, Order, Fill } = require('../models')
 const { OrderStateMachine, FillStateMachine } = require('../state-machines')
 const {
   Big,
   getRecords,
-  SublevelIndex
+  SublevelIndex,
+  generateId
 } = require('../utils')
 
 /**
@@ -69,7 +69,7 @@ class BlockOrderWorker extends EventEmitter {
    * @return {String}                     ID for the created Block Order
    */
   async createBlockOrder ({ marketName, side, amount, price, timeInForce }) {
-    const id = safeid()
+    const id = generateId()
 
     const orderbook = this.orderbooks.get(marketName)
 

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -5,7 +5,7 @@ const { expect, rewire, sinon } = require('test/test-helper')
 const BlockOrderWorker = rewire(path.resolve(__dirname))
 
 describe('BlockOrderWorker', () => {
-  let safeid
+  let generateId
   let BlockOrder
   let Order
   let Fill
@@ -24,8 +24,8 @@ describe('BlockOrderWorker', () => {
 
   beforeEach(() => {
     loggerErrorStub = sinon.stub()
-    safeid = sinon.stub()
-    BlockOrderWorker.__set__('safeid', safeid)
+    generateId = sinon.stub()
+    BlockOrderWorker.__set__('generateId', generateId)
 
     BlockOrder = sinon.stub()
     BlockOrder.STATUSES = {
@@ -265,7 +265,7 @@ describe('BlockOrderWorker', () => {
 
     it('creates an id', async () => {
       const fakeId = 'myfake'
-      safeid.returns(fakeId)
+      generateId.returns(fakeId)
 
       const params = {
         marketName: 'BTC/LTC',
@@ -280,7 +280,7 @@ describe('BlockOrderWorker', () => {
 
     it('creates a block order', async () => {
       const fakeId = 'myfake'
-      safeid.returns(fakeId)
+      generateId.returns(fakeId)
 
       const params = {
         marketName: 'BTC/LTC',
@@ -317,7 +317,7 @@ describe('BlockOrderWorker', () => {
 
     it('starts working a block order', async () => {
       const fakeId = 'myfake'
-      safeid.returns(fakeId)
+      generateId.returns(fakeId)
 
       const params = {
         marketName: 'BTC/LTC',
@@ -332,7 +332,7 @@ describe('BlockOrderWorker', () => {
 
     it('fails a block order if working a block order is unsuccessful', async () => {
       const fakeId = 'myfake'
-      safeid.returns(fakeId)
+      generateId.returns(fakeId)
 
       const params = {
         marketName: 'BTC/LTC',

--- a/broker-daemon/state-machines/fill-state-machine.js
+++ b/broker-daemon/state-machines/fill-state-machine.js
@@ -1,7 +1,7 @@
-const safeid = require('generate-safe-id')
 const StateMachineHistory = require('javascript-state-machine/lib/history')
 
 const { Fill } = require('../models')
+const { generateId } = require('../utils')
 
 const StateMachine = require('./state-machine')
 const {
@@ -38,7 +38,7 @@ const FillStateMachine = StateMachine.factory({
       key: function (key) {
         // this only defines a getter - it will be set by the `fill` setter
         if (!key) {
-          return this.fill.key || `${UNASSIGNED_PREFIX}${safeid()}`
+          return this.fill.key || `${UNASSIGNED_PREFIX}${generateId()}`
         }
       },
       additionalFields: {

--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -1,7 +1,7 @@
-const safeid = require('generate-safe-id')
 const StateMachineHistory = require('javascript-state-machine/lib/history')
 
 const { Order } = require('../models')
+const { generateId } = require('../utils')
 
 const StateMachine = require('./state-machine')
 const {
@@ -39,7 +39,7 @@ const OrderStateMachine = StateMachine.factory({
       key: function (key) {
         // this only defines a getter - it will be set by the `order` setter
         if (!key) {
-          return this.order.key || `${UNASSIGNED_PREFIX}${safeid()}`
+          return this.order.key || `${UNASSIGNED_PREFIX}${generateId()}`
         }
       },
       additionalFields: {

--- a/broker-daemon/utils/generate-id.js
+++ b/broker-daemon/utils/generate-id.js
@@ -1,0 +1,8 @@
+const crypto = require('crypto')
+
+function generateId () {
+  const data = crypto.randomBytes(20).toString('hex')
+  return crypto.createHash('sha256').update(data).digest('base64')
+}
+
+module.exports = generateId

--- a/broker-daemon/utils/index.js
+++ b/broker-daemon/utils/index.js
@@ -12,6 +12,7 @@ const nanoToDatetime = require('./nano-to-datetime')
 const grpcGateway = require('./grpc-gateway')
 const createHttpServer = require('./create-http-server')
 const timestampToNano = require('./timestamp-to-nano')
+const generateId = require('./generate-id')
 
 module.exports = {
   getRecords,
@@ -27,5 +28,6 @@ module.exports = {
   nanoToDatetime,
   grpcGateway,
   createHttpServer,
-  timestampToNano
+  timestampToNano,
+  generateId
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -410,48 +410,6 @@
         }
       }
     },
-    "base64url": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
-      "integrity": "sha1-1k03XWinxkDZEuI1jRcNylu1RoE=",
-      "requires": {
-        "concat-stream": "~1.4.7",
-        "meow": "~2.0.0"
-      },
-      "dependencies": {
-        "concat-stream": {
-          "version": "1.4.11",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.11.tgz",
-          "integrity": "sha512-X3JMh8+4je3U1cQpG87+f9lXHDrqcb2MVLg9L7o8b1UZ0DzhRrUpdn65ttzu10PpJPPI3MQNkis+oha6TSA9Mw==",
-          "requires": {
-            "inherits": "~2.0.1",
-            "readable-stream": "~1.1.9",
-            "typedarray": "~0.0.5"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
     "big-integer": {
       "version": "1.6.28",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.28.tgz",
@@ -645,20 +603,6 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
-    },
-    "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
-    },
-    "camelcase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-      "integrity": "sha1-vRoRv5sxoc5JNJOpMN4aC69K1+w=",
-      "requires": {
-        "camelcase": "^1.0.1",
-        "map-obj": "^1.0.0"
-      }
     },
     "camelize": {
       "version": "1.0.0",
@@ -2756,14 +2700,6 @@
         "lodash.padstart": "^4.1.0"
       }
     },
-    "generate-safe-id": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/generate-safe-id/-/generate-safe-id-1.0.2.tgz",
-      "integrity": "sha1-7EBmbsHii0LJOWmHCvG/ewKbBn8=",
-      "requires": {
-        "base64url": "^1.0.6"
-      }
-    },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -2775,11 +2711,6 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
-    },
-    "get-stdin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
     },
     "get-value": {
       "version": "2.0.6",
@@ -3571,16 +3502,6 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
-    "indent-string": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
-      "integrity": "sha1-25m8xYPrarux5I3LsZmamGBBy2s=",
-      "requires": {
-        "get-stdin": "^4.0.1",
-        "minimist": "^1.1.0",
-        "repeating": "^1.1.0"
-      }
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3749,14 +3670,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-    },
-    "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
@@ -4331,11 +4244,6 @@
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
-    "map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
-    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -4348,24 +4256,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-    },
-    "meow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
-      "integrity": "sha1-j1MKjs9dQNP0tN+Tw0cpAPuiqPE=",
-      "requires": {
-        "camelcase-keys": "^1.0.0",
-        "indent-string": "^1.1.0",
-        "minimist": "^1.1.0",
-        "object-assign": "^1.0.0"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
-          "integrity": "sha1-5l3Idm07R7S4MHRlyDEdoDCwcKY="
-        }
-      }
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -8651,14 +8541,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-    },
-    "repeating": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-      "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-      "requires": {
-        "is-finite": "^1.0.0"
-      }
     },
     "require-uncached": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "colors": "1.2.4",
     "compare-versions": "3.1.0",
     "express": "4.16.3",
-    "generate-safe-id": "1.0.2",
     "grpc": "1.11.3",
     "grpc-caller": "0.5.0",
     "grpc-methods": "sparkswap/grpc-methods#v0.6.3",


### PR DESCRIPTION
## Description
The generate-safe-id library we were using for unique ids of mongo records had a security vulnerability, so this PR switches to use crypto instead.

## Related PRs
https://github.com/sparkswap/relayer/pull/166

## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
