### PR TITLE
Cannot cancel order

### DIFF
--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -138,7 +138,7 @@ class BlockOrderWorker extends EventEmitter {
   async cancelBlockOrder (blockOrderId) {
     this.logger.info('Cancelling block order ', { id: blockOrderId })
 
-    const blockOrder = BlockOrder.fromStore(this.store, blockOrderId)
+    const blockOrder = await BlockOrder.fromStore(this.store, blockOrderId)
 
     const orders = await getRecords(
       this.ordersStore,

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -381,7 +381,7 @@ describe('BlockOrderWorker', () => {
         fail: sinon.stub()
       }
 
-      BlockOrder.fromStore.returns(fakeBlockOrder)
+      BlockOrder.fromStore.resolves(fakeBlockOrder)
       worker = new BlockOrderWorker({ orderbooks, store, logger, relayer, engines })
       fakeErr = new Error('fake')
       fakeId = 'myid'
@@ -432,7 +432,7 @@ describe('BlockOrderWorker', () => {
       store.get.callsArgWithAsync(1, null, blockOrder)
       OrderStateMachine.getAll.resolves(orders)
       FillStateMachine.getAll.resolves(fills)
-      BlockOrder.fromStore.returns({ id: blockOrderId })
+      BlockOrder.fromStore.resolves({ id: blockOrderId })
       worker = new BlockOrderWorker({ orderbooks, store, logger, relayer, engines })
     })
 
@@ -500,7 +500,7 @@ describe('BlockOrderWorker', () => {
       ]
       store.get.callsArgWithAsync(1, null, blockOrder)
       blockOrderCancel = sinon.stub()
-      BlockOrder.fromStore.returns({
+      BlockOrder.fromStore.resolves({
         id: blockOrderId,
         cancel: blockOrderCancel,
         key: blockOrderKey,


### PR DESCRIPTION
## Description
There is a bug when cancelling orders that was introduced when the BlockOrder.fromStore method was implemented. The blockorder.fromstore in the cancel function needs to be awaited so that it is the blockOrder object and not a promise.


## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
