### PR TITLE
Reject block orders where the user does not have enough funds committed

### DIFF
--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -309,10 +309,10 @@ describe('BlockOrderWorker', () => {
       relayer.paymentChannelNetworkService.getAddress.withArgs({symbol: 'LTC'}).resolves({address: relayerCounterAddress})
       relayer.paymentChannelNetworkService.getAddress.withArgs({symbol: 'BTC'}).resolves({address: relayerBaseAddress})
 
-      ltcEngine.isBalanceSufficient.withArgs(relayerCounterAddress, Big('2000000000')).resolves(true)
-      btcEngine.isBalanceSufficient.withArgs(relayerBaseAddress, Big('2000000000'), {outbound: false}).resolves(true)
-      ltcEngine.isBalanceSufficient.withArgs(relayerCounterAddress, Big('2000000000'), {outbound: false}).resolves(true)
-      btcEngine.isBalanceSufficient.withArgs(relayerBaseAddress, Big('2000000000')).resolves(true)
+      ltcEngine.isBalanceSufficient.withArgs(relayerCounterAddress, '2000000000').resolves(true)
+      btcEngine.isBalanceSufficient.withArgs(relayerBaseAddress, '2000000000', {outbound: false}).resolves(true)
+      ltcEngine.isBalanceSufficient.withArgs(relayerCounterAddress, '2000000000', {outbound: false}).resolves(true)
+      btcEngine.isBalanceSufficient.withArgs(relayerBaseAddress, '2000000000').resolves(true)
       engines = new Map([ ['BTC', btcEngine], ['LTC', ltcEngine] ])
       blockOrderStub = {
         counterSymbol: 'LTC',
@@ -400,7 +400,7 @@ describe('BlockOrderWorker', () => {
         price: '100',
         timeInForce: 'GTC'
       }
-      ltcEngine.isBalanceSufficient.withArgs(relayerCounterAddress, Big('2000000000')).resolves(false)
+      ltcEngine.isBalanceSufficient.withArgs(relayerCounterAddress, '2000000000').resolves(false)
 
       return expect(worker.createBlockOrder(params)).to.be.rejectedWith('Insufficient funds in outbound LTC channel to create order')
     })
@@ -413,7 +413,7 @@ describe('BlockOrderWorker', () => {
         price: '100',
         timeInForce: 'GTC'
       }
-      btcEngine.isBalanceSufficient.withArgs(relayerBaseAddress, Big('2000000000'), {outbound: false}).resolves(false)
+      btcEngine.isBalanceSufficient.withArgs(relayerBaseAddress, '2000000000', {outbound: false}).resolves(false)
 
       return expect(worker.createBlockOrder(params)).to.be.rejectedWith('Insufficient funds in inbound BTC channel to create order')
     })
@@ -429,7 +429,7 @@ describe('BlockOrderWorker', () => {
       blockOrderStub.isAsk.returns(true)
       blockOrderStub.isBid.returns(false)
 
-      btcEngine.isBalanceSufficient.withArgs(relayerBaseAddress, Big('2000000000')).resolves(false)
+      btcEngine.isBalanceSufficient.withArgs(relayerBaseAddress, '2000000000').resolves(false)
 
       return expect(worker.createBlockOrder(params)).to.be.rejectedWith('Insufficient funds in outbound BTC channel to create order')
     })
@@ -445,7 +445,7 @@ describe('BlockOrderWorker', () => {
       blockOrderStub.isAsk.returns(true)
       blockOrderStub.isBid.returns(false)
 
-      ltcEngine.isBalanceSufficient.withArgs(relayerCounterAddress, Big('2000000000'), {outbound: false}).resolves(false)
+      ltcEngine.isBalanceSufficient.withArgs(relayerCounterAddress, '2000000000', {outbound: false}).resolves(false)
 
       return expect(worker.createBlockOrder(params)).to.be.rejectedWith('Insufficient funds in inbound LTC channel to create order')
     })

--- a/broker-daemon/models/block-order.js
+++ b/broker-daemon/models/block-order.js
@@ -173,6 +173,22 @@ class BlockOrder {
   }
 
   /**
+   * get boolean for if the blockOrder is a bid
+   * @return {Boolean}
+   */
+  get isBid () {
+    return this.side === BlockOrder.SIDES.BID
+  }
+
+  /**
+  * get boolean for if the blockOrder is an ask
+  * @return {Boolean}
+   */
+  get isAsk () {
+    return this.side === BlockOrder.SIDES.ASK
+  }
+
+  /**
    * Move the block order to a failed status
    * @return {BlockOrder} Modified block order instance
    */

--- a/broker-daemon/models/block-order.spec.js
+++ b/broker-daemon/models/block-order.spec.js
@@ -687,5 +687,27 @@ describe('BlockOrder', () => {
         expect(blockOrder).to.have.property('quantumPrice', '100.0000000000000000')
       })
     })
+
+    describe('get isBid', () => {
+      it('returns true if blockOrder is a bid', () => {
+        expect(blockOrder).to.have.property('isBid', true)
+      })
+
+      it('returns false if blockOrder is not a bid', () => {
+        blockOrder.side = 'ASK'
+        expect(blockOrder).to.have.property('isBid', false)
+      })
+    })
+
+    describe('get isAsk', () => {
+      it('returns true if blockOrder is an ask', () => {
+        blockOrder.side = 'ASK'
+        expect(blockOrder).to.have.property('isAsk', true)
+      })
+
+      it('returns false if blockOrder is not an ask', () => {
+        expect(blockOrder).to.have.property('isAsk', false)
+      })
+    })
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -4072,7 +4072,7 @@
       }
     },
     "lnd-engine": {
-      "version": "github:sparkswap/lnd-engine#66dd514f78da4feabc50f8ec3fdda51d0dbde716",
+      "version": "github:sparkswap/lnd-engine#77a885c451e59060c652735b9d2542b20fa1f47f",
       "from": "github:sparkswap/lnd-engine",
       "requires": {
         "big.js": "5.1.2",


### PR DESCRIPTION
## Description
Rather than creating a block order and having the individual orders get rejected, the Broker Daemon should reject block order creation where there are not enough funds to cover the orders desired.

In createBlockOrder, we now check that the amount of the order is less than or equal to the amount the user has in that channel

## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
