### PR TITLE
exclude node_modules from mocha test runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dist-cli": "npm run broker-proto && bash ./scripts/publish-broker-cli.sh",
     "format": "standard --fix",
     "pretest": "npm run format; exit 0",
-    "test": "NODE_PATH=. mocha 'broker-cli/**/**/*.spec.js' 'broker-daemon/**/**/*.spec.js'",
+    "test": "NODE_PATH=. mocha 'broker-cli/{,!(node_modules)/**}/**/*.spec.js' 'broker-daemon/**/**/*.spec.js'",
     "coverage": "nyc npm test",
     "ci-test": "npm run format && npm test",
     "start-sparkswapd": "pm2-docker pm2.json --watch",
@@ -30,6 +30,10 @@
     "env": [
       "mocha",
       "chai"
+    ],
+    "ignore": [
+      "broker-cli/node_modules/*",
+      "node_modules/*"
     ]
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "broker",
   "version": "0.1.0-alpha-preview",
-  "description": "Broker software to interact with the Sparkswap Relayer ",
-  "main": "index.js",
+  "description": "Broker software to interact with the Sparkswap Relayer",
+  "main": "src/index.js",
   "config": {
     "project_name": "broker",
     "daemon": "sparkswapd"
@@ -30,17 +30,13 @@
     "env": [
       "mocha",
       "chai"
-    ],
-    "ignore": [
-      "broker-cli/node_modules/*",
-      "node_modules/*"
     ]
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sparkswap/broker.git"
   },
-  "author": "",
+  "author": "sparkswap",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/sparkswap/broker/issues"


### PR DESCRIPTION
## Description
Test runs started to feel a little sluggish, which may be due to how mocha are loads files. Currently, we are not excluding node_modules for these test runs.

Initial Test Run: 19s
Test Run with Excluded directories: 11s

## Related PRs
List related PRs if applicable


## Todos
- [n/a] Tests
- [n/a] Documentation
- [n/a] Link to Trello
