### PR TITLE
Retry lnd engine validation

### DIFF
--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -251,12 +251,12 @@ class BrokerDaemon {
    * We do not await this function because we want the validations to run in the background.
    * It can take time for the engines to be ready, so we use exponential backoff to retry validation
    * for a period of time, until it is either successful or there is actually something wrong.
-   * @returns {<void>}
+   * @returns {void}
    */
   async validateEngines () {
     this.engines.forEach(async (engine, symbol) => {
       try {
-        await exponentialBackoff(() => { engine.validateNodeConfig() }, EXPONENTIAL_BACKOFF_ATTEMPTS, EXPONENTIAL_BACKOFF_DELAY, {symbol})
+        await exponentialBackoff(() => { return engine.validateNodeConfig() }, EXPONENTIAL_BACKOFF_ATTEMPTS, EXPONENTIAL_BACKOFF_DELAY, {symbol})
       } catch (e) {
         this.logger.error(`Failed to validate engine for ${symbol}, error: ${e}`)
         return

--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -44,7 +44,7 @@ const DEFAULT_INTERCHAIN_ROUTER_ADDRESS = '0.0.0.0:40369'
  * @constant
  * @type {String}
  */
-const EXPONENTIAL_BACKOFF_ATTEMPTS = 10
+const EXPONENTIAL_BACKOFF_ATTEMPTS = 24
 
 /**
  * Delay in each retry attempt to validating an engine
@@ -52,7 +52,7 @@ const EXPONENTIAL_BACKOFF_ATTEMPTS = 10
  * @constant
  * @type {Integer} milliseconds
  */
-const EXPONENTIAL_BACKOFF_DELAY = 1000
+const EXPONENTIAL_BACKOFF_DELAY = 5000
 
 /**
  * Default host and port that the Relayer is set up on

--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -245,11 +245,17 @@ class BrokerDaemon {
   }
 
   async validateEngines () {
-    await Promise.all(Array.from(this.engines, async ([ symbol, engine ]) => {
-      this.logger.info(`Validating engine configuration for ${symbol}`)
-      exponentialBackoff(() => { return engine.validateNodeConfig() }, EXPONENTIAL_BACKOFF_ATTEMPTS, EXPONENTIAL_BACKOFF_DELAY)
+    this.engines.forEach(async (engine, symbol) => {
+      try {
+        this.logger.info(`Validating engine configuration for ${symbol}`)
+        await exponentialBackoff(() => { engine.validateNodeConfig() }, EXPONENTIAL_BACKOFF_ATTEMPTS, EXPONENTIAL_BACKOFF_DELAY)
+      } catch (e) {
+        this.logger.error(`Failed to validate engine for ${symbol}, error: ${e}`)
+        return
+      }
+
       this.logger.info(`Validated engine configuration for ${symbol}`)
-    }))
+    })
   }
 }
 

--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -189,6 +189,8 @@ class BrokerDaemon {
         })()
       ])
 
+      // This will run in the background. It is implemented with exponential backoff so
+      // the validation will be retried on the engine until successful or until final failure.
       this.validateEngines()
 
       this.rpcServer.listen(this.rpcAddress)
@@ -244,6 +246,13 @@ class BrokerDaemon {
     return this.orderbooks.get(marketName).initialize()
   }
 
+  /**
+   * Validates engines
+   * We do not await this function because we want the validations to run in the background.
+   * It can take time for the engines to be ready, so we use exponential backoff to retry validation
+   * for a period of time, until it is either successful or there is actually something wrong.
+   * @returns {<void>}
+   */
   async validateEngines () {
     this.engines.forEach(async (engine, symbol) => {
       try {

--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -256,8 +256,7 @@ class BrokerDaemon {
   async validateEngines () {
     this.engines.forEach(async (engine, symbol) => {
       try {
-        this.logger.info(`Validating engine configuration for ${symbol}`)
-        await exponentialBackoff(() => { engine.validateNodeConfig() }, EXPONENTIAL_BACKOFF_ATTEMPTS, EXPONENTIAL_BACKOFF_DELAY)
+        await exponentialBackoff(() => { engine.validateNodeConfig() }, EXPONENTIAL_BACKOFF_ATTEMPTS, EXPONENTIAL_BACKOFF_DELAY, {symbol})
       } catch (e) {
         this.logger.error(`Failed to validate engine for ${symbol}, error: ${e}`)
         return

--- a/broker-daemon/index.spec.js
+++ b/broker-daemon/index.spec.js
@@ -33,6 +33,7 @@ describe('broker daemon', () => {
   let brokerDaemonOptions
   let rpcUser
   let rpcPass
+  let exponentialBackoff
 
   beforeEach(() => {
     level = sinon.stub().returns('fake-level')
@@ -52,6 +53,7 @@ describe('broker daemon', () => {
       error: sinon.spy(),
       info: sinon.spy()
     }
+    exponentialBackoff = sinon.stub().resolves()
     LndEngine = sinon.stub()
     LndEngine.prototype.validateNodeConfig = sinon.stub().resolves()
     Orderbook = sinon.stub()
@@ -94,6 +96,7 @@ describe('broker daemon', () => {
     BrokerDaemon.__set__('BrokerRPCServer', rpcServer)
     BrokerDaemon.__set__('InterchainRouter', interchainRouter)
     BrokerDaemon.__set__('logger', logger)
+    BrokerDaemon.__set__('exponentialBackoff', exponentialBackoff)
 
     privRpcKeyPath = '/my/private/rpc/key/path'
     pubRpcKeyPath = '/my/public/rpc/key/path'
@@ -381,21 +384,10 @@ describe('broker daemon', () => {
     })
 
     it('validates the engines', async () => {
-      const btcEngine = {
-        validateNodeConfig: sinon.stub().resolves()
-      }
-      const ltcEngine = {
-        validateNodeConfig: sinon.stub().resolves()
-      }
-      brokerDaemon.engines = new Map([
-        [ 'BTC', btcEngine ],
-        [ 'LTC', ltcEngine ]
-      ])
-
+      brokerDaemon.validateEngines = sinon.stub().returns()
       await brokerDaemon.initialize()
 
-      expect(btcEngine.validateNodeConfig).to.have.been.calledOnce()
-      expect(ltcEngine.validateNodeConfig).to.have.been.calledOnce()
+      expect(brokerDaemon.validateEngines).to.have.been.calledOnce()
     })
 
     it('initializes markets', async () => {
@@ -411,6 +403,51 @@ describe('broker daemon', () => {
       await brokerDaemon.initialize()
 
       expect(BlockOrderWorker.prototype.initialize).to.have.been.calledOnce()
+    })
+  })
+
+  describe('#validateEngines', () => {
+    let attempts
+    let delay
+    let btcEngine
+    let ltcEngine
+
+    beforeEach(() => {
+      brokerDaemon = new BrokerDaemon(brokerDaemonOptions)
+
+      btcEngine = {
+        validateNodeConfig: sinon.stub().resolves()
+      }
+      ltcEngine = {
+        validateNodeConfig: sinon.stub().resolves()
+      }
+      brokerDaemon.engines = new Map([
+        [ 'BTC', btcEngine ],
+        [ 'LTC', ltcEngine ]
+      ])
+
+      attempts = BrokerDaemon.__get__('EXPONENTIAL_BACKOFF_ATTEMPTS')
+      delay = BrokerDaemon.__get__('EXPONENTIAL_BACKOFF_DELAY')
+    })
+
+    it('passes engine validation to exponential backoff for each engine', () => {
+      brokerDaemon.validateEngines()
+
+      const validateBtcEngine = exponentialBackoff.args[0][0]
+      validateBtcEngine()
+
+      expect(btcEngine.validateNodeConfig).to.have.been.called()
+
+      const validateLtcEngine = exponentialBackoff.args[1][0]
+      validateLtcEngine()
+
+      expect(ltcEngine.validateNodeConfig).to.have.been.called()
+
+      expect(exponentialBackoff).to.have.been.calledTwice()
+      expect(exponentialBackoff).to.have.been.calledWith(
+        sinon.match.func,
+        attempts,
+        delay)
     })
   })
 

--- a/broker-daemon/index.spec.js
+++ b/broker-daemon/index.spec.js
@@ -447,7 +447,16 @@ describe('broker daemon', () => {
       expect(exponentialBackoff).to.have.been.calledWith(
         sinon.match.func,
         attempts,
-        delay)
+        delay,
+        {symbol: 'BTC'}
+      )
+
+      expect(exponentialBackoff).to.have.been.calledWith(
+        sinon.match.func,
+        attempts,
+        delay,
+        {symbol: 'LTC'}
+      )
     })
   })
 

--- a/broker-daemon/index.spec.js
+++ b/broker-daemon/index.spec.js
@@ -430,18 +430,24 @@ describe('broker daemon', () => {
       delay = BrokerDaemon.__get__('EXPONENTIAL_BACKOFF_DELAY')
     })
 
-    it('passes engine validation to exponential backoff for each engine', () => {
+    it('validates the node config on each engine', () => {
       brokerDaemon.validateEngines()
 
       const validateBtcEngine = exponentialBackoff.args[0][0]
-      validateBtcEngine()
+      const btcEngineRes = validateBtcEngine()
 
       expect(btcEngine.validateNodeConfig).to.have.been.called()
+      expect(btcEngineRes).to.be.instanceOf(Promise)
 
       const validateLtcEngine = exponentialBackoff.args[1][0]
-      validateLtcEngine()
+      const ltcEngineRes = validateLtcEngine()
 
       expect(ltcEngine.validateNodeConfig).to.have.been.called()
+      expect(ltcEngineRes).to.be.instanceOf(Promise)
+    })
+
+    it('validates the engines in exponentialBackoff to allow for retries', () => {
+      brokerDaemon.validateEngines()
 
       expect(exponentialBackoff).to.have.been.calledTwice()
       expect(exponentialBackoff).to.have.been.calledWith(

--- a/broker-daemon/utils/delay.js
+++ b/broker-daemon/utils/delay.js
@@ -1,3 +1,11 @@
+
+/**
+ * Prevents code execution for a designated amount of milliseconds
+ *
+ * @param {Integer} milliseconds
+ * @return {Promise}
+ */
+
 function delay (ms) {
   return new Promise((resolve, reject) => {
     setTimeout(resolve, ms)

--- a/broker-daemon/utils/delay.js
+++ b/broker-daemon/utils/delay.js
@@ -1,0 +1,7 @@
+function delay (ms) {
+  return new Promise((resolve, reject) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+module.exports = delay

--- a/broker-daemon/utils/delay.spec.js
+++ b/broker-daemon/utils/delay.spec.js
@@ -1,0 +1,19 @@
+const { sinon, rewire, expect } = require('test/test-helper')
+const path = require('path')
+const delay = rewire(path.resolve(__dirname, 'delay'))
+
+describe('delay', () => {
+  let delayTime
+  let setTimeout
+
+  beforeEach(() => {
+    setTimeout = sinon.stub().callsArg(0)
+    delayTime = 100
+    delay.__set__('setTimeout', setTimeout)
+  })
+
+  it('calls the call function', async () => {
+    await delay(delayTime)
+    expect(setTimeout).to.have.been.called()
+  })
+})

--- a/broker-daemon/utils/delay.spec.js
+++ b/broker-daemon/utils/delay.spec.js
@@ -12,8 +12,20 @@ describe('delay', () => {
     delay.__set__('setTimeout', setTimeout)
   })
 
-  it('calls the call function', async () => {
+  it('calls setTimeout with the callFunction and delay time', async () => {
     await delay(delayTime)
-    expect(setTimeout).to.have.been.called()
+    expect(setTimeout).to.have.been.calledWith(sinon.match.func, delayTime)
+  })
+
+  it('calls the callFunction after setTimeout resolves', async () => {
+    let isResolved = false
+
+    delay(delayTime).then(() => {
+      isResolved = true
+    })
+
+    expect(isResolved).to.be.false()
+    setTimeout.args[0][0]()
+    setImmediate(() => expect(isResolved).to.be.true())
   })
 })

--- a/broker-daemon/utils/exponential-backoff.js
+++ b/broker-daemon/utils/exponential-backoff.js
@@ -26,7 +26,7 @@ async function exponentialBackoff (callFunction, attempts, delayTime, logOptions
       const attemptsLeft = attempts - 1
       logger.error(`Error calling ${callFunction}. Retrying in ${delayTime / 1000} seconds, attempts left: ${attemptsLeft}`, logOptions)
       await delay(delayTime)
-      res = await exponentialBackoff(callFunction, attemptsLeft, delayTime * DELAY_MULTIPLIER)
+      res = await exponentialBackoff(callFunction, attemptsLeft, delayTime * DELAY_MULTIPLIER, logOptions)
     } else {
       throw new Error(error, `Error with ${callFunction}, no retry attempts left`)
     }

--- a/broker-daemon/utils/exponential-backoff.js
+++ b/broker-daemon/utils/exponential-backoff.js
@@ -1,16 +1,25 @@
 const logger = require('./logger')
 const delay = require('./delay')
 
+/**
+ * Calls a function repeatedly until success or throws if it fails on final retry
+ *
+ * @param {Function} function to be called
+ * @param {Integer} attempts left
+ * @param {Integer} delayTime in milliseconds between calls
+
+ * @return {Promise}
+ */
 async function exponentialBackoff (callFunction, attempts, delayTime) {
   try {
-    var res = callFunction()
+    var res = await callFunction()
   } catch (error) {
-    logger.error(`Error (${error}) with ${callFunction}, retry attempts left: ${attempts}`)
+    logger.error(`Error with ${callFunction}, retry attempts left: ${attempts}, error: ${error}`)
     if (attempts > 0) {
       await delay(delayTime)
-      exponentialBackoff(callFunction, --attempts, delayTime * 2)
+      res = await exponentialBackoff(callFunction, --attempts, delayTime * 2)
     } else {
-      logger.error(`Error (${error}) with ${callFunction}, no retry attempts left`)
+      throw new Error(error, `Error with ${callFunction}, no retry attempts left`)
     }
   }
   return res

--- a/broker-daemon/utils/exponential-backoff.js
+++ b/broker-daemon/utils/exponential-backoff.js
@@ -2,6 +2,13 @@ const logger = require('./logger')
 const delay = require('./delay')
 
 /**
+ * How much to delay each retry by
+ *
+ * @constant
+ * @type {Integer} milliseconds
+ */
+const DELAY_MULTIPLIER = 1.5
+/**
  * Calls a function repeatedly until success or throws if it fails on final retry
  *
  * @param {Function} function to be called
@@ -17,7 +24,7 @@ async function exponentialBackoff (callFunction, attempts, delayTime) {
     logger.error(`Error with ${callFunction}, retry attempts left: ${attempts}, error: ${error}`)
     if (attempts > 0) {
       await delay(delayTime)
-      res = await exponentialBackoff(callFunction, --attempts, delayTime * 2)
+      res = await exponentialBackoff(callFunction, --attempts, delayTime * DELAY_MULTIPLIER)
     } else {
       throw new Error(error, `Error with ${callFunction}, no retry attempts left`)
     }

--- a/broker-daemon/utils/exponential-backoff.js
+++ b/broker-daemon/utils/exponential-backoff.js
@@ -16,7 +16,6 @@ const DELAY_MULTIPLIER = 1.5
  * @param {Integer} delayTime in milliseconds between calls
  * @param {Object} logOptions if you want to pass information to log in the error log
 
-
  * @return {Promise}
  */
 async function exponentialBackoff (callFunction, attempts, delayTime, logOptions = {}) {

--- a/broker-daemon/utils/exponential-backoff.js
+++ b/broker-daemon/utils/exponential-backoff.js
@@ -1,0 +1,21 @@
+async function exponentialBackoff (callFunction, attempts, delay, callback) {
+  try {
+    var res = await callFunction()
+  } catch (e) {
+    console.log(e)
+  }
+
+  if (res) {
+    callback(res)
+  } else {
+    if (attempts > 0) {
+      setTimeout(function () {
+        exponentialBackoff(callFunction, --attempts, delay * 2, callback)
+      }, delay)
+    } else {
+      console.log(`${callFunction} failed`)
+    }
+  }
+}
+
+module.exports = exponentialBackoff

--- a/broker-daemon/utils/exponential-backoff.js
+++ b/broker-daemon/utils/exponential-backoff.js
@@ -23,9 +23,10 @@ async function exponentialBackoff (callFunction, attempts, delayTime, logOptions
     var res = await callFunction()
   } catch (error) {
     if (attempts > 0) {
-      logger.error(`Error calling ${callFunction}. Retrying in ${delayTime / 1000} seconds, attempts left: ${attempts - 1}`, logOptions)
+      const attemptsLeft = attempts - 1
+      logger.error(`Error calling ${callFunction}. Retrying in ${delayTime / 1000} seconds, attempts left: ${attemptsLeft}`, logOptions)
       await delay(delayTime)
-      res = await exponentialBackoff(callFunction, --attempts, delayTime * DELAY_MULTIPLIER)
+      res = await exponentialBackoff(callFunction, attemptsLeft, delayTime * DELAY_MULTIPLIER)
     } else {
       throw new Error(error, `Error with ${callFunction}, no retry attempts left`)
     }

--- a/broker-daemon/utils/exponential-backoff.js
+++ b/broker-daemon/utils/exponential-backoff.js
@@ -14,15 +14,17 @@ const DELAY_MULTIPLIER = 1.5
  * @param {Function} function to be called
  * @param {Integer} attempts left
  * @param {Integer} delayTime in milliseconds between calls
+ * @param {Object} logOptions if you want to pass information to log in the error log
+
 
  * @return {Promise}
  */
-async function exponentialBackoff (callFunction, attempts, delayTime) {
+async function exponentialBackoff (callFunction, attempts, delayTime, logOptions = {}) {
   try {
     var res = await callFunction()
   } catch (error) {
-    logger.error(`Error with ${callFunction}, retry attempts left: ${attempts}, error: ${error}`)
     if (attempts > 0) {
+      logger.error(`Error calling ${callFunction}. Retrying in ${delayTime / 1000} seconds, attempts left: ${attempts - 1}`, logOptions)
       await delay(delayTime)
       res = await exponentialBackoff(callFunction, --attempts, delayTime * DELAY_MULTIPLIER)
     } else {

--- a/broker-daemon/utils/exponential-backoff.js
+++ b/broker-daemon/utils/exponential-backoff.js
@@ -1,21 +1,23 @@
-async function exponentialBackoff (callFunction, attempts, delay, callback) {
-  try {
-    var res = await callFunction()
-  } catch (e) {
-    console.log(e)
-  }
+const { logger } = require('./logger')
 
-  if (res) {
-    callback(res)
-  } else {
-    if (attempts > 0) {
-      setTimeout(function () {
-        exponentialBackoff(callFunction, --attempts, delay * 2, callback)
-      }, delay)
-    } else {
-      console.log(`${callFunction} failed`)
-    }
-  }
+function exponentialBackoff (callFunction, attempts, delay) {
+  callFunction()
+    .catch(function (error) {
+      logger.error(error)
+    })
+    .then((res) => {
+      if (res) {
+        return res
+      } else {
+        if (attempts > 0) {
+          setTimeout(function () {
+            exponentialBackoff(callFunction, --attempts, delay * 2)
+          }, delay)
+        } else {
+          logger.error(`${callFunction} failed`)
+        }
+      }
+    })
 }
 
 module.exports = exponentialBackoff

--- a/broker-daemon/utils/exponential-backoff.spec.js
+++ b/broker-daemon/utils/exponential-backoff.spec.js
@@ -1,0 +1,49 @@
+const { sinon, rewire, expect } = require('test/test-helper')
+const path = require('path')
+
+const exponentialBackoff = rewire(path.resolve(__dirname, 'exponential-backoff'))
+
+describe('exponentialBackoff', () => {
+  let callFunction
+  let attempts
+  let delayTime
+  let delay
+  let logger
+  let res
+  let logOptions
+
+  beforeEach(() => {
+    res = 'response'
+    callFunction = sinon.stub().resolves(res)
+    attempts = 2
+    delayTime = 100
+    logger = { error: sinon.stub() }
+    delay = sinon.stub()
+    logOptions = {info: 'info'}
+    exponentialBackoff.__set__('logger', logger)
+    exponentialBackoff.__set__('delay', delay)
+  })
+
+  it('calls the call function', async () => {
+    await exponentialBackoff(callFunction, attempts, delayTime, logOptions)
+
+    expect(callFunction).to.be.to.have.been.calledOnce()
+  })
+
+  it('returns the response of the callFunction if there were no errors', async () => {
+    const result = await exponentialBackoff(callFunction, attempts, delayTime, logOptions)
+    expect(result).to.eql(res)
+  })
+
+  it('retries the callFunction if there was an error and there are still retries left', async () => {
+    callFunction = sinon.stub().rejects('Error')
+    try {
+      await exponentialBackoff(callFunction, attempts, delayTime, logOptions)
+      expect(logger.error).to.have.been.called()
+      expect(delay).to.have.been.calledWith(delayTime)
+      expect(callFunction).to.have.been.calledThrice()
+    } catch (error) {
+      expect(error.message).to.eql('Error')
+    }
+  })
+})

--- a/broker-daemon/utils/index.js
+++ b/broker-daemon/utils/index.js
@@ -13,6 +13,7 @@ const grpcGateway = require('./grpc-gateway')
 const createHttpServer = require('./create-http-server')
 const timestampToNano = require('./timestamp-to-nano')
 const generateId = require('./generate-id')
+const exponentialBackoff = require('./exponential-backoff')
 
 module.exports = {
   getRecords,
@@ -29,5 +30,6 @@ module.exports = {
   grpcGateway,
   createHttpServer,
   timestampToNano,
-  generateId
+  generateId,
+  exponentialBackoff
 }

--- a/broker-daemon/utils/index.js
+++ b/broker-daemon/utils/index.js
@@ -14,6 +14,7 @@ const createHttpServer = require('./create-http-server')
 const timestampToNano = require('./timestamp-to-nano')
 const generateId = require('./generate-id')
 const exponentialBackoff = require('./exponential-backoff')
+const delay = require('./delay')
 
 module.exports = {
   getRecords,
@@ -31,5 +32,6 @@ module.exports = {
   createHttpServer,
   timestampToNano,
   generateId,
-  exponentialBackoff
+  exponentialBackoff,
+  delay
 }


### PR DESCRIPTION
## Description
If LND is not ready, sparkswapd will fail to start. It will retry 10 times with PM2, but frequently LND needs much longer (e.g. re-indexing the blockchain).

1) Add exponentialBackoff
2) Make validating engines a background process


## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
