### PR TITLE
Fix: Reset orderbook when resetting the event store

### DIFF
--- a/broker-daemon/orderbook/index.js
+++ b/broker-daemon/orderbook/index.js
@@ -118,6 +118,7 @@ class Orderbook {
 
       this.logger.info(`Market ${this.marketName} encountered sync'ing error, re-building`, { error })
       await watcher.migrate()
+      await this.index.ensureIndex()
       this.watchMarket()
     }
 

--- a/broker-daemon/orderbook/index.spec.js
+++ b/broker-daemon/orderbook/index.spec.js
@@ -356,6 +356,16 @@ describe('Orderbook', () => {
         expect(watcher.migrate).to.have.been.calledOnce()
       })
 
+      it('resets the orderbook index', async () => {
+        watcher.migrate.resolves()
+        await onError()
+
+        const ensureIndex = OrderbookIndex.prototype.ensureIndex
+
+        expect(ensureIndex).to.have.been.calledOnce()
+        expect(ensureIndex).to.have.been.calledOn(orderbook.index)
+      })
+
       it('retries watching the market', async () => {
         watcher.migrate.resolves()
         await onError()


### PR DESCRIPTION
## Description
The change which caused the event store to flush when encountering an invalid checksum (#279) does not flush the `OrderbookIndex` itself as the `OrderbookIndex` is designed only to handle `put` events, and ignores `del` events.

This created an issue where stale orders would show up if they existed in the `OrderbookIndex` before the market event store was flushed.

Ideally, the `OrderbookIndex` could handle `del` events (much like the `BidIndex` and `AskIndex` already do) but since that would require some serious changes, instead this change adds a call to reset the `OrderbookIndex` when migrating the event store.

This is an instance of the decision made in #279 to only validate the checksum when processing new events coming back to bite us. We should re-examine in the future if we want to do another checksum within the `OrderbookIndex` to avoid issues like this.

## Related PRs
#279 

## Todos
- [x] Tests
- [x] Documentation
