### PR TITLE
Fix - Engine validation changes

### DIFF
--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -8,7 +8,7 @@ const Orderbook = require('./orderbook')
 const BlockOrderWorker = require('./block-order-worker')
 const BrokerRPCServer = require('./broker-rpc/broker-rpc-server')
 const InterchainRouter = require('./interchain-router')
-const { logger, exponentialBackoff } = require('./utils')
+const { logger } = require('./utils')
 const CONFIG = require('./config')
 
 /**
@@ -37,22 +37,6 @@ const DEFAULT_DATA_DIR = '~/.sparkswap/data'
  * @default
  */
 const DEFAULT_INTERCHAIN_ROUTER_ADDRESS = '0.0.0.0:40369'
-
-/**
- * Attempts to retry validating an engine
- *
- * @constant
- * @type {String}
- */
-const EXPONENTIAL_BACKOFF_ATTEMPTS = 24
-
-/**
- * Delay in each retry attempt to validating an engine
- *
- * @constant
- * @type {Integer} milliseconds
- */
-const EXPONENTIAL_BACKOFF_DELAY = 5000
 
 /**
  * Default host and port that the Relayer is set up on

--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -8,7 +8,7 @@ const Orderbook = require('./orderbook')
 const BlockOrderWorker = require('./block-order-worker')
 const BrokerRPCServer = require('./broker-rpc/broker-rpc-server')
 const InterchainRouter = require('./interchain-router')
-const { logger, exponentialBackoff } = require('./utils')
+const { logger } = require('./utils')
 const CONFIG = require('./config')
 
 /**
@@ -37,22 +37,6 @@ const DEFAULT_DATA_DIR = '~/.sparkswap/data'
  * @default
  */
 const DEFAULT_INTERCHAIN_ROUTER_ADDRESS = '0.0.0.0:40369'
-
-/**
- * Attempts to retry validating an engine
- *
- * @constant
- * @type {String}
- */
-const EXPONENTIAL_BACKOFF_ATTEMPTS = 24
-
-/**
- * Delay in each retry attempt to validating an engine
- *
- * @constant
- * @type {Integer} milliseconds
- */
-const EXPONENTIAL_BACKOFF_DELAY = 5000
 
 /**
  * Default host and port that the Relayer is set up on
@@ -189,10 +173,6 @@ class BrokerDaemon {
         })()
       ])
 
-      // This will run in the background. It is implemented with exponential backoff so
-      // the validation will be retried on the engine until successful or until final failure.
-      this.validateEngines()
-
       this.rpcServer.listen(this.rpcAddress)
       this.logger.info(`BrokerDaemon RPC server started: gRPC Server listening on ${this.rpcAddress}`)
 
@@ -244,26 +224,6 @@ class BrokerDaemon {
 
     this.orderbooks.set(marketName, new Orderbook(marketName, this.relayer, this.store.sublevel(marketName), this.logger))
     return this.orderbooks.get(marketName).initialize()
-  }
-
-  /**
-   * Validates engines
-   * We do not await this function because we want the validations to run in the background.
-   * It can take time for the engines to be ready, so we use exponential backoff to retry validation
-   * for a period of time, until it is either successful or there is actually something wrong.
-   * @returns {void}
-   */
-  async validateEngines () {
-    this.engines.forEach(async (engine, symbol) => {
-      try {
-        await exponentialBackoff(() => { return engine.validateNodeConfig() }, EXPONENTIAL_BACKOFF_ATTEMPTS, EXPONENTIAL_BACKOFF_DELAY, {symbol})
-      } catch (e) {
-        this.logger.error(`Failed to validate engine for ${symbol}, error: ${e}`)
-        return
-      }
-
-      this.logger.info(`Validated engine configuration for ${symbol}`)
-    })
   }
 }
 

