### PR TITLE
Feature: Orderbook Checksum

### DIFF
--- a/broker-daemon/orderbook/index.js
+++ b/broker-daemon/orderbook/index.js
@@ -234,10 +234,6 @@ class Orderbook {
     }
   }
 
-  async getChecksum () {
-
-  }
-
   /**
    * Gets the last record in an event store
    * @private

--- a/broker-daemon/orderbook/index.js
+++ b/broker-daemon/orderbook/index.js
@@ -79,25 +79,51 @@ class Orderbook {
 
     const watcher = this.relayer.watchMarket(this.eventStore, params)
 
-    watcher.once('sync', async () => {
+    /**
+     * Handle sync events from the watcher by updating internal state
+     * @return {void}
+     */
+    const onWatcherSync = () => {
       this.synced = true
       this.logger.info(`Market ${this.marketName} synced.`)
-    })
+    }
 
-    watcher.once('end', (error) => {
+    /**
+     * Handle end events from the watcher by retrying
+     * @param  {Error} error
+     * @return {void}
+     */
+    const onWatcherEnd = (error) => {
+      this.synced = false
+      watcher.removeListener('sync', onWatcherSync)
+      watcher.removeListener('error', onWatcherError)
+
       this.logger.info(`Market ${this.marketName} unavailable, retrying in ${RETRY_WATCHMARKET}ms`, { error })
-
       // TODO: exponential backoff?
       setTimeout(() => {
         this.watchMarket()
       }, RETRY_WATCHMARKET)
-    })
+    }
 
