### PR TITLE
Feature: Retry orderbook when watchMarket fails

### DIFF
--- a/broker-daemon/orderbook/index.js
+++ b/broker-daemon/orderbook/index.js
@@ -60,7 +60,7 @@ class Orderbook {
    * @returns {Promise<Array<MarketEventOrder>>} A promise that resolves an array of MarketEventOrder records
    */
   async all () {
-    this._assertSynced()
+    this.assertSynced()
     this.logger.info(`Retrieving all records for ${this.marketName}`)
     return getRecords(this.store, MarketEventOrder.fromStorage.bind(MarketEventOrder))
   }
@@ -73,7 +73,7 @@ class Orderbook {
    * @return {Array<Object>} trades
    */
   async getTrades (since, limit) {
-    this._assertSynced()
+    this.assertSynced()
     const params = {limit}
     if (since) {
       const sinceDate = new Date(since).toISOString()
@@ -97,7 +97,7 @@ class Orderbook {
    * @return {Promise<BestOrders>} A promise that resolves MarketEventOrders of the best priced orders
    */
   getBestOrders ({ side, depth, quantumPrice }) {
-    this._assertSynced()
+    this.assertSynced()
     return new Promise((resolve, reject) => {
       this.logger.info(`Retrieving best priced from ${side} up to ${depth}`)
 
@@ -151,7 +151,7 @@ class Orderbook {
    * @returns {Array<MarketEventOrder>}
    */
   async getOrderbookEventsByTimestamp (timestamp) {
-    this._assertSynced()
+    this.assertSynced()
     return getRecords(
       this.store,
       (key, value) => JSON.parse(value),
@@ -167,7 +167,7 @@ class Orderbook {
    * @returns {Array<MarketEventOrder>}
    */
   async getMarketEventsByTimestamp (timestamp) {
-    this._assertSynced()
+    this.assertSynced()
     return getRecords(
       this.eventStore,
       (key, value) => JSON.parse(value),

--- a/broker-daemon/orderbook/index.js
+++ b/broker-daemon/orderbook/index.js
@@ -8,6 +8,8 @@ const nano = require('nano-seconds')
 const consoleLogger = console
 consoleLogger.debug = console.log.bind(console)
 
+const RETRY_WATCHMARKET = 5000
+
 class Orderbook {
   constructor (marketName, relayer, store, logger = consoleLogger) {
     this.marketName = marketName
@@ -48,10 +50,10 @@ class Orderbook {
     })
 
     watcher.on('end', (error) => {
-      this.logger.info(`Market ${this.marketName} unavailable, retrying in 5s`, { error })
+      this.logger.info(`Market ${this.marketName} unavailable, retrying in ${RETRY_WATCHMARKET}ms`, { error })
       setTimeout(() => {
         this.initialize()
-      }, 5000)
+      }, RETRY_WATCHMARKET)
     })
   }
 

--- a/broker-daemon/orderbook/index.js
+++ b/broker-daemon/orderbook/index.js
@@ -30,7 +30,7 @@ class Orderbook {
     this.logger.info(`Initializing market ${this.marketName}...`)
 
     const { baseSymbol, counterSymbol } = this
-    const { lastUpdated, sequence } = await this.lastUpdate()
+    const { lastUpdated, sequence } = await this._lastUpdate()
     const params = { baseSymbol, counterSymbol, lastUpdated, sequence }
 
     await this.relayer.watchMarket(this.eventStore, params)
@@ -131,45 +131,6 @@ class Orderbook {
   }
 
   /**
-   * Gets the last record in an event store
-   *
-   * @returns {MarketEvent}
-   * @returns {Object} empty object if no record exists
-   */
-  async getLastRecord () {
-    const [ lastEvent = {} ] = await getRecords(
-      this.eventStore,
-      MarketEvent.fromStorage.bind(MarketEvent),
-      {
-        reverse: true,
-        limit: 1
-      }
-    )
-    return lastEvent
-  }
-
-  /**
-   * Gets the last time this market was updated with data from the relayer
-   *
-   * @returns {Object} res
-   * @returns {String} [lastUpdated=0] - nanosecond timestamp
-   * @returns {String} [sequence=0] - event version for a given timestamp
-   */
-  async lastUpdate () {
-    this.logger.info(`Retrieving last update from store for ${this.marketName}`)
-
-    const {
-      timestamp: lastUpdated = '0',
-      sequence = '0'
-    } = await this.getLastRecord()
-
-    return {
-      lastUpdated,
-      sequence
-    }
-  }
-
-  /**
    * Gets current orderbook events by timestamp
    *
    * @param {String} timestamp - timestamp in nano-seconds
@@ -197,6 +158,45 @@ class Orderbook {
       // Limits the query to gte to a specific timestamp
       MarketEvent.rangeFromTimestamp(timestamp)
     )
+  }
+
+  /**
+   * Gets the last record in an event store
+   *
+   * @returns {MarketEvent}
+   * @returns {Object} empty object if no record exists
+   */
+  async _getLastRecord () {
+    const [ lastEvent = {} ] = await getRecords(
+      this.eventStore,
+      MarketEvent.fromStorage.bind(MarketEvent),
+      {
+        reverse: true,
+        limit: 1
+      }
+    )
+    return lastEvent
+  }
+
+  /**
+   * Gets the last time this market was updated with data from the relayer
+   *
+   * @returns {Object} res
+   * @returns {String} [lastUpdated=0] - nanosecond timestamp
+   * @returns {String} [sequence=0] - event version for a given timestamp
+   */
+  async _lastUpdate () {
+    this.logger.info(`Retrieving last update from store for ${this.marketName}`)
+
+    const {
+      timestamp: lastUpdated = '0',
+      sequence = '0'
+    } = await this._getLastRecord()
+
+    return {
+      lastUpdated,
+      sequence
+    }
   }
 }
 

--- a/broker-daemon/orderbook/index.js
+++ b/broker-daemon/orderbook/index.js
@@ -26,7 +26,7 @@ class Orderbook {
     return this.marketName.split('/')[1]
   }
 
-  initialize () {
+  async initialize () {
     this.logger.info(`Initializing market ${this.marketName}...`)
     this.synced = false
 
@@ -47,7 +47,7 @@ class Orderbook {
     })
 
     watcher.on('end', (error) => {
-      this.logger.info(`Market ${this.marketName} unavailable, retrying in 5s` { error })
+      this.logger.info(`Market ${this.marketName} unavailable, retrying in 5s`, { error })
       setTimeout(() => {
         this.initialize()
       }, 5000)

--- a/broker-daemon/orderbook/index.js
+++ b/broker-daemon/orderbook/index.js
@@ -178,10 +178,11 @@ class Orderbook {
 
   /**
    * Ensures that the orderbook is synced before accessing it
+   * @private
    * @return {void}
    * @throws {Error} If Orderbook is not synced to Relayer
    */
-  _assertSynced () {
+  assertSynced () {
     if (!this.synced) {
       throw new Error(`Cannot access Orderbook for ${this.marketName} until it is synced`)
     }
@@ -189,11 +190,11 @@ class Orderbook {
 
   /**
    * Gets the last record in an event store
-   *
+   * @private
    * @returns {MarketEvent}
    * @returns {Object} empty object if no record exists
    */
-  async _getLastRecord () {
+  async getLastRecord () {
     const [ lastEvent = {} ] = await getRecords(
       this.eventStore,
       MarketEvent.fromStorage.bind(MarketEvent),
@@ -207,18 +208,18 @@ class Orderbook {
 
   /**
    * Gets the last time this market was updated with data from the relayer
-   *
+   * @private
    * @returns {Object} res
    * @returns {String} [lastUpdated=0] - nanosecond timestamp
    * @returns {String} [sequence=0] - event version for a given timestamp
    */
-  async _lastUpdate () {
+  async lastUpdate () {
     this.logger.info(`Retrieving last update from store for ${this.marketName}`)
 
     const {
       timestamp: lastUpdated = '0',
       sequence = '0'
-    } = await this._getLastRecord()
+    } = await this.getLastRecord()
 
     return {
       lastUpdated,

--- a/broker-daemon/orderbook/index.js
+++ b/broker-daemon/orderbook/index.js
@@ -8,9 +8,26 @@ const nano = require('nano-seconds')
 const consoleLogger = console
 consoleLogger.debug = console.log.bind(console)
 
+/**
+ * Time, in milliseconds, between tries to get the market events from
+ * the Relayer.
+ * @constant
+ * @type {Number}
+ */
 const RETRY_WATCHMARKET = 5000
 
+/**
+ * @class Current state of the orderbook in a particular market
+ */
 class Orderbook {
+  /**
+   * Create a new orderbook for a given market
+   * @param  {String}        marketName Name of the market to track, e.g. `BTC/LTC`
+   * @param  {RelayerClient} relayer    Client to connect to the Relayer
+   * @param  {Sublevel}      store      Sublevel-compatible data store
+   * @param  {Object}        logger     
+   * @return {Orderbook}
+   */
   constructor (marketName, relayer, store, logger = consoleLogger) {
     this.marketName = marketName
     this.relayer = relayer
@@ -29,6 +46,12 @@ class Orderbook {
     return this.marketName.split('/')[1]
   }
 
+  /**
+   * Initialize the orderbook by syncing its state to the Relayer and indexing
+   * the orders.
+   * Also includes retry logic if the Relayer fails.
+   * @return {void}
+   */
   async initialize () {
     this.logger.info(`Initializing market ${this.marketName}...`)
     this.synced = false

--- a/broker-daemon/orderbook/index.js
+++ b/broker-daemon/orderbook/index.js
@@ -51,6 +51,8 @@ class Orderbook {
 
     watcher.on('end', (error) => {
       this.logger.info(`Market ${this.marketName} unavailable, retrying in ${RETRY_WATCHMARKET}ms`, { error })
+
+      // TODO: exponential backoff?
       setTimeout(() => {
         this.initialize()
       }, RETRY_WATCHMARKET)

--- a/broker-daemon/orderbook/index.js
+++ b/broker-daemon/orderbook/index.js
@@ -16,6 +16,7 @@ class Orderbook {
     this.index = new OrderbookIndex(store, this.eventStore, this.marketName)
     this.store = this.index.store
     this.logger = logger
+    this.synced = false
   }
 
   get baseSymbol () {
@@ -31,7 +32,7 @@ class Orderbook {
     this.synced = false
 
     const { baseSymbol, counterSymbol } = this
-    const { lastUpdated, sequence } = await this._lastUpdate()
+    const { lastUpdated, sequence } = await this.lastUpdate()
     const params = { baseSymbol, counterSymbol, lastUpdated, sequence }
 
     const watcher = this.relayer.watchMarket(this.eventStore, params)

--- a/broker-daemon/orderbook/index.spec.js
+++ b/broker-daemon/orderbook/index.spec.js
@@ -195,7 +195,7 @@ describe('Orderbook', () => {
     })
   })
 
-  describe('#lastUpdate', () => {
+  describe('#_lastUpdate', () => {
     let orderbook
     let getLastRecordStub
     let timestamp
@@ -212,26 +212,26 @@ describe('Orderbook', () => {
       })
 
       orderbook = new Orderbook(marketName, relayer, baseStore, logger)
-      orderbook.getLastRecord = getLastRecordStub
+      orderbook._getLastRecord = getLastRecordStub
     })
 
     it('grabs the last record from the orderbook', async () => {
-      await orderbook.lastUpdate()
+      await orderbook._lastUpdate()
       expect(getLastRecordStub)
     })
 
     it('returns lastUpdated timestamp', async () => {
-      const result = await orderbook.lastUpdate()
+      const result = await orderbook._lastUpdate()
       expect(result).to.have.property('lastUpdated', timestamp)
     })
 
     it('returns a sequence number', async () => {
-      const result = await orderbook.lastUpdate()
+      const result = await orderbook._lastUpdate()
       expect(result).to.have.property('sequence', sequence)
     })
   })
 
-  describe('#getLastRecord', () => {
+  describe('#_getLastRecord', () => {
     it('gets the timestamp of the last event', async () => {
       const marketName = 'XYZ/ABC'
       const orderbook = new Orderbook(marketName, relayer, baseStore, logger)
@@ -243,7 +243,7 @@ describe('Orderbook', () => {
       }
       getRecords.resolves([ lastEvent ])
 
-      const event = await orderbook.getLastRecord()
+      const event = await orderbook._getLastRecord()
 
       expect(getRecords).to.have.been.calledOnce()
       expect(getRecords).to.have.been.calledWith(eventStore, bound, sinon.match({ reverse: true, limit: 1 }))
@@ -256,7 +256,7 @@ describe('Orderbook', () => {
 
       getRecords.resolves([])
 
-      const event = await orderbook.getLastRecord()
+      const event = await orderbook._getLastRecord()
 
       expect(event).to.be.eql({})
     })

--- a/broker-daemon/orderbook/index.spec.js
+++ b/broker-daemon/orderbook/index.spec.js
@@ -195,7 +195,7 @@ describe('Orderbook', () => {
     })
   })
 
-  describe('#_lastUpdate', () => {
+  describe('#lastUpdate', () => {
     let orderbook
     let getLastRecordStub
     let timestamp
@@ -212,26 +212,26 @@ describe('Orderbook', () => {
       })
 
       orderbook = new Orderbook(marketName, relayer, baseStore, logger)
-      orderbook._getLastRecord = getLastRecordStub
+      orderbook.getLastRecord = getLastRecordStub
     })
 
     it('grabs the last record from the orderbook', async () => {
-      await orderbook._lastUpdate()
+      await orderbook.lastUpdate()
       expect(getLastRecordStub)
     })
 
     it('returns lastUpdated timestamp', async () => {
-      const result = await orderbook._lastUpdate()
+      const result = await orderbook.lastUpdate()
       expect(result).to.have.property('lastUpdated', timestamp)
     })
 
     it('returns a sequence number', async () => {
-      const result = await orderbook._lastUpdate()
+      const result = await orderbook.lastUpdate()
       expect(result).to.have.property('sequence', sequence)
     })
   })
 
-  describe('#_getLastRecord', () => {
+  describe('#getLastRecord', () => {
     it('gets the timestamp of the last event', async () => {
       const marketName = 'XYZ/ABC'
       const orderbook = new Orderbook(marketName, relayer, baseStore, logger)
@@ -243,7 +243,7 @@ describe('Orderbook', () => {
       }
       getRecords.resolves([ lastEvent ])
 
-      const event = await orderbook._getLastRecord()
+      const event = await orderbook.getLastRecord()
 
       expect(getRecords).to.have.been.calledOnce()
       expect(getRecords).to.have.been.calledWith(eventStore, bound, sinon.match({ reverse: true, limit: 1 }))
@@ -256,7 +256,7 @@ describe('Orderbook', () => {
 
       getRecords.resolves([])
 
-      const event = await orderbook._getLastRecord()
+      const event = await orderbook.getLastRecord()
 
       expect(event).to.be.eql({})
     })

--- a/broker-daemon/relayer/market-watcher.js
+++ b/broker-daemon/relayer/market-watcher.js
@@ -1,0 +1,123 @@
+/**
+ * @class Watch a relayer market and put the events into a data store
+ * It emits two events: 
+ * - `sync` when it is caught up to the market
+ * - `end` when it is no longer connected to the market
+ */
+class MarketWatcher extends EventEmitter {
+  /**
+   * Set up the watcher
+   * @param  {grpc.ServerStreaming} watcher        Stream of events from the Relayer
+   * @param  {Sublevel}             store          Leveldb compatible store
+   * @param  {Object}               RESPONSE_TYPES Response types from the proto file
+   * @param  {Object} logger
+   * @return {MarketWatcher}
+   */
+  constructor (watcher, store, RESPONSE_TYPES, logger) {
+    super()
+    this.watcher = watcher
+    this.store = store
+    this.migrating = null
+    this.logger = logger
+    this.RESPONSE_TYPES
+
+    this.setupListeners()
+  }
+
+  /**
+   * Set up the listeners on the watcher
+   * @return {void}
+   */
+  setupListeners () {
+    // Tear down listeners when the watcher completes
+    this.on('end', () => {
+      this.removeAllListeners()
+      this.watcher.removeAllListeners()
+    })
+
+    this.watcher.on('end', () => {
+      this.logger.error('Remote ended stream')
+      this.emit('end')
+    })
+
+    this.watcher.on('error', (err) => {
+      this.logger.error('Relayer watchMarket grpc failed', err)
+      this.emit('end', err)
+    })
+
+    this.watcher.on('data', (repsonse) => {
+      this.handleResponse(response)
+    })
+  }
+
+  /**
+   * Handle an inbound event from the Relayer
+   * @param  {Object} response Response from the Relayer stream
+   * @return {void}
+   */
+  async handleResponse (response) {
+    const { RESPONSE_TYPES } = this
+
+    await this.migration()
+
+    this.logger.debug(`response type is ${response.type}`)
+
+    if (RESPONSE_TYPES[response.type] === RESPONSE_TYPES.EXISTING_EVENTS_DONE) {
+      this.upToDate()
+    } else if (RESPONSE_TYPES[response.type] === RESPONSE_TYPES.START_OF_EVENTS) {
+      this.migrate()
+    } else if ([RESPONSE_TYPES.EXISTING_EVENT, RESPONSE_TYPES.NEW_EVENT].includes(RESPONSE_TYPES[response.type])) {
+      this.createMarketEvent(response)
+    } else {
+      this.logger.debug(`Unknown response type: ${response.type}`)
+    }
+  }
+
+  /**
+   * Delete every event in the store and set a promise on `migrating` that resolves once deletion is complete.
+   * @return {Promise} Resolves when migration is complete
+   */
+  migrate () {
+    this.logger.debug(`Removing existing orderbook events as part of migration`)
+    this.migrating = migrateStore(this.store, this.store, (key) => { return { type: 'del', key } })
+    return this.migrating
+  }
+
+  /**
+   * Helper promise to await to ensure that any migrations are complete before proceeding
+   * @return {Promise} Resolves when there are no in-progress migrations
+   */
+  async migration () {
+    // migrating is falsey (null) by default
+    if (this.migrating) {
+      this.logger.debug(`Waiting for migration to finish before acting on new response`)
+      await this.migrating
+    }
+    return
+  }
+
+  /**
+   * Store a market event
+   * @param  {Object} response Response from the Relayer
+   * @return {void}
+   */
+  createMarketEvent (response) {
+    const { marketEvent } = response
+
+    this.logger.debug('Creating a market event', marketEvent)
+
+    const { key, value } = new MarketEvent(marketEvent)
+    this.store.put(key, value)
+  }
+
+  /**
+   * Emit an event when the watcher is up to date
+   * @return {void}
+   */
+  upToDate () {
+    this.logger.debug(`Up to date with market`)
+    this.emit('sync')   
+  }
+}
+
+module.exports = MarketWatcher

--- a/broker-daemon/relayer/market-watcher.js
+++ b/broker-daemon/relayer/market-watcher.js
@@ -1,6 +1,10 @@
+const EventEmitter = require('events')
+const { MarketEvent } = require('../models')
+const { migrateStore } = require('../utils')
+
 /**
  * @class Watch a relayer market and put the events into a data store
- * It emits two events: 
+ * It emits two events:
  * - `sync` when it is caught up to the market
  * - `end` when it is no longer connected to the market
  */
@@ -19,7 +23,7 @@ class MarketWatcher extends EventEmitter {
     this.store = store
     this.migrating = null
     this.logger = logger
-    this.RESPONSE_TYPES
+    this.RESPONSE_TYPES = RESPONSE_TYPES
 
     this.setupListeners()
   }
@@ -45,7 +49,7 @@ class MarketWatcher extends EventEmitter {
       this.emit('end', err)
     })
 
-    this.watcher.on('data', (repsonse) => {
+    this.watcher.on('data', (response) => {
       this.handleResponse(response)
     })
   }
@@ -93,7 +97,6 @@ class MarketWatcher extends EventEmitter {
       this.logger.debug(`Waiting for migration to finish before acting on new response`)
       await this.migrating
     }
-    return
   }
 
   /**
@@ -116,7 +119,7 @@ class MarketWatcher extends EventEmitter {
    */
   upToDate () {
     this.logger.debug(`Up to date with market`)
-    this.emit('sync')   
+    this.emit('sync')
   }
 }
 

--- a/broker-daemon/relayer/market-watcher.js
+++ b/broker-daemon/relayer/market-watcher.js
@@ -37,7 +37,7 @@ class MarketWatcher extends EventEmitter {
 
     this.watcher.on('end', () => {
       this.logger.error('Remote ended stream')
-      this.emit('end')
+      this.emit('end', new Error('Remote ended stream'))
     })
 
     this.watcher.on('error', (err) => {

--- a/broker-daemon/relayer/market-watcher.js
+++ b/broker-daemon/relayer/market-watcher.js
@@ -30,6 +30,7 @@ class MarketWatcher extends EventEmitter {
 
   /**
    * Set up the listeners on the watcher
+   * @private
    * @return {void}
    */
   setupListeners () {
@@ -56,6 +57,7 @@ class MarketWatcher extends EventEmitter {
 
   /**
    * Handle an inbound event from the Relayer
+   * @private
    * @param  {Object} response Response from the Relayer stream
    * @return {void}
    */
@@ -79,6 +81,7 @@ class MarketWatcher extends EventEmitter {
 
   /**
    * Delete every event in the store and set a promise on `migrating` that resolves once deletion is complete.
+   * @private
    * @return {Promise} Resolves when migration is complete
    */
   migrate () {
@@ -89,6 +92,7 @@ class MarketWatcher extends EventEmitter {
 
   /**
    * Helper promise to await to ensure that any migrations are complete before proceeding
+   * @private
    * @return {Promise} Resolves when there are no in-progress migrations
    */
   async migration () {
@@ -101,6 +105,7 @@ class MarketWatcher extends EventEmitter {
 
   /**
    * Store a market event
+   * @private
    * @param  {Object} response Response from the Relayer
    * @return {void}
    */
@@ -115,6 +120,7 @@ class MarketWatcher extends EventEmitter {
 
   /**
    * Emit an event when the watcher is up to date
+   * @private
    * @return {void}
    */
   upToDate () {

--- a/broker-daemon/relayer/market-watcher.spec.js
+++ b/broker-daemon/relayer/market-watcher.spec.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const { sinon, rewire, delay, expect } = require('test/test-helper')
+const { sinon, rewire, expect } = require('test/test-helper')
 
 const MarketWatcher = rewire(path.resolve(__dirname, 'market-watcher.js'))
 
@@ -17,6 +17,7 @@ describe('MarketWatcher', () => {
   }
   let onStub
   let emitStub
+  let removeAllListenersStub
 
   beforeEach(() => {
     logger = {

--- a/broker-daemon/relayer/market-watcher.spec.js
+++ b/broker-daemon/relayer/market-watcher.spec.js
@@ -1,0 +1,360 @@
+const path = require('path')
+const { sinon, rewire, delay, expect } = require('test/test-helper')
+
+const MarketWatcher = rewire(path.resolve(__dirname, 'market-watcher.js'))
+
+describe('MarketWatcher', () => {
+  let migrateStore
+  let MarketEvent
+  let logger
+  let watcher
+  let store
+  let RESPONSE_TYPES = {
+    EXISTING_EVENT: 'EXISTING_EVENT',
+    EXISTING_EVENTS_DONE: 'EXISTING_EVENTS_DONE',
+    NEW_EVENT: 'NEW_EVENT',
+    START_OF_EVENTS: 'START_OF_EVENTS'
+  }
+  let onStub
+  let emitStub
+
+  beforeEach(() => {
+    logger = {
+      debug: sinon.stub(),
+      info: sinon.stub(),
+      error: sinon.stub()
+    }
+    watcher = {
+      on: sinon.stub(),
+      removeAllListeners: sinon.stub()
+    }
+    store = {
+      put: sinon.stub()
+    }
+    onStub = sinon.stub()
+    emitStub = sinon.stub()
+    removeAllListenersStub = sinon.stub()
+
+    MarketEvent = sinon.stub()
+    migrateStore = sinon.stub().resolves()
+
+    MarketWatcher.__set__('MarketEvent', MarketEvent)
+    MarketWatcher.__set__('migrateStore', migrateStore)
+
+    MarketWatcher.prototype.on = onStub
+    MarketWatcher.prototype.emit = emitStub
+    MarketWatcher.prototype.removeAllListeners = removeAllListenersStub
+  })
+
+  describe('new', () => {
+    it('assigns a logger', () => {
+      const mw = new MarketWatcher(watcher, store, RESPONSE_TYPES, logger)
+
+      expect(mw).to.have.property('logger')
+      expect(mw.logger).to.be.equal(logger)
+    })
+
+    it('assigns a store', () => {
+      const mw = new MarketWatcher(watcher, store, RESPONSE_TYPES, logger)
+
+      expect(mw).to.have.property('store')
+      expect(mw.store).to.be.equal(store)
+    })
+
+    it('assigns a watcher', () => {
+      const mw = new MarketWatcher(watcher, store, RESPONSE_TYPES, logger)
+
+      expect(mw).to.have.property('watcher')
+      expect(mw.watcher).to.be.equal(watcher)
+    })
+
+    it('assigns a RESPONSE_TYPES', () => {
+      const mw = new MarketWatcher(watcher, store, RESPONSE_TYPES, logger)
+
+      expect(mw).to.have.property('RESPONSE_TYPES')
+      expect(mw.RESPONSE_TYPES).to.be.equal(RESPONSE_TYPES)
+    })
+
+    it('creates a falsey value for migrating', () => {
+      const mw = new MarketWatcher(watcher, store, RESPONSE_TYPES, logger)
+
+      expect(mw).to.have.property('migrating')
+      expect(mw.migrating).to.be.null()
+    })
+
+    it('sets up listeners', () => {
+      const sl = MarketWatcher.prototype.setupListeners
+      MarketWatcher.prototype.setupListeners = sinon.stub()
+
+      const mw = new MarketWatcher(watcher, store, RESPONSE_TYPES, logger)
+
+      expect(mw.setupListeners).to.have.been.calledOnce()
+
+      MarketWatcher.prototype.setupListeners = sl
+    })
+  })
+
+  describe('#setupListeners', () => {
+    let mw
+
+    beforeEach(() => {
+      mw = new MarketWatcher(watcher, store, RESPONSE_TYPES, logger)
+    })
+
+    it('tears down listeners after completing watch', () => {
+      expect(onStub).to.have.been.calledOnce()
+      expect(onStub).to.have.been.calledWith('end', sinon.match.func)
+      const onEnd = onStub.args[0][1]
+
+      onEnd()
+
+      expect(removeAllListenersStub).to.have.been.calledOnce()
+      expect(watcher.removeAllListeners).to.have.been.calledOnce()
+    })
+
+    it('handles end events from the wather', () => {
+      expect(watcher.on).to.have.been.calledWith('end', sinon.match.func)
+
+      const onEnd = watcher.on.withArgs('end').args[0][1]
+
+      onEnd()
+
+      expect(emitStub).to.have.been.calledOnce()
+      expect(emitStub).to.have.been.calledWith('end')
+    })
+
+    it('handles error events from the watcher', () => {
+      expect(watcher.on).to.have.been.calledWith('error', sinon.match.func)
+
+      const onError = watcher.on.withArgs('error').args[0][1]
+      const fakeError = new Error('fake error')
+
+      onError(fakeError)
+
+      expect(emitStub).to.have.been.calledOnce()
+      expect(emitStub).to.have.been.calledWith('end', fakeError)
+    })
+
+    it('handles incoming data from the watcher', () => {
+      mw.handleResponse = sinon.stub()
+
+      expect(watcher.on).to.have.been.calledWith('data', sinon.match.func)
+
+      const onData = watcher.on.withArgs('data').args[0][1]
+      const fakeResp = {}
+
+      onData(fakeResp)
+
+      expect(mw.handleResponse).to.have.been.calledOnce()
+      expect(mw.handleResponse).to.have.been.calledWith(fakeResp)
+    })
+  })
+
+  describe('#handleResponse', () => {
+    let mw
+    let response
+
+    beforeEach(() => {
+      mw = new MarketWatcher(watcher, store, RESPONSE_TYPES, logger)
+
+      mw.migration = sinon.stub().resolves()
+      mw.upToDate = sinon.stub()
+      mw.migrate = sinon.stub()
+      mw.createMarketEvent = sinon.stub()
+
+      response = {}
+    })
+
+    it('waits for migration to be finished', async () => {
+      let waited = false
+
+      mw.migration.callsFake(() => {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            waited = true
+            resolve()
+          }, 10)
+        })
+      })
+
+      await mw.handleResponse(response)
+
+      expect(waited).to.be.true()
+    })
+
+    it('handles DONE events', async () => {
+      response.type = RESPONSE_TYPES.EXISTING_EVENTS_DONE
+
+      await mw.handleResponse(response)
+
+      expect(mw.upToDate).to.have.been.calledOnce()
+    })
+
+    it('handles START events', async () => {
+      response.type = RESPONSE_TYPES.START_OF_EVENTS
+
+      await mw.handleResponse(response)
+
+      expect(mw.migrate).to.have.been.calledOnce()
+    })
+
+    it('handles EXISTING events', async () => {
+      response.type = RESPONSE_TYPES.EXISTING_EVENT
+
+      await mw.handleResponse(response)
+
+      expect(mw.createMarketEvent).to.have.been.calledOnce()
+      expect(mw.createMarketEvent).to.have.been.calledWith(response)
+    })
+
+    it('handles NEW events', async () => {
+      response.type = RESPONSE_TYPES.EXISTING_EVENT
+
+      await mw.handleResponse(response)
+
+      expect(mw.createMarketEvent).to.have.been.calledOnce()
+      expect(mw.createMarketEvent).to.have.been.calledWith(response)
+    })
+
+    it('handles unknown events', async () => {
+      response.type = 'BUASDFASDIFJ'
+
+      await mw.handleResponse(response)
+
+      expect(mw.upToDate).to.not.have.been.called()
+      expect(mw.migrate).to.not.have.been.called()
+      expect(mw.createMarketEvent).to.not.have.been.called()
+    })
+  })
+
+  describe('#migrate', () => {
+    let mw
+    let migrate
+    let fakePromise
+
+    beforeEach(async () => {
+      mw = new MarketWatcher(watcher, store, RESPONSE_TYPES, logger)
+      fakePromise = 'mypromise'
+      migrateStore.returns(fakePromise)
+      migrate = await mw.migrate()
+    })
+
+    it('deletes all events in the store', () => {
+      expect(migrateStore).to.have.been.calledOnce()
+      expect(migrateStore).to.have.been.calledWith(store, store, sinon.match.func)
+
+      const migration = migrateStore.args[0][2]
+      const fakeKey = 'mykey'
+      expect(migration(fakeKey)).to.be.eql({ type: 'del', key: fakeKey })
+    })
+
+    it('assigns the promise for deletion to the `migrating` property', () => {
+      expect(mw.migrating).to.be.eql(fakePromise)
+    })
+
+    it('returns the promise for deletion', () => {
+      expect(migrate).to.be.eql(fakePromise)
+    })
+  })
+
+  describe('#migration', () => {
+    let mw
+
+    beforeEach(() => {
+      mw = new MarketWatcher(watcher, store, RESPONSE_TYPES, logger)
+    })
+
+    it('returns immediately if a migration has not started', async () => {
+      let waited = false
+
+      setTimeout(() => {
+        waited = true
+      }, 10)
+
+      await mw.migration()
+
+      expect(waited).to.be.false()
+    })
+
+    it('waits for migration to be done before returning', async () => {
+      let waited = false
+
+      mw.migrating = new Promise((resolve) => {
+        setTimeout(() => {
+          waited = true
+          resolve()
+        }, 10)
+      })
+
+      await mw.migration()
+
+      expect(waited).to.be.true()
+    })
+
+    it('returns immediately if a migration has ended', async () => {
+      let waited = false
+
+      mw.migrating = new Promise((resolve) => {
+        resolve()
+      })
+
+      setTimeout(() => {
+        waited = true
+      }, 10)
+
+      await mw.migration()
+
+      expect(waited).to.be.false()
+    })
+  })
+
+  describe('#createMarketEvent', () => {
+    let mw
+    let response
+    let marketEvent
+    let key
+    let value
+
+    beforeEach(() => {
+      mw = new MarketWatcher(watcher, store, RESPONSE_TYPES, logger)
+      marketEvent = 'fake market event'
+      response = {
+        marketEvent
+      }
+      key = 'fakeKey'
+      value = 'fakeValue'
+
+      MarketEvent.callsFake(function () {
+        this.key = key
+        this.value = value
+      })
+
+      mw.createMarketEvent(response)
+    })
+
+    it('creates a market event', () => {
+      expect(MarketEvent).to.have.been.calledOnce()
+      expect(MarketEvent).to.have.been.calledWithNew()
+      expect(MarketEvent).to.have.been.calledWith(marketEvent)
+    })
+
+    it('puts the market event in the store', () => {
+      expect(store.put).to.have.been.calledOnce()
+      expect(store.put).to.have.been.calledWith(key, value)
+    })
+  })
+
+  describe('#upToDate', () => {
+    let mw
+
+    beforeEach(() => {
+      mw = new MarketWatcher(watcher, store, RESPONSE_TYPES, logger)
+      mw.upToDate()
+    })
+
+    it('emits a sync event', () => {
+      expect(emitStub).to.have.been.calledOnce()
+      expect(emitStub).to.have.been.calledWith('sync')
+    })
+  })
+})

--- a/broker-daemon/relayer/relayer-client.js
+++ b/broker-daemon/relayer/relayer-client.js
@@ -1,5 +1,4 @@
 const path = require('path')
-const EventEmitter = require('events')
 const { readFileSync } = require('fs')
 const { credentials } = require('grpc')
 const caller = require('grpc-caller')
@@ -7,8 +6,7 @@ const caller = require('grpc-caller')
 const Identity = require('./identity')
 const MarketWatcher = require('./market-watcher')
 
-const { MarketEvent } = require('../models')
-const { loadProto, migrateStore } = require('../utils')
+const { loadProto } = require('../utils')
 
 const consoleLogger = console
 consoleLogger.debug = console.log.bind(console)
@@ -73,8 +71,6 @@ class RelayerClient {
    * @returns {EventEmitter} An event emitter that emits `sync` when the market is up to date and `end` when the stream ends (by error or otherwise)
    */
   watchMarket (store, { baseSymbol, counterSymbol, lastUpdated, sequence }) {
-    this.logger.info('Setting up market watcher', params)
-
     const RESPONSE_TYPES = this.proto.WatchMarketResponse.ResponseType
     const params = {
       baseSymbol,
@@ -83,9 +79,10 @@ class RelayerClient {
       sequence
     }
 
+    this.logger.info('Setting up market watcher', params)
     const watcher = this.orderbookService.watchMarket(params)
 
-    return new MarketWatcher(watcher, store, RESPONSE_TYPES, logger)
+    return new MarketWatcher(watcher, store, RESPONSE_TYPES, this.logger)
   }
 }
 

--- a/broker-daemon/relayer/relayer-client.spec.js
+++ b/broker-daemon/relayer/relayer-client.spec.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const { sinon, rewire, delay, expect } = require('test/test-helper')
+const { sinon, rewire, expect } = require('test/test-helper')
 
 const RelayerClient = rewire(path.resolve('broker-daemon', 'relayer', 'relayer-client'))
 
@@ -211,7 +211,6 @@ describe('RelayerClient', () => {
     let params
     let watchMarket
     let stream
-    let migrateStore
 
     beforeEach(() => {
       stream = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4072,7 +4072,7 @@
       }
     },
     "lnd-engine": {
-      "version": "github:sparkswap/lnd-engine#77a885c451e59060c652735b9d2542b20fa1f47f",
+      "version": "github:sparkswap/lnd-engine#66dd514f78da4feabc50f8ec3fdda51d0dbde716",
       "from": "github:sparkswap/lnd-engine",
       "requires": {
         "big.js": "5.1.2",


### PR DESCRIPTION
## Description
This PR allows the Broker to stay up when `watchMarket` fails, and retry `watchMarket` until it comes back up. It throws an error if trying to use the orderbook which relies on being synced with the Relayer.

## Todos
- [x] Tests
- [x] Documentation
