### PR TITLE
Fix: watchmarket leak

### DIFF
--- a/broker-daemon/orderbook/index.js
+++ b/broker-daemon/orderbook/index.js
@@ -34,6 +34,8 @@ class Orderbook {
     this.eventStore = store.sublevel('events')
     this.index = new OrderbookIndex(store, this.eventStore, this.marketName)
     this.store = this.index.store
+    this.askIndex = new AskIndex(this.store)
+    this.bidIndex = new BidIndex(this.store)
     this.logger = logger
     this.synced = false
   }
@@ -50,11 +52,27 @@ class Orderbook {
    * Initialize the orderbook by syncing its state to the Relayer and indexing
    * the orders.
    * Also includes retry logic if the Relayer fails.
-   * @return {void}
+   * @return {Promise}
    */
   async initialize () {
     this.logger.info(`Initializing market ${this.marketName}...`)
     this.synced = false
+
+    this.logger.debug(`Rebuilding indexes`)
+    await this.index.ensureIndex()
+    await this.askIndex.ensureIndex()
+    await this.bidIndex.ensureIndex()
+
+    await this.watchMarket()
+  }
+
+  /**
+   * Sync orderbook state with the Relayer
+   * @private
+   * @return {Promise} Resolves when market is being watched (not necessarily when it is synced)
+   */
+  async watchMarket () {
+    this.logger.debug(`Watching market ${this.marketName}...`)
 
     const { baseSymbol, counterSymbol } = this
     const { lastUpdated, sequence } = await this.lastUpdate()
@@ -63,13 +81,8 @@ class Orderbook {
     const watcher = this.relayer.watchMarket(this.eventStore, params)
 
     watcher.on('sync', async () => {
-      this.logger.debug(`Rebuilding indexes`)
-      await this.index.ensureIndex()
-      this.askIndex = await (new AskIndex(this.store)).ensureIndex()
-      this.bidIndex = await (new BidIndex(this.store)).ensureIndex()
-
       this.synced = true
-      this.logger.info(`Market ${this.marketName} initialized.`)
+      this.logger.info(`Market ${this.marketName} synced.`)
     })
 
     watcher.on('end', (error) => {
@@ -77,7 +90,7 @@ class Orderbook {
 
       // TODO: exponential backoff?
       setTimeout(() => {
-        this.initialize()
+        this.watchMarket()
       }, RETRY_WATCHMARKET)
     })
   }

--- a/broker-daemon/orderbook/index.js
+++ b/broker-daemon/orderbook/index.js
@@ -51,7 +51,6 @@ class Orderbook {
   /**
    * Initialize the orderbook by syncing its state to the Relayer and indexing
    * the orders.
-   * Also includes retry logic if the Relayer fails.
    * @return {Promise}
    */
   async initialize () {
@@ -67,7 +66,7 @@ class Orderbook {
   }
 
   /**
-   * Sync orderbook state with the Relayer
+   * Sync orderbook state with the Relayer and retry when it fails
    * @private
    * @return {Promise} Resolves when market is being watched (not necessarily when it is synced)
    */

--- a/broker-daemon/orderbook/orderbook-index.js
+++ b/broker-daemon/orderbook/orderbook-index.js
@@ -49,6 +49,10 @@ class OrderbookIndex {
    * @return {Promise} resolves when the index is cleared
    */
   _clearIndex () {
+    // remove any previously applied hooks
+    if (this._removeHook) {
+      this._removeHook()
+    }
     return migrateStore(this.store, this.store, (key) => { return { type: 'del', key } })
   }
 
@@ -64,7 +68,7 @@ class OrderbookIndex {
    * Create a hook for new events added to the store to modify the orderbook
    */
   _addIndexHook () {
-    this.eventStore.pre((dbOperation, add) => {
+    this._removeHook = this.eventStore.pre((dbOperation, add) => {
       if (dbOperation.type !== 'put') {
         return
       }

--- a/broker-daemon/orderbook/orderbook-index.spec.js
+++ b/broker-daemon/orderbook/orderbook-index.spec.js
@@ -157,6 +157,13 @@ describe('OrderbookIndex', () => {
 
     beforeEach(() => {
       orderbookIndex = new OrderbookIndex(baseStore, eventStore, marketName)
+      orderbookIndex._removeHook = sinon.stub()
+    })
+
+    it('removes any previous hooks', async () => {
+      await orderbookIndex._clearIndex()
+
+      expect(orderbookIndex._removeHook).to.have.been.calledOnce()
     })
 
     it('deletes the store through a self migration', async () => {

--- a/broker-daemon/relayer/market-watcher.js
+++ b/broker-daemon/relayer/market-watcher.js
@@ -64,6 +64,8 @@ class MarketWatcher extends EventEmitter {
   async handleResponse (response) {
     const { RESPONSE_TYPES } = this
 
+    // TODO: I don't think this will work well if there is more than one event queued since they all
+    // rely so heavily on ordering.
     await this.migration()
 
     this.logger.debug(`response type is ${response.type}`)

--- a/broker-daemon/utils/sublevel-index.js
+++ b/broker-daemon/utils/sublevel-index.js
@@ -240,7 +240,7 @@ class Index {
    * @return {void}
    */
   _addIndexHook () {
-    this.store.pre((dbOperation, add) => {
+    this._removeHook = this.store.pre((dbOperation, add) => {
       const { key, value, type } = dbOperation
 
       if (type === 'put' && this.filter(key, value)) {
@@ -256,6 +256,10 @@ class Index {
    * @return {Promise<void>} Resolves when the database is cleared
    */
   _clearIndex () {
+    // reset the hook if it already exists
+    if (this._removeHook) {
+      this._removeHook()
+    }
     return migrateStore(this._index, this._index, (key) => ({ type: 'del', key, prefix: this._index }))
   }
 

--- a/broker-daemon/utils/sublevel-index.spec.js
+++ b/broker-daemon/utils/sublevel-index.spec.js
@@ -439,10 +439,17 @@ describe('Index', () => {
 
     describe('#_addIndexHook', async () => {
       let preHook
+      let removeHook
 
       beforeEach(() => {
+        removeHook = sinon.stub()
+        store.pre.returns(removeHook)
         index._addIndexHook()
         preHook = store.pre.args[0][0]
+      })
+
+      it('saves a fn to remove the hook', () => {
+        expect(index._removeHook).to.be.equal(removeHook)
       })
 
       it('adds a pre hook to the source database', () => {
@@ -488,6 +495,13 @@ describe('Index', () => {
     })
 
     describe('#_clearIndex', () => {
+      it('removes any previous hooks', async () => {
+        index._removeHook = sinon.stub()
+        await index._clearIndex()
+
+        expect(index._removeHook).to.have.been.calledOnce()
+      })
+
       it('returns the promise from migrate store', () => {
         const fakePromise = 'fake'
         migrateStore.returns(fakePromise)


### PR DESCRIPTION
## Description
My last PR (#271) introduced an issue where index hooks were getting re-applied to the store multiple times, resulting in errors when trying to delete keys.

This change fixes that in two ways:
1. By removing index hooks as part of the clearIndex operation (for general hygiene)
2. Having indexes only be built on startup, and re-use the hooks for handling when the orderbook needs to be started from scratch, since it uses regular `del` operations anyway.

## Related PRs
#271 Introduced the issue.


## Todos
- [x] Tests
- [x] Documentation
