### PR TITLE
FIX: prettify errors for wallet network-address and wallet network-status

### DIFF
--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -207,7 +207,7 @@ async function networkAddress (args, opts, logger) {
 
     logger.info(paymentChannelNetworkAddress)
   } catch (e) {
-    logger.error(e)
+    logger.error(handleError(e))
   }
 }
 
@@ -252,7 +252,7 @@ async function networkStatus (args, opts, logger) {
     logger.info(` ${market.bold.white}`)
     logger.info(statusTable.toString())
   } catch (e) {
-    logger.error(e)
+    logger.error(handleError(e))
   }
 }
 


### PR DESCRIPTION
## Description
Fixes an issue where `sparkswap wallet network-status` and `sparkswap wallet network-address` did not show pretty errors when the daemon was unavailable.
