### PR TITLE
Fix: url encode order id format to make it compatible with the CLI

### DIFF
--- a/broker-cli/commands/order/summary.js
+++ b/broker-cli/commands/order/summary.js
@@ -2,6 +2,7 @@ const BrokerDaemonClient = require('../../broker-daemon-client')
 const Table = require('cli-table')
 const { ENUMS: { ORDER_TYPES }, handleError } = require('../../utils')
 require('colors')
+const size = require('window-size')
 
 /**
  * Prints table of the users orders
@@ -11,9 +12,12 @@ require('colors')
  * @returns {Void}
  */
 function createUI (market, orders) {
+  const windowWidth = size.get().width
+  const unitWidth = Math.floor(windowWidth / 16)
+
   const orderTable = new Table({
     head: ['Order ID', 'Side', 'Amount', 'Limit Price', 'Time', 'Status'],
-    colWidths: [45, 7, 18, 18, 6, 10],
+    colWidths: [5 * unitWidth, unitWidth, 3 * unitWidth, 3 * unitWidth, unitWidth, 2 * unitWidth],
     style: { head: ['gray'] }
   })
 

--- a/broker-daemon/utils/generate-id.js
+++ b/broker-daemon/utils/generate-id.js
@@ -16,9 +16,9 @@ function generateId () {
  */
 function urlEncode (base64Str) {
   return base64Str
-    .replace(/=/g, "")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
 }
 
 module.exports = generateId

--- a/broker-daemon/utils/generate-id.js
+++ b/broker-daemon/utils/generate-id.js
@@ -1,10 +1,19 @@
 const crypto = require('crypto')
 
+/**
+ * Generate a random ID string
+ * @return {String} 43 random characters in [base64url encoding]{@link https://tools.ietf.org/html/rfc4648}
+ */
 function generateId () {
   const data = crypto.randomBytes(20).toString('hex')
   return urlEncode(crypto.createHash('sha256').update(data).digest('base64'))
 }
 
+/**
+ * Convert a string from Base64 to [Base64url]{@link https://tools.ietf.org/html/rfc4648}
+ * @param  {String} base64Str Base64 encoded String
+ * @return {String}           Base64url encoded string
+ */
 function urlEncode (base64Str) {
   return base64Str
     .replace(/=/g, "")

--- a/broker-daemon/utils/generate-id.js
+++ b/broker-daemon/utils/generate-id.js
@@ -2,7 +2,14 @@ const crypto = require('crypto')
 
 function generateId () {
   const data = crypto.randomBytes(20).toString('hex')
-  return crypto.createHash('sha256').update(data).digest('base64')
+  return urlEncode(crypto.createHash('sha256').update(data).digest('base64'))
+}
+
+function urlEncode (base64Str) {
+  return base64Str
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
 }
 
 module.exports = generateId

--- a/broker-daemon/utils/generate-id.spec.js
+++ b/broker-daemon/utils/generate-id.spec.js
@@ -1,0 +1,99 @@
+const path = require('path')
+const { sinon, rewire, expect } = require('test/test-helper')
+
+const generateId = rewire(path.resolve(__dirname, 'generate-id'))
+
+describe('generateId', () => {
+  describe('generateId', () => {
+    let urlEncode
+    let crypto
+    let hash
+    let bytes
+    let resetUrlEncode
+    let resetCrypto
+    let randomString
+    let randomBase64
+    let randomUrlEncoded
+
+    beforeEach(() => {
+      randomString = 'aoisjdfoasijfd9sdfu0a9sdf09'
+      randomBase64 = 'asfdjJF09809ASDFasdf+asdf/asdf='
+      randomUrlEncoded = 'asfdjJF09809ASDFasdf-asdf_asdf'
+
+      urlEncode = sinon.stub().returns(randomUrlEncoded)
+      hash = {
+        update: sinon.stub(),
+        digest: sinon.stub().returns(randomBase64)
+      }
+      hash.update.returns(hash)
+
+      bytes = {
+        toString: sinon.stub().returns(randomString)
+      }
+
+      crypto = {
+        randomBytes: sinon.stub().returns(bytes),
+        createHash: sinon.stub().returns(hash)
+      }
+
+      resetUrlEncode = generateId.__set__('urlEncode', urlEncode)
+      resetCrypto = generateId.__set__('crypto', crypto)
+    })
+
+    afterEach(() => {
+      resetUrlEncode()
+      resetCrypto()
+    })
+
+    it('creates random hex data', () => {
+      generateId()
+
+      expect(crypto.randomBytes).to.have.been.calledOnce()
+      expect(crypto.randomBytes).to.have.been.calledWith(20)
+      expect(bytes.toString).to.have.been.calledOnce()
+      expect(bytes.toString).to.have.been.calledWith('hex')
+    })
+
+    it('hashes the random data', () => {
+      generateId()
+
+      expect(crypto.createHash).to.have.been.calledOnce()
+      expect(crypto.createHash).to.have.been.calledWith('sha256')
+      expect(hash.update).to.have.been.calledOnce()
+      expect(hash.update).to.have.been.calledWith(randomString)
+      expect(hash.digest).to.have.been.calledOnce()
+      expect(hash.digest).to.have.been.calledWith('base64')
+    })
+
+    it('url encodes the hash', () => {
+      expect(generateId()).to.be.eql(randomUrlEncoded)
+
+      expect(urlEncode).to.have.been.calledOnce()
+      expect(urlEncode).to.have.been.calledWith(randomBase64)
+    })
+  })
+
+  describe('urlEncode', () => {
+    let urlEncode
+
+    beforeEach(() => {
+      urlEncode = generateId.__get__('urlEncode')
+    })
+
+    it('strips off trailing equals signs', () => {
+      expect(urlEncode('asf8asuf98uas9f8u===')).to.be.eql('asf8asuf98uas9f8u')
+    })
+
+    it('converts + to -', () => {
+      expect(urlEncode('asdf+asdf+asdf')).to.be.eql('asdf-asdf-asdf')
+    })
+
+    it('converts / to _', () => {
+      expect(urlEncode('asdf/asdf/asdf')).to.be.eql('asdf_asdf_asdf')
+    })
+
+    it('converts them all together', () => {
+      expect(urlEncode('asdf/asdf+asdf/asdf+asdf==')).to.be.eql('asdf_asdf-asdf_asdf-asdf')
+    })
+  })
+})


### PR DESCRIPTION
## Description
This change applies base64 url encoding to block order ids when they are being generated so that they are compatible with the existing CLI rules and so that they are effectively future-proofed for web-based clients.