### PR TITLE
Fix: Let swaps complete for partial order fills

### DIFF
--- a/broker-daemon/interchain-router/get-preimage.js
+++ b/broker-daemon/interchain-router/get-preimage.js
@@ -80,8 +80,8 @@ async function getPreimage ({ params, send, onCancel, onError, ordersByHash, eng
     return send({ permanentError: err.message })
   }
 
-  const { inboundSymbol, inboundAmount, outboundSymbol, outboundAmount, takerAddress } = order
-  const [ expectedSymbol, actualSymbol, expectedAmount, actualAmount ] = [ inboundSymbol, symbol, inboundAmount, amount ]
+  const { inboundSymbol, inboundFillAmount, outboundSymbol, outboundFillAmount, takerAddress } = order
+  const [ expectedSymbol, actualSymbol, expectedAmount, actualAmount ] = [ inboundSymbol, symbol, inboundFillAmount, amount ]
 
   if (expectedSymbol !== actualSymbol) {
     const err = `Wrong currency paid in for ${swapHash}. Expected ${expectedSymbol}, found ${actualSymbol}`
@@ -117,7 +117,7 @@ async function getPreimage ({ params, send, onCancel, onError, ordersByHash, eng
   }
 
   logger.debug(`Sending payment to ${takerAddress} to translate swap ${swapHash}`)
-  const { paymentPreimage, permanentError } = await outboundEngine.translateSwap(takerAddress, swapHash, outboundAmount, timeLockDelta)
+  const { paymentPreimage, permanentError } = await outboundEngine.translateSwap(takerAddress, swapHash, outboundFillAmount, timeLockDelta)
 
   if (permanentError) {
     logger.error(permanentError)

--- a/broker-daemon/interchain-router/get-preimage.spec.js
+++ b/broker-daemon/interchain-router/get-preimage.spec.js
@@ -18,10 +18,10 @@ describe('getPreimage', () => {
   beforeEach(() => {
     order = {
       inboundSymbol: 'BTC',
-      inboundAmount: '1000000',
+      inboundFillAmount: '1000000',
       swapHash: 'as09fdjasdf09ja0dsf==',
       outboundSymbol: 'LTC',
-      outboundAmount: '10000000',
+      outboundFillAmount: '10000000',
       takerAddress: 'bolt:9128734923874'
     }
 
@@ -132,7 +132,7 @@ describe('getPreimage', () => {
     await getPreimage(({ params, send, ordersByHash, engines }))
 
     expect(engines.get('LTC').translateSwap).to.have.been.calledOnce()
-    expect(engines.get('LTC').translateSwap).to.have.been.calledWith(order.takerAddress, params.paymentHash, order.outboundAmount, '600000')
+    expect(engines.get('LTC').translateSwap).to.have.been.calledWith(order.takerAddress, params.paymentHash, order.outboundFillAmount, '600000')
   })
 
   it('returns permanentError if the outbound engine returns one', async () => {

--- a/broker-daemon/models/order.spec.js
+++ b/broker-daemon/models/order.spec.js
@@ -232,7 +232,31 @@ describe('Order', () => {
       order = new Order(blockOrderId, params)
     })
 
+    describe('fill getters', () => {
+      beforeEach(() => {
+        order.fillAmount = '9000'
+      })
+
+      it('defines an alias for fillAmount', () => {
+        expect(order).to.have.property('baseFillAmount', '9000')
+      })
+
+      it('defines a converter to the counter amount for the fill', () => {
+        expect(order).to.have.property('counterFillAmount', '90000')
+      })
+
+      it('throws if trying to access the counterFillAmount without a fillAmount', () => {
+        order.fillAmount = null
+
+        expect(() => order.counterFillAmount).to.throw()
+      })
+    })
+
     describe('inbound/outbound getters', () => {
+      beforeEach(() => {
+        order.fillAmount = '9000'
+      })
+
       it('defines an inbound symbol getter', () => {
         expect(order).to.have.property('inboundSymbol', params.baseSymbol)
       })
@@ -241,12 +265,24 @@ describe('Order', () => {
         expect(order).to.have.property('outboundSymbol', params.counterSymbol)
       })
 
-      it('defines an inbound amount getter', () => {
-        expect(order).to.have.property('inboundAmount', params.baseAmount)
+      it('defines an inbound fill amount getter', () => {
+        expect(order).to.have.property('inboundFillAmount', '9000')
       })
 
-      it('defines an outbound amount getter', () => {
-        expect(order).to.have.property('outboundAmount', params.counterAmount)
+      it('throws if trying to use the inbound fill amount without a fill amount', () => {
+        order.fillAmount = null
+
+        expect(() => order.inboundFillAmount).to.throw()
+      })
+
+      it('defines an outbound fill amount getter', () => {
+        expect(order).to.have.property('outboundFillAmount', '90000')
+      })
+
+      it('throws if trying to use the outbound fill amount without a fill amount', () => {
+        order.fillAmount = null
+
+        expect(() => order.outboundFillAmount).to.throw()
       })
     })
 
@@ -297,15 +333,16 @@ describe('Order', () => {
     describe('get paramsForPrepareSwap', () => {
       it('defines a getter for params required to prepare a swap in an engine', () => {
         const swapHash = 'asoifdjaofj02309832'
+        const fillAmount = '9000'
         const fakeId = 'myid'
-        Object.assign(order, { swapHash, orderId: fakeId })
+        Object.assign(order, { swapHash, orderId: fakeId, fillAmount })
 
         expect(order).to.have.property('paramsForPrepareSwap')
         expect(order.paramsForPrepareSwap).to.be.eql({
           orderId: fakeId,
           swapHash: swapHash,
           symbol: params.baseSymbol,
-          amount: params.baseAmount
+          amount: fillAmount
         })
       })
 

--- a/broker-daemon/state-machines/order-state-machine.spec.js
+++ b/broker-daemon/state-machines/order-state-machine.spec.js
@@ -545,9 +545,9 @@ describe('OrderStateMachine', () => {
     let orderId
     let swapHash
     let inboundSymbol
-    let inboundAmount
+    let inboundFillAmount
     let outboundSymbol
-    let outboundAmount
+    let outboundFillAmount
     let engine
 
     beforeEach(async () => {
@@ -556,22 +556,22 @@ describe('OrderStateMachine', () => {
       orderId = '1234'
       swapHash = '0q9wudf09asdf'
       inboundSymbol = 'LTC'
-      inboundAmount = '10000'
+      inboundFillAmount = '10000'
       outboundSymbol = 'BTC'
-      outboundAmount = '100'
+      outboundFillAmount = '100'
 
       fakeOrder = {
         orderId,
         swapHash,
-        inboundAmount,
+        inboundFillAmount,
         inboundSymbol,
         outboundSymbol,
-        outboundAmount,
+        outboundFillAmount,
         paramsForPrepareSwap: {
           orderId,
           swapHash,
           symbol: inboundSymbol,
-          amount: inboundAmount
+          amount: inboundFillAmount
         }
       }
       engine = { prepareSwap: prepareSwapStub }
@@ -598,7 +598,7 @@ describe('OrderStateMachine', () => {
       await osm.execute()
 
       expect(prepareSwapStub).to.have.been.calledOnce()
-      expect(prepareSwapStub).to.have.been.calledWith(orderId, swapHash, inboundAmount)
+      expect(prepareSwapStub).to.have.been.calledWith(orderId, swapHash, inboundFillAmount)
     })
 
     it('authorizes the request', async () => {


### PR DESCRIPTION
## Description
This fixes a bug wherein partial fills would be rejected as swaps as being smaller than expected since they weren't for the entire order.

This change fixes the comparison to use the size of the fill as the size of the swap we are expecting.

## Todos
- [x] Tests
- [x] Documentation
