### PR TITLE
remove disable relayer auth flag as relayer auth should always be enabled

### DIFF
--- a/broker-daemon/bin/sparkswapd.js
+++ b/broker-daemon/bin/sparkswapd.js
@@ -75,7 +75,6 @@ program
       relayerCertPath,
       idPrivkeyPath: privIdKeyPath,
       idPubkeyPath: pubIdKeyPath,
-      disableRelayerAuth,
       disableAuth,
       rpcPrivkeyPath: privRpcKeyPath,
       rpcPubkeyPath: pubRpcKeyPath,
@@ -114,8 +113,7 @@ program
       rpcPass,
       relayerOptions: {
         relayerRpcHost,
-        relayerCertPath,
-        disableRelayerAuth
+        relayerCertPath
       }
     }
     return new BrokerDaemon(brokerOptions).initialize()

--- a/broker-daemon/bin/sparkswapd.spec.js
+++ b/broker-daemon/bin/sparkswapd.spec.js
@@ -130,20 +130,6 @@ describe('sparkswapd', () => {
     expect(BrokerDaemon).to.have.been.calledWith(sinon.match({ relayerOptions: { relayerCertPath } }))
   })
 
-  it('provides a flag for relayer auth', () => {
-    argv.push('--disable-relayer-auth')
-
-    sparkswapd(argv)
-
-    expect(BrokerDaemon).to.have.been.calledWith(sinon.match({ relayerOptions: { disableRelayerAuth: true } }))
-  })
-
-  it('disables relayer auth unless the flag is provided', () => {
-    sparkswapd(argv)
-
-    expect(BrokerDaemon).to.have.been.calledWith(sinon.match({ relayerOptions: { disableRelayerAuth: undefined } }))
-  })
-
   it('provides the markets', () => {
     const markets = 'BTC/LTC,ABC/XYZ'
     argv.push('--markets')

--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -91,14 +91,13 @@ class BrokerDaemon {
    * @param {Object} opts.relayerOptions
    * @param {String} opts.relayerOptions.relayerRpcHost - Host and port for the Relayer RPC
    * @param {String} opts.relayerOptions.certPath - Absolute path to the root certificate for the relayer
-   * @param {Boolean} [relayerOptions.disableRelayerAuth=false] - Disable SSL encryption and message signing in communications with the Relayer. DEVELOPMENT ONLY.
    * @return {BrokerDaemon}
    */
   constructor ({ privRpcKeyPath, pubRpcKeyPath, privIdKeyPath, pubIdKeyPath, rpcAddress, interchainRouterAddress, dataDir, marketNames, engines, disableAuth = false, rpcUser = null, rpcPass = null, relayerOptions = {} }) {
     if (!privIdKeyPath) throw new Error('Private Key path is required to create a BrokerDaemon')
     if (!pubIdKeyPath) throw new Error('Public Key path is required to create a BrokerDaemon')
 
-    const { relayerRpcHost, relayerCertPath, disableRelayerAuth = false } = relayerOptions
+    const { relayerRpcHost, relayerCertPath } = relayerOptions
     this.idKeyPath = {
       privKeyPath: privIdKeyPath,
       pubKeyPath: pubIdKeyPath
@@ -116,7 +115,7 @@ class BrokerDaemon {
     this.logger = logger
     this.store = sublevel(level(this.dataDir))
     this.eventHandler = new EventEmitter()
-    this.relayer = new RelayerClient(this.idKeyPath, { host: this.relayerRpcHost, certPath: this.relayerCertPath, disableAuth: disableRelayerAuth }, this.logger)
+    this.relayer = new RelayerClient(this.idKeyPath, { host: this.relayerRpcHost, certPath: this.relayerCertPath }, this.logger)
 
     this.engines = new Map(Object.entries(engines || {}).map(([ symbol, engineConfig ]) => {
       return [ symbol, createEngineFromConfig(symbol, engines[symbol], { logger: this.logger }) ]

--- a/broker-daemon/index.spec.js
+++ b/broker-daemon/index.spec.js
@@ -120,8 +120,7 @@ describe('broker daemon', () => {
     disableAuth = false
     relayerOptions = {
       relayerCertPath: '/fake/path',
-      relayerRpcHost: 'fakehost',
-      disableRelayerAuth: false
+      relayerRpcHost: 'fakehost'
     }
 
     brokerDaemonOptions = {
@@ -156,12 +155,6 @@ describe('broker daemon', () => {
   it('throws for unrecognized engine types', () => {
     brokerDaemonOptions.engines.BTC.type = 'LIT'
     expect(() => new BrokerDaemon(brokerDaemonOptions)).to.throw('Unknown engine type')
-  })
-
-  it('disables relayer client auth', () => {
-    brokerDaemonOptions.relayerOptions.disableRelayerAuth = true
-    brokerDaemon = new BrokerDaemon(brokerDaemonOptions)
-    expect(RelayerClient).to.have.been.calledWith(sinon.match.any, sinon.match({ disableAuth: true }), sinon.match.any)
   })
 
   describe('daemon properties', () => {

--- a/broker-daemon/relayer/relayer-client.spec.js
+++ b/broker-daemon/relayer/relayer-client.spec.js
@@ -374,17 +374,4 @@ describe('RelayerClient', () => {
       expect(store.put).to.have.been.calledWith(MarketEvent.prototype.key, MarketEvent.prototype.value)
     })
   })
-
-  describe('insecureIdentity', () => {
-    let insecureIdentity
-
-    beforeEach(() => {
-      insecureIdentity = RelayerClient.__get__('insecureIdentity')
-    })
-
-    it('creates an insecure identity', () => {
-      const res = insecureIdentity(logger)
-      expect(res).to.have.property('authorize')
-    })
-  })
 })


### PR DESCRIPTION
## Description
We should remove the flag where we can disable auth from the relayer, as this was only used for development and should now be required for dev going forward.

## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