-    watcher.once('error', async (error) => {
+    /**
+     * Handle error events from the watcher by clearing our store and retrying
+     * @param  {Error} error
+     * @return {Promise<void>}
+     */
+    const onWatcherError = async (error) => {
+      this.synced = false
+
+      watcher.removeListener('sync', onWatcherSync)
+      watcher.removeListener('end', onWatcherEnd)
+
       this.logger.info(`Market ${this.marketName} encountered sync'ing error, re-building`, { error })
       await watcher.migrate()
       this.watchMarket()
-    })
+    }
+
+    watcher.once('sync', onWatcherSync)
+    watcher.once('end', onWatcherEnd)
+    watcher.once('error', onWatcherError)
   }
 
   /**

--- a/broker-daemon/orderbook/index.js
+++ b/broker-daemon/orderbook/index.js
@@ -68,7 +68,7 @@ class Orderbook {
   /**
    * Sync orderbook state with the Relayer and retry when it fails
    * @private
-   * @return {Promise}               Resolves when market is being watched (not necessarily when it is synced)
+   * @return {Promise} Resolves when market is being watched (not necessarily when it is synced)
    */
   async watchMarket () {
     this.logger.debug(`Watching market ${this.marketName}...`)

--- a/broker-daemon/orderbook/index.spec.js
+++ b/broker-daemon/orderbook/index.spec.js
@@ -264,11 +264,11 @@ describe('Orderbook', () => {
       expect(watcher.once).to.have.been.calledWith('sync', sinon.match.func)
     })
 
-    xit('sets an end listener', () => {
+    it('sets an end listener', () => {
       expect(watcher.once).to.have.been.calledWith('end', sinon.match.func)
     })
 
-    xit('sets an error listener', () => {
+    it('sets an error listener', () => {
       expect(watcher.once).to.have.been.calledWith('error', sinon.match.func)
     })
 

--- a/broker-daemon/relayer/market-watcher.js
+++ b/broker-daemon/relayer/market-watcher.js
@@ -25,9 +25,10 @@ class MarketWatcher extends EventEmitter {
     this.logger = logger
     this.RESPONSE_TYPES = RESPONSE_TYPES
     this.finishBeforeProcessing = new Set()
+    this.checksum = new Checksum()
 
+    this.populateChecksum()
     this.setupListeners()
-    this.createChecksum()
   }
 
   /**
@@ -72,16 +73,14 @@ class MarketWatcher extends EventEmitter {
   }
 
   /**
-   * Create a new checksum by processing all market events in the data store.
+   * Populate a new checksum by processing all market events in the data store.
    * It delays further processing of events until the checksum is built.
    * @private
    * @todo does it make sense to build this off the index so we don't have
    * to process every event in the store?
    * @return {void}
    */
-  createChecksum () {
-    this.checksum = new Checksum()
-
+  populateChecksum () {
     const checksumPopulation = eachRecord(this.store, (key, value) => {
       const marketEvent = MarketEvent.fromStorage(key, value)
       this.checksum.process(marketEvent.orderId)

--- a/broker-daemon/relayer/market-watcher.js
+++ b/broker-daemon/relayer/market-watcher.js
@@ -34,6 +34,16 @@ class MarketWatcher extends EventEmitter {
   }
 
   /**
+   * Delete every event in the store and set a promise on `migrating` that resolves once deletion is complete.
+   * @return {Promise} Resolves when migration is complete
+   */
+  migrate () {
+    this.logger.debug(`Removing existing orderbook events as part of migration`)
+    this.migrating = migrateStore(this.store, this.store, (key) => { return { type: 'del', key } })
+    return this.migrating
+  }
+
+  /**
    * Set up the listeners on the watcher
    * @private
    * @return {void}
@@ -111,17 +121,6 @@ class MarketWatcher extends EventEmitter {
     } else {
       this.logger.debug(`Unknown response type: ${response.type}`)
     }
-  }
-
-  /**
-   * Delete every event in the store and set a promise on `migrating` that resolves once deletion is complete.
-   * @private
-   * @return {Promise} Resolves when migration is complete
-   */
-  migrate () {
-    this.logger.debug(`Removing existing orderbook events as part of migration`)
-    this.migrating = migrateStore(this.store, this.store, (key) => { return { type: 'del', key } })
-    return this.migrating
   }
 
   /**

--- a/broker-daemon/relayer/market-watcher.js
+++ b/broker-daemon/relayer/market-watcher.js
@@ -1,7 +1,7 @@
 const EventEmitter = require('events')
 const { promisify } = require('util')
 const { MarketEvent } = require('../models')
-const { migrateStore, eachRecord, checksum } = require('../utils')
+const { migrateStore, eachRecord, Checksum } = require('../utils')
 
 /**
  * @class Watch a relayer market and put the events into a data store
@@ -80,7 +80,7 @@ class MarketWatcher extends EventEmitter {
    * @return {Promise} Resolves when the checksum is built
    */
   createChecksum () {
-    this.checksum = checksum()
+    this.checksum = new Checksum()
 
     return eachRecord(this.store, (key, value) => {
       const marketEvent = MarketEvent.fromStorage(key, value)

--- a/broker-daemon/relayer/market-watcher.js
+++ b/broker-daemon/relayer/market-watcher.js
@@ -184,7 +184,7 @@ class MarketWatcher extends EventEmitter {
   validateChecksum (checksum) {
     this.logger.debug('Validating checksum', { checksum })
 
-    if (!this.checksum.check(Buffer.from(checksum, 'base64'))) {
+    if (!this.checksum.matches(Buffer.from(checksum, 'base64'))) {
       // TODO: do we need to remove events from the db?
       this.logger.error('Checksums did not match, invalidating')
       this.emit('error', new Error('[MarketWatcher]: Checksum mismatch'))

--- a/broker-daemon/relayer/market-watcher.js
+++ b/broker-daemon/relayer/market-watcher.js
@@ -27,10 +27,7 @@ class MarketWatcher extends EventEmitter {
     this.RESPONSE_TYPES = RESPONSE_TYPES
 
     this.setupListeners()
-
-    // initialize the checksum and hold off on processing
-    // events until it is complete
-    this.creatingChecksum = this.createChecksum()
+    this.createChecksum()
   }
 
   /**
@@ -74,7 +71,9 @@ class MarketWatcher extends EventEmitter {
   }
 
   /**
-   * Create a new checksum by processing all market events in the data store
+   * Create a new checksum by processing all market events in the data store.
+   * It assigns its promise to the value `creatingChecksum` to delay processing
+   * until it's complete.
    * @private
    * @todo does it make sense to build this off the index so we don't have
    * to process every event in the store?
@@ -83,10 +82,12 @@ class MarketWatcher extends EventEmitter {
   createChecksum () {
     this.checksum = new Checksum()
 
-    return eachRecord(this.store, (key, value) => {
+    this.creatingChecksum = eachRecord(this.store, (key, value) => {
       const marketEvent = MarketEvent.fromStorage(key, value)
       this.checksum.process(marketEvent.orderId)
     })
+
+    return this.creatingChecksum
   }
 
   /**

--- a/broker-daemon/relayer/market-watcher.js
+++ b/broker-daemon/relayer/market-watcher.js
@@ -75,6 +75,7 @@ class MarketWatcher extends EventEmitter {
 
   /**
    * Create a new checksum by processing all market events in the data store
+   * @private
    * @todo does it make sense to build this off the index so we don't have
    * to process every event in the store?
    * @return {Promise} Resolves when the checksum is built

--- a/broker-daemon/relayer/market-watcher.js
+++ b/broker-daemon/relayer/market-watcher.js
@@ -30,7 +30,7 @@ class MarketWatcher extends EventEmitter {
 
     // initialize the checksum and hold off on processing
     // events until it is complete
-    this.migrating = this.createChecksum()
+    this.creatingChecksum = this.createChecksum()
   }
 
   /**
@@ -102,7 +102,7 @@ class MarketWatcher extends EventEmitter {
     // will be the same as the order in which they arrive.
     // This could have some potential issues, particularly if, for example, a CANCELLED is processed
     // before its corresponding PLACED.
-    await this.migration()
+    await this.delayProcessing()
 
     this.logger.debug(`response type is ${response.type}`)
 
@@ -124,16 +124,13 @@ class MarketWatcher extends EventEmitter {
   }
 
   /**
-   * Helper promise to await to ensure that any migrations are complete before proceeding
+   * Helper promise to await to ensure that any outstanding promises are complete before proceeding
    * @private
-   * @return {Promise} Resolves when there are no in-progress migrations
+   * @return {Promise} Resolves when there are no in-progress promises
    */
-  async migration () {
-    // migrating is falsey (null) by default
-    if (this.migrating) {
-      this.logger.debug(`Waiting for migration to finish before acting on new response`)
-      await this.migrating
-    }
+  async delayProcessing () {
+    this.logger.debug(`Waiting for migration and checksum to finish before acting on new response`)
+    await Promise.all([this.migrating, this.creatingChecksum])
   }
 
   /**

--- a/broker-daemon/relayer/market-watcher.spec.js
+++ b/broker-daemon/relayer/market-watcher.spec.js
@@ -450,22 +450,25 @@ describe('MarketWatcher', () => {
       expect(mw.finishBeforeProcessing.size).to.be.eql(0)
     })
 
-    xit('does not remove unresolved promises from the set', () => {
-      mw.finishBeforeProcessing.add(new Promise((resolve) => {
+    it('does not remove unresolved promises from the set', () => {
+      const initialPromise = new Promise((resolve) => {
         resolve()
-      }))
+      })
+      const secondPromise = new Promise(() => {})
 
-      expect(mw.finishBeforeProcessing.size).to.be.eql(1)
+      mw.finishBeforeProcessing.add(initialPromise)
 
       mw.delayProcessing().then(() => {
         // the second promise should still be in the set since
         // it was added after we started waiting on the set
-        expect(mw.finishBeforeProcessing.size).to.be.eql(1)
+        expect(mw.finishBeforeProcessing.has(initialPromise)).to.be.false()
+        expect(mw.finishBeforeProcessing.has(secondPromise)).to.be.true()
       })
 
-      mw.finishBeforeProcessing.add(new Promise(() => {}))
+      mw.finishBeforeProcessing.add(secondPromise)
 
-      expect(mw.finishBeforeProcessing.size).to.be.eql(2)
+      expect(mw.finishBeforeProcessing.has(initialPromise)).to.be.true()
+      expect(mw.finishBeforeProcessing.has(secondPromise)).to.be.true()
     })
   })
 

--- a/broker-daemon/utils/checksum.js
+++ b/broker-daemon/utils/checksum.js
@@ -34,27 +34,44 @@ function xor (a, b) {
 }
 
 /**
- * Create an updatable checksum of a set of data
- * @return {Object}
+ * @class An updatable checksum of a set of data.
+ * Checksum uses a XOR of SHA-256 hashes of given data elements, providing
+ * a checksum that can be easily added to and subtracted from.
  * @example
- * const mysum = checksum()
+ * const mysum = new Checksum()
  * mysum.check(sha256('hello')) // returns false
  * mysum.process('hello')
  * mysum.check(sha256('hello')) // returns true
  * mysum.process('hello')
  * mysum.check(sha256('hello')) // returns false
  */
-function checksum () {
-  return {
-    sum: Buffer.alloc(SHA256_BYTE_SIZE),
-    check (sum) {
-      return this.sum.equals(sum)
-    },
-    process (value) {
-      this.sum = xor(this.sum, sha256(value))
-      return this
-    }
+class Checksum {
+  /**
+   * Create a new checksum for a data set
+   * @return {Checksum} Initialized checksum with an empty data set
+   */
+  constructor () {
+    this.sum = Buffer.alloc(SHA256_BYTE_SIZE)
+  }
+
+  /**
+   * Check that the provided sum matches our calculated sum
+   * @param  {Buffer}  sum Buffer of a checksum of equivalent length
+   * @return {Boolean}     True if the checksums match, false otherwise
+   */
+  check (sum) {
+    return this.sum.equals(sum)
+  }
+
+  /**
+   * Add a value to, or remove a value from the data set
+   * @param  {String} value Value to add to or remove from the data set, e.g. a unique ID
+   * @return {Checksum}     Mutated checksum class, for easy chaining (e.g. mysum.process('a').process('b'))
+   */
+  process (value) {
+    this.sum = xor(this.sum, sha256(value))
+    return this
   }
 }
 
-module.exports = checksum
+module.exports = Checksum

--- a/broker-daemon/utils/checksum.js
+++ b/broker-daemon/utils/checksum.js
@@ -1,0 +1,60 @@
+const { createHash } = require('crypto')
+
+/**
+ * Length of a SHA-256 Hash in Bytes
+ * @constant
+ * @type {Number}
+ */
+const SHA256_BYTE_SIZE = 32
+
+/**
+ * Create a sha256 digest of a value
+ * @param  {String} value Value to digest
+ * @return {Buffer}       SHA-256 of the value
+ */
+function sha256 (value) {
+  return createHash('sha256').update(value).digest()
+}
+
+/**
+ * Perform a XOR on two buffers
+ * @param  {Buffer} a
+ * @param  {Buffer} b
+ * @return {Buffer}   XOR'ed buffer
+ */
+function xor (a, b) {
+  const length = Math.max(a.length, b.length)
+  const buffer = Buffer.allocUnsafe(length)
+
+  for (var i = 0; i < length; ++i) {
+    buffer[i] = a[i] ^ b[i]
+  }
+
+  return buffer
+}
+
+/**
+ * Create an updatable checksum of a set of data
+ * @return {Object}
+ * @example
+ * const mysum = checksum()
+ * mysum.check(sha256('hello')) // returns false
+ * mysum.process('hello')
+ * mysum.check(sha256('hello')) // returns true
+ * mysum.process('hello')
+ * mysum.check(sha256('hello')) // returns false
+ */
+function checksum () {
+  return {
+    sum: Buffer.alloc(SHA256_BYTE_SIZE),
+    check (sum) {
+      return this.sum.equals(sum)
+    },
+    process (value) {
+      this.sum = xor(this.sum, sha256(value))
+      return this
+    }
+  }
+}
+
+module.exports = checksum

--- a/broker-daemon/utils/checksum.js
+++ b/broker-daemon/utils/checksum.js
@@ -58,8 +58,16 @@ class Checksum {
    * Check that the provided sum matches our calculated sum
    * @param  {Buffer}  sum Buffer of a checksum of equivalent length
    * @return {Boolean}     True if the checksums match, false otherwise
+   * @throws {Error} If sum is not a Buffer
+   * @throws {Error} If sum does not have the correct length
    */
-  check (sum) {
+  matches (sum) {
+    if (!Buffer.isBuffer(sum)) {
+      throw new Error(`Checksums can only be matched against Buffers`)
+    }
+    if (sum.length !== SHA256_BYTE_SIZE) {
+      throw new Error(`Checksums can only be matched against Buffers of length ${SHA256_BYTE_SIZE}`)
+    }
     return this.sum.equals(sum)
   }
 

--- a/broker-daemon/utils/checksum.spec.js
+++ b/broker-daemon/utils/checksum.spec.js
@@ -2,7 +2,7 @@ const path = require('path')
 const { expect, rewire, sinon } = require('test/test-helper')
 
 describe('checksum', () => {
-  const checksum = rewire(path.resolve(__dirname, 'checksum'))
+  const Checksum = rewire(path.resolve(__dirname, 'checksum'))
 
   describe('sha256', () => {
     let createHash
@@ -20,9 +20,9 @@ describe('checksum', () => {
       hash.update.returns(hash)
       createHash = sinon.stub().returns(hash)
 
-      checksum.__set__('createHash', createHash)
+      Checksum.__set__('createHash', createHash)
 
-      sha256 = checksum.__get__('sha256')
+      sha256 = Checksum.__get__('sha256')
       start = 'hello'
       end = 'goodbye'
 
@@ -53,7 +53,7 @@ describe('checksum', () => {
     let xor
 
     beforeEach(() => {
-      xor = checksum.__get__('xor')
+      xor = Checksum.__get__('xor')
 
       bufA = Buffer.from([0x0, 0x1, 0x2])
       bufB = Buffer.from([0x1, 0x2, 0x3, 0x4])
@@ -72,7 +72,7 @@ describe('checksum', () => {
     })
   })
 
-  describe('checksum', () => {
+  describe('Checksum', () => {
     let sha256Stub
     let shaReset
     let xorStub
@@ -83,14 +83,14 @@ describe('checksum', () => {
     beforeEach(() => {
       sha256Stub = sinon.stub()
 
-      shaReset = checksum.__set__('sha256', sha256Stub)
+      shaReset = Checksum.__set__('sha256', sha256Stub)
 
       xored = Buffer.from('hello world')
       xorStub = sinon.stub().returns(xored)
 
-      xorReset = checksum.__set__('xor', xorStub)
+      xorReset = Checksum.__set__('xor', xorStub)
 
-      chk = checksum()
+      chk = new Checksum()
     })
 
     afterEach(() => {
@@ -162,11 +162,11 @@ describe('checksum', () => {
 })
 
 describe('checksum e2e', () => {
-  const checksum = require('./checksum')
+  const Checksum = require('./checksum')
   let mysum
 
   beforeEach(() => {
-    mysum = checksum()
+    mysum = new Checksum()
   })
 
   it('matches a zero checksum', () => {
@@ -182,12 +182,12 @@ describe('checksum e2e', () => {
   })
 
   it('matches two separate checksums', () => {
-    expect(mysum.process('hello').check(checksum().process('hello').sum)).to.be.true()
+    expect(mysum.process('hello').check((new Checksum()).process('hello').sum)).to.be.true()
   })
 
   it('matches when processing multiple items', () => {
-    expect(mysum.process('hello').process('goodbye').check(checksum().process('hello').sum)).to.be.false()
-    expect(mysum.check(checksum().process('hello').process('goodbye').sum)).to.be.true()
-    expect(mysum.process('hello').check(checksum().process('goodbye').sum)).to.be.true()
+    expect(mysum.process('hello').process('goodbye').check((new Checksum()).process('hello').sum)).to.be.false()
+    expect(mysum.check((new Checksum()).process('hello').process('goodbye').sum)).to.be.true()
+    expect(mysum.process('hello').check((new Checksum()).process('goodbye').sum)).to.be.true()
   })
 })

--- a/broker-daemon/utils/checksum.spec.js
+++ b/broker-daemon/utils/checksum.spec.js
@@ -1,0 +1,193 @@
+const path = require('path')
+const { expect, rewire, sinon } = require('test/test-helper')
+
+describe('checksum', () => {
+  const checksum = rewire(path.resolve(__dirname, 'checksum'))
+
+  describe('sha256', () => {
+    let createHash
+    let hash
+    let hashed
+    let start
+    let end
+    let sha256
+
+    beforeEach(() => {
+      hash = {
+        update: sinon.stub(),
+        digest: sinon.stub()
+      }
+      hash.update.returns(hash)
+      createHash = sinon.stub().returns(hash)
+
+      checksum.__set__('createHash', createHash)
+
+      sha256 = checksum.__get__('sha256')
+      start = 'hello'
+      end = 'goodbye'
+
+      hash.digest.returns(end)
+      hashed = sha256(start)
+    })
+
+    it('creates a sha256 hash', () => {
+      expect(createHash).to.have.been.calledOnce()
+      expect(createHash).to.have.been.calledWith('sha256')
+    })
+
+    it('updates the hash with the supplied data', () => {
+      expect(hash.update).to.have.been.calledOnce()
+      expect(hash.update).to.have.been.calledWith(start)
+    })
+
+    it('returns a digest of the hash', () => {
+      expect(hash.digest).to.have.been.calledOnce()
+      expect(hashed).to.be.eql(end)
+    })
+  })
+
+  describe('xor', () => {
+    let bufA
+    let bufB
+    let xorBuf
+    let xor
+
+    beforeEach(() => {
+      xor = checksum.__get__('xor')
+
+      bufA = Buffer.from([0x0, 0x1, 0x2])
+      bufB = Buffer.from([0x1, 0x2, 0x3, 0x4])
+      xorBuf = xor(bufA, bufB)
+    })
+
+    it('returns a buffer of the length of the larger buffer', () => {
+      expect(xorBuf.length).to.be.eql(4)
+    })
+
+    it('xors each byte of each buffer', () => {
+      expect(xorBuf[0]).to.be.eql(1)
+      expect(xorBuf[1]).to.be.eql(3)
+      expect(xorBuf[2]).to.be.eql(1)
+      expect(xorBuf[3]).to.be.eql(4)
+    })
+  })
+
+  describe('checksum', () => {
+    let sha256Stub
+    let shaReset
+    let xorStub
+    let xorReset
+    let xored
+    let chk
+
+    beforeEach(() => {
+      sha256Stub = sinon.stub()
+
+      shaReset = checksum.__set__('sha256', sha256Stub)
+
+      xored = Buffer.from('hello world')
+      xorStub = sinon.stub().returns(xored)
+
+      xorReset = checksum.__set__('xor', xorStub)
+
+      chk = checksum()
+    })
+
+    afterEach(() => {
+      shaReset()
+      xorReset()
+    })
+
+    describe('create', () => {
+      it('returns an object', () => {
+        expect(chk).to.be.an('object')
+      })
+
+      it('initializes the sum', () => {
+        expect(chk).to.have.property('sum')
+        expect(chk.sum).to.be.instanceOf(Buffer)
+        expect(chk.sum).to.have.length(32)
+      })
+
+      it('provides a check function', () => {
+        expect(chk).to.have.property('check')
+        expect(chk.check).to.be.a('function')
+      })
+
+      it('provides a process function', () => {
+        expect(chk).to.have.property('process')
+        expect(chk.process).to.be.a('function')
+      })
+    })
+
+    describe('process', () => {
+      let processed
+      let added
+      let addedHashed
+
+      beforeEach(() => {
+        added = 'shalala'
+        addedHashed = 'spartacus'
+        sha256Stub.withArgs(added).returns(addedHashed)
+        processed = chk.process(added)
+      })
+
+      it('returns the checksum object', () => {
+        expect(processed).to.be.equal(chk)
+      })
+
+      it('updates the checksum', () => {
+        expect(sha256Stub).to.have.been.calledOnce()
+        expect(sha256Stub).to.have.been.calledWith(added)
+        expect(xorStub).to.have.been.calledOnce()
+        expect(xorStub).to.have.been.calledWith(Buffer.alloc(32), addedHashed)
+        expect(chk.sum).to.be.eql(xored)
+      })
+    })
+
+    describe('check', () => {
+      beforeEach(() => {
+        chk.sum = Buffer.from('glarp')
+      })
+
+      it('matches sums that match', () => {
+        expect(chk.check(Buffer.from('glarp'))).to.be.true()
+      })
+
+      it('does not match sums that do not match', () => {
+        expect(chk.check(Buffer.from('glorp'))).to.be.false()
+      })
+    })
+  })
+})
+
+describe('checksum e2e', () => {
+  const checksum = require('./checksum')
+  let mysum
+
+  beforeEach(() => {
+    mysum = checksum()
+  })
+
+  it('matches a zero checksum', () => {
+    expect(mysum.check(Buffer.alloc(32))).to.be.true()
+  })
+
+  it('does not match when processing another item', () => {
+    expect(mysum.process('hello').check(Buffer.alloc(32))).to.be.false()
+  })
+
+  it('matches when processing the same item twice', () => {
+    expect(mysum.process('hello').process('hello').check(Buffer.alloc(32))).to.be.true()
+  })
+
+  it('matches two separate checksums', () => {
+    expect(mysum.process('hello').check(checksum().process('hello').sum)).to.be.true()
+  })
+
+  it('matches when processing multiple items', () => {
+    expect(mysum.process('hello').process('goodbye').check(checksum().process('hello').sum)).to.be.false()
+    expect(mysum.check(checksum().process('hello').process('goodbye').sum)).to.be.true()
+    expect(mysum.process('hello').check(checksum().process('goodbye').sum)).to.be.true()
+  })
+})

--- a/broker-daemon/utils/checksum.spec.js
+++ b/broker-daemon/utils/checksum.spec.js
@@ -109,9 +109,9 @@ describe('checksum', () => {
         expect(chk.sum).to.have.length(32)
       })
 
-      it('provides a check function', () => {
-        expect(chk).to.have.property('check')
-        expect(chk.check).to.be.a('function')
+      it('provides a match function', () => {
+        expect(chk).to.have.property('matches')
+        expect(chk.matches).to.be.a('function')
       })
 
       it('provides a process function', () => {
@@ -145,17 +145,25 @@ describe('checksum', () => {
       })
     })
 
-    describe('check', () => {
+    describe('matches', () => {
       beforeEach(() => {
-        chk.sum = Buffer.from('glarp')
+        chk.sum = Buffer.from('4b26bc25cbb8fa69920f06e228155cf560621d4797f625d66b293d258bfa6fd8', 'hex')
+      })
+
+      it('throws if provided a non-buffer', () => {
+        expect(() => chk.matches('glarp')).to.throw()
+      })
+
+      it('throws if provided a buffer of the wrong length', () => {
+        expect(() => chk.matches(Buffer.alloc(0))).to.throw()
       })
 
       it('matches sums that match', () => {
-        expect(chk.check(Buffer.from('glarp'))).to.be.true()
+        expect(chk.matches(Buffer.from('4b26bc25cbb8fa69920f06e228155cf560621d4797f625d66b293d258bfa6fd8', 'hex'))).to.be.true()
       })
 
       it('does not match sums that do not match', () => {
-        expect(chk.check(Buffer.from('glorp'))).to.be.false()
+        expect(chk.matches(Buffer.from('92bcd48480eb4640b9888855c875310599db0bf07141b4d27666171d2458c438', 'hex'))).to.be.false()
       })
     })
   })
@@ -170,24 +178,24 @@ describe('checksum e2e', () => {
   })
 
   it('matches a zero checksum', () => {
-    expect(mysum.check(Buffer.alloc(32))).to.be.true()
+    expect(mysum.matches(Buffer.alloc(32))).to.be.true()
   })
 
   it('does not match when processing another item', () => {
-    expect(mysum.process('hello').check(Buffer.alloc(32))).to.be.false()
+    expect(mysum.process('hello').matches(Buffer.alloc(32))).to.be.false()
   })
 
   it('matches when processing the same item twice', () => {
-    expect(mysum.process('hello').process('hello').check(Buffer.alloc(32))).to.be.true()
+    expect(mysum.process('hello').process('hello').matches(Buffer.alloc(32))).to.be.true()
   })
 
   it('matches two separate checksums', () => {
-    expect(mysum.process('hello').check((new Checksum()).process('hello').sum)).to.be.true()
+    expect(mysum.process('hello').matches((new Checksum()).process('hello').sum)).to.be.true()
   })
 
   it('matches when processing multiple items', () => {
-    expect(mysum.process('hello').process('goodbye').check((new Checksum()).process('hello').sum)).to.be.false()
-    expect(mysum.check((new Checksum()).process('hello').process('goodbye').sum)).to.be.true()
-    expect(mysum.process('hello').check((new Checksum()).process('goodbye').sum)).to.be.true()
+    expect(mysum.process('hello').process('goodbye').matches((new Checksum()).process('hello').sum)).to.be.false()
+    expect(mysum.matches((new Checksum()).process('hello').process('goodbye').sum)).to.be.true()
+    expect(mysum.process('hello').matches((new Checksum()).process('goodbye').sum)).to.be.true()
   })
 })

--- a/broker-daemon/utils/each-record.js
+++ b/broker-daemon/utils/each-record.js
@@ -1,0 +1,17 @@
+function eachRecord (store, fn, params = {}) {
+  return new Promise((resolve, reject) => {
+    const stream = store.createReadStream(params)
+
+    stream.on('error', reject)
+
+    stream.on('end', () => {
+      resolve()
+    })
+
+    stream.on('data', ({ key, value }) => {
+      fn(key, value)
+    })
+  })
+}
+
+module.exports = eachRecord

--- a/broker-daemon/utils/each-record.spec.js
+++ b/broker-daemon/utils/each-record.spec.js
@@ -1,0 +1,83 @@
+const { sinon, expect } = require('test/test-helper')
+
+const eachRecord = require('./each-record')
+
+describe('eachRecord', () => {
+  let store
+  let stream
+  let fn
+  let params
+
+  beforeEach(() => {
+    stream = {
+      on: sinon.stub()
+    }
+    store = {
+      createReadStream: sinon.stub().returns(stream)
+    }
+    fn = sinon.stub()
+    params = {}
+  })
+
+  it('returns a promise', () => {
+    expect(eachRecord(store, fn, params)).to.be.a('promise')
+  })
+
+  it('creates a readstream from the store', () => {
+    eachRecord(store, fn, params)
+
+    expect(store.createReadStream).to.have.been.calledOnce()
+    expect(store.createReadStream).to.have.been.calledWith(sinon.match(params))
+  })
+
+  it('passes through params to the readstream', () => {
+    params = {
+      reverse: true
+    }
+
+    eachRecord(store, fn, params)
+    expect(store.createReadStream).to.have.been.calledWith(sinon.match(params))
+  })
+
+  it('sets an error handler', () => {
+    eachRecord(store, fn, params)
+
+    expect(stream.on).to.have.been.calledWith('error', sinon.match.func)
+  })
+
+  it('sets an end handler', () => {
+    eachRecord(store, fn, params)
+
+    expect(stream.on).to.have.been.calledWith('end', sinon.match.func)
+  })
+
+  it('sets an data handler', () => {
+    eachRecord(store, fn, params)
+
+    expect(stream.on).to.have.been.calledWith('data', sinon.match.func)
+  })
+
+  it('rejects on error', async () => {
+    stream.on.withArgs('error').callsArgWithAsync(1, new Error('fake error'))
+    return expect(eachRecord(store, fn, params)).to.be.rejectedWith(Error)
+  })
+
+  it('resolves on end', async () => {
+    stream.on.withArgs('end').callsArgAsync(1)
+    return expect(await eachRecord(store, fn, params)).to.be.eql()
+  })
+
+  it('processes records through the provided fn', async () => {
+    const fakeRecord = { key: 'mykey', value: 'myvalue' }
+    const fakeProcessed = { hello: 'world' }
+    fn.returns(fakeProcessed)
+
+    stream.on.withArgs('data').callsArgWithAsync(1, fakeRecord)
+    stream.on.withArgs('end').callsArgAsync(1)
+
+    await eachRecord(store, fn, params)
+
+    expect(fn).to.have.been.calledOnce()
+    expect(fn).to.have.been.calledWith(sinon.match(fakeRecord.key), sinon.match(fakeRecord.value))
+  })
+})

--- a/broker-daemon/utils/get-records.js
+++ b/broker-daemon/utils/get-records.js
@@ -1,18 +1,13 @@
-function getRecords (store, eachRecord, params = {}) {
-  return new Promise((resolve, reject) => {
-    const stream = store.createReadStream(params)
-    const records = []
+const eachRecord = require('./each-record')
 
-    stream.on('error', reject)
+async function getRecords (store, fn, params = {}) {
+  const records = []
 
-    stream.on('end', () => {
-      resolve(records)
-    })
+  await eachRecord(store, (key, value) => {
+    records.push(fn(key, value))
+  }, params)
 
-    stream.on('data', ({ key, value }) => {
-      records.push(eachRecord(key, value))
-    })
-  })
+  return records
 }
 
 module.exports = getRecords

--- a/broker-daemon/utils/index.js
+++ b/broker-daemon/utils/index.js
@@ -14,6 +14,7 @@ const createHttpServer = require('./create-http-server')
 const timestampToNano = require('./timestamp-to-nano')
 const generateId = require('./generate-id')
 const eachRecord = require('./each-record')
+const checksum = require('./checksum')
 
 module.exports = {
   getRecords,
@@ -31,5 +32,6 @@ module.exports = {
   createHttpServer,
   timestampToNano,
   generateId,
-  eachRecord
+  eachRecord,
+  checksum
 }

--- a/broker-daemon/utils/index.js
+++ b/broker-daemon/utils/index.js
@@ -14,7 +14,7 @@ const createHttpServer = require('./create-http-server')
 const timestampToNano = require('./timestamp-to-nano')
 const generateId = require('./generate-id')
 const eachRecord = require('./each-record')
-const checksum = require('./checksum')
+const Checksum = require('./checksum')
 
 module.exports = {
   getRecords,
@@ -33,5 +33,5 @@ module.exports = {
   timestampToNano,
   generateId,
   eachRecord,
-  checksum
+  Checksum
 }

--- a/broker-daemon/utils/index.js
+++ b/broker-daemon/utils/index.js
@@ -13,6 +13,7 @@ const grpcGateway = require('./grpc-gateway')
 const createHttpServer = require('./create-http-server')
 const timestampToNano = require('./timestamp-to-nano')
 const generateId = require('./generate-id')
+const eachRecord = require('./each-record')
 
 module.exports = {
   getRecords,
@@ -29,5 +30,6 @@ module.exports = {
   grpcGateway,
   createHttpServer,
   timestampToNano,
-  generateId
+  generateId,
+  eachRecord
 }

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -9,7 +9,7 @@
 // unhandled promise rejections are not handled by default in mocha currently,
 // but are deprecated in node.js, so should indicate test failure
 // @see {@link https://github.com/mochajs/mocha/issues/2640|mochajs/mocha#2640}
-process.on('unhandledRejection', () => { throw new Error('Unhandled rejection during testing') })
+process.on('unhandledRejection', (e) => { throw (e || new Error('unknown error')) })
 
 const sinon = require('sinon')
 const chai = require('chai')


### PR DESCRIPTION
## Description
This PR adds a checksum to the orderbook representing its current state. It compares that checksum against the checksums sent by the Relayer, and if there is a mismatch, it dumps its current state in order to re-sync.

This allows the Broker to detect when it is out of sync with the Relayer (due to a dropped event) and get back into sync.

## Todos
- [x] Tests
- [x] Documentation

## Future considerations
This does not take advantage of (or validate) that indexing that we do to create the orderbook itself (i.e. the `OrderbookIndex`) primarily because I wanted to keep the checksum localized to processing new Relayer events. However, it may become a performance issue at some point, or be a useful way to validate the Orderbook Index itself against the checksum.