### PR TITLE
Feature: add optional cors support for the http server

### DIFF
--- a/broker-daemon/broker-rpc/broker-rpc-server.js
+++ b/broker-daemon/broker-rpc/broker-rpc-server.js
@@ -61,7 +61,7 @@ class BrokerRPCServer {
    * @param {Boolean} [opts.disableAuth=false]
    * @return {BrokerRPCServer}
    */
-  constructor ({ logger, engines, relayer, blockOrderWorker, orderbooks, pubKeyPath, privKeyPath, disableAuth = false, rpcUser = null, rpcPass = null } = {}) {
+  constructor ({ logger, engines, relayer, blockOrderWorker, orderbooks, pubKeyPath, privKeyPath, disableAuth = false, enableCors = false, rpcUser = null, rpcPass = null } = {}) {
     this.logger = logger
     this.engines = engines
     this.relayer = relayer
@@ -75,7 +75,7 @@ class BrokerRPCServer {
     this.protoPath = path.resolve(BROKER_PROTO_PATH)
 
     this.server = new grpc.Server()
-    this.httpServer = createHttpServer(this.protoPath, DEFAULT_RPC_ADDRESS, { disableAuth, privKeyPath, pubKeyPath, logger })
+    this.httpServer = createHttpServer(this.protoPath, DEFAULT_RPC_ADDRESS, { disableAuth, enableCors, privKeyPath, pubKeyPath, logger })
 
     this.adminService = new AdminService(this.protoPath, { logger, relayer, engines, auth: this.auth })
     this.server.addService(this.adminService.definition, this.adminService.implementation)

--- a/broker-daemon/utils/create-http-server.js
+++ b/broker-daemon/utils/create-http-server.js
@@ -6,6 +6,7 @@ const fs = require('fs')
 const grpc = require('grpc')
 
 const grpcGateway = require('./grpc-gateway')
+const corsMiddleware = require('./enable-cors')
 
 /**
  * creates an express app/server with the given protopath and rpcAddress
@@ -18,12 +19,16 @@ const grpcGateway = require('./grpc-gateway')
  * @param {String} pubKeyPath
  * @return {ExpressApp}
  */
-function createHttpServer (protoPath, rpcAddress, { disableAuth = false, privKeyPath, pubKeyPath, logger }) {
+function createHttpServer (protoPath, rpcAddress, { disableAuth = false, enableCors = false, privKeyPath, pubKeyPath, logger }) {
   const app = express()
 
   app.use(helmet())
   app.use(bodyParser.json())
   app.use(bodyParser.urlencoded({ extended: false }))
+
+  if (enableCors) {
+    app.use(corsMiddleware())
+  }
 
   if (disableAuth) {
     app.use('/', grpcGateway([`/${protoPath}`], rpcAddress))

--- a/broker-daemon/utils/enable-cors.js
+++ b/broker-daemon/utils/enable-cors.js
@@ -1,0 +1,10 @@
+function enableCors () {
+  return (req, res, next) => {
+    res.header('Access-Control-Allow-Origin', '*')
+    res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
+
+    next()
+  }
+}
+
+module.exports = enableCors

--- a/broker-daemon/utils/enable-cors.spec.js
+++ b/broker-daemon/utils/enable-cors.spec.js
@@ -1,0 +1,33 @@
+const path = require('path')
+const { expect, rewire, sinon } = require('test/test-helper')
+
+const enableCors = rewire(path.resolve(__dirname, 'enable-cors'))
+
+describe('enableCors', () => {
+  let corsMiddleware
+  let req
+  let res
+  let next
+
+  beforeEach(() => {
+    res = {
+      header: sinon.stub()
+    }
+    next = sinon.stub()
+    corsMiddleware = enableCors()
+    corsMiddleware(req, res, next)
+  })
+
+  it('sets the access control allow origin header to any domain', () => {
+    expect(res.header).to.have.been.calledWith('Access-Control-Allow-Origin', '*')
+  })
+
+  it('sets the access control allow headers header', () => {
+    expect(res.header).to.have.been.calledWith('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
+  })
+
+  it('moves to the next middleware', () => {
+    expect(next).to.have.been.calledOnce()
+    expect(next).to.have.been.calledAfter(res.header)
+  })
+})

--- a/broker-daemon/utils/grpc-gateway.js
+++ b/broker-daemon/utils/grpc-gateway.js
@@ -55,6 +55,7 @@ const middleware = (protoFiles, grpcLocation, credentials = requiredGrpc.credent
                 router[httpMethod](convertUrl(m.options['google.api.http'][httpMethod]), (req, res) => {
                   const params = convertParams(req, m.options['google.api.http'][httpMethod])
                   const meta = convertHeaders(req.headers, grpc)
+
                   if (debug) {
                     const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress
                     console.log(`GATEWAY: ${(new Date()).toISOString().yellow} (${ip.blue}): /${pkg.replace(/\./g, '.'.white).blue}.${svc.blue}/${m.name.blue}(${params})`)


### PR DESCRIPTION
## Description
As part of the Lightning Hackday, I made a web GUI for viewing the orderbook. To do so, I needed to enable CORS for the Broker to allow the web GUI to pull the data.

Rather than letting that interesting functionality go away, I added it as an option to the http server. There currently is not a user-configurable way to turn it on, but that can be added later fairly easily by adding some configuration to the environment and Broker Daemon constructor.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Link to Trello