--- a/broker-daemon/index.spec.js
+++ b/broker-daemon/index.spec.js
@@ -55,7 +55,6 @@ describe('broker daemon', () => {
     }
     exponentialBackoff = sinon.stub().resolves()
     LndEngine = sinon.stub()
-    LndEngine.prototype.validateNodeConfig = sinon.stub().resolves()
     Orderbook = sinon.stub()
     Orderbook.prototype.initialize = sinon.stub()
     BlockOrderWorker = sinon.stub()
@@ -383,13 +382,6 @@ describe('broker daemon', () => {
       expect(interchainRouterListenSpy).to.have.been.calledWith(brokerDaemon.interchainRouterAddress)
     })
 
-    it('validates the engines', async () => {
-      brokerDaemon.validateEngines = sinon.stub().returns()
-      await brokerDaemon.initialize()
-
-      expect(brokerDaemon.validateEngines).to.have.been.calledOnce()
-    })
-
     it('initializes markets', async () => {
       brokerDaemon.initializeMarkets = sinon.stub().resolves()
 
@@ -403,66 +395,6 @@ describe('broker daemon', () => {
       await brokerDaemon.initialize()
 
       expect(BlockOrderWorker.prototype.initialize).to.have.been.calledOnce()
-    })
-  })
-
-  describe('#validateEngines', () => {
-    let attempts
-    let delay
-    let btcEngine
-    let ltcEngine
-
-    beforeEach(() => {
-      brokerDaemon = new BrokerDaemon(brokerDaemonOptions)
-
-      btcEngine = {
-        validateNodeConfig: sinon.stub().resolves()
-      }
-      ltcEngine = {
-        validateNodeConfig: sinon.stub().resolves()
-      }
-      brokerDaemon.engines = new Map([
-        [ 'BTC', btcEngine ],
-        [ 'LTC', ltcEngine ]
-      ])
-
-      attempts = BrokerDaemon.__get__('EXPONENTIAL_BACKOFF_ATTEMPTS')
-      delay = BrokerDaemon.__get__('EXPONENTIAL_BACKOFF_DELAY')
-    })
-
-    it('validates the node config on each engine', () => {
-      brokerDaemon.validateEngines()
-
-      const validateBtcEngine = exponentialBackoff.args[0][0]
-      const btcEngineRes = validateBtcEngine()
-
-      expect(btcEngine.validateNodeConfig).to.have.been.called()
-      expect(btcEngineRes).to.be.instanceOf(Promise)
-
-      const validateLtcEngine = exponentialBackoff.args[1][0]
-      const ltcEngineRes = validateLtcEngine()
-
-      expect(ltcEngine.validateNodeConfig).to.have.been.called()
-      expect(ltcEngineRes).to.be.instanceOf(Promise)
-    })
-
-    it('validates the engines in exponentialBackoff to allow for retries', () => {
-      brokerDaemon.validateEngines()
-
-      expect(exponentialBackoff).to.have.been.calledTwice()
-      expect(exponentialBackoff).to.have.been.calledWith(
-        sinon.match.func,
-        attempts,
-        delay,
-        {symbol: 'BTC'}
-      )
-
-      expect(exponentialBackoff).to.have.been.calledWith(
-        sinon.match.func,
-        attempts,
-        delay,
-        {symbol: 'LTC'}
-      )
     })
   })
 

--- a/broker-daemon/utils/exponential-backoff.js
+++ b/broker-daemon/utils/exponential-backoff.js
@@ -6,8 +6,28 @@ const delay = require('./delay')
  *
  * @constant
  * @type {Integer} milliseconds
+ * @default
  */
 const DELAY_MULTIPLIER = 1.5
+
+/**
+ * Max attempts for retries during exponential backoff
+ *
+ * @constant
+ * @type {String}
+ * @default
+ */
+const EXPONENTIAL_BACKOFF_ATTEMPTS = 24
+
+/**
+ * Delay, in milliseconds, for each retry attempt
+ *
+ * @constant
+ * @type {Integer} milliseconds
+ * @default
+ */
+const EXPONENTIAL_BACKOFF_DELAY = 5000
+
 /**
  * Calls a function repeatedly until success or throws if it fails on final retry
  *
@@ -18,7 +38,7 @@ const DELAY_MULTIPLIER = 1.5
 
  * @return {Promise}
  */
-async function exponentialBackoff (callFunction, attempts, delayTime, logOptions = {}) {
+async function exponentialBackoff (callFunction, attempts = EXPONENTIAL_BACKOFF_ATTEMPTS, delayTime = EXPONENTIAL_BACKOFF_DELAY, logOptions = {}) {
   try {
     var res = await callFunction()
   } catch (error) {


### PR DESCRIPTION
## Description
In the past, we've used a synchronous way of validating a broker's engines so that we would prevent the broker from starting until all nodes were available.

However, we have now changed the validations of engines to occur async to allow the broker to be operational even if a single node is not available.

With this said, the validation of an engine now occurs on [engine initialization](https://github.com/sparkswap/lnd-engine/pull/110) and is the responsibility of the engine itself.

## Related PRs
#110 


## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
