### PR TITLE
Feature: Retrieve a broker's Identity

### DIFF
--- a/broker-cli/commands/identity.js
+++ b/broker-cli/commands/identity.js
@@ -1,13 +1,12 @@
 const BrokerDaemonClient = require('../broker-daemon-client')
-const { ENUMS, validations, handleError } = require('../utils')
-const { STATUS_CODES } = ENUMS
+const { validations, handleError } = require('../utils')
 
 /**
- * sparkswap healthcheck
+ * sparkswap id
  *
- * Tests the broker and engine connection for the cli
+ * Get the BrokerDaemon's Identity
  *
- * ex: `sparkswap healthcheck`
+ * ex: `sparkswap id`
  *
  * @param {Object} args
  * @param {Object} opts

--- a/broker-cli/commands/identity.js
+++ b/broker-cli/commands/identity.js
@@ -1,0 +1,37 @@
+const BrokerDaemonClient = require('../broker-daemon-client')
+const { ENUMS, validations, handleError } = require('../utils')
+const { STATUS_CODES } = ENUMS
+
+/**
+ * sparkswap healthcheck
+ *
+ * Tests the broker and engine connection for the cli
+ *
+ * ex: `sparkswap healthcheck`
+ *
+ * @param {Object} args
+ * @param {Object} opts
+ * @param {String} [rpcAddress] broker rpc address
+ * @param {Logger} logger
+ */
+
+async function getIdentity (args, opts, logger) {
+  const { rpcAddress = null } = opts
+
+  try {
+    const client = await new BrokerDaemonClient(rpcAddress)
+
+    const { publicKey } = await client.adminService.getIdentity({})
+
+    logger.info(publicKey)
+  } catch (e) {
+    logger.error(handleError(e))
+  }
+};
+
+module.exports = (program) => {
+  program
+    .command('id', 'Gets the Public Key of the Broker Daemon')
+    .option('--rpc-address', 'Location of the RPC server to use.', validations.isHost)
+    .action(getIdentity)
+}

--- a/broker-cli/commands/identity.js
+++ b/broker-cli/commands/identity.js
@@ -10,7 +10,7 @@ const { validations, handleError } = require('../utils')
  *
  * @param {Object} args
  * @param {Object} opts
- * @param {String} [rpcAddress] broker rpc address
+ * @param {String} [rpcAddress=null] broker rpc address
  * @param {Logger} logger
  */
 
@@ -31,6 +31,6 @@ async function getIdentity (args, opts, logger) {
 module.exports = (program) => {
   program
     .command('id', 'Gets the Public Key of the Broker Daemon')
-    .option('--rpc-address', 'Location of the RPC server to use.', validations.isHost)
+    .option('--rpc-address [rpc-address]', 'Location of the RPC server to use.', validations.isHost)
     .action(getIdentity)
 }

--- a/broker-cli/commands/identity.spec.js
+++ b/broker-cli/commands/identity.spec.js
@@ -1,0 +1,63 @@
+const path = require('path')
+const {
+  sinon,
+  rewire,
+  expect
+} = require('test/test-helper')
+
+const programPath = path.resolve(__dirname, 'identity')
+const program = rewire(programPath)
+
+describe('getIdentity', () => {
+  let args
+  let opts
+  let logger
+  let revert
+  let infoSpy
+  let errorSpy
+  let publicKey
+  let getIdentityStub
+  let brokerStub
+  let rpcAddress
+
+  const getIdentity = program.__get__('getIdentity')
+
+  beforeEach(() => {
+    rpcAddress = undefined
+    args = {}
+    opts = { rpcAddress }
+    infoSpy = sinon.spy()
+    errorSpy = sinon.spy()
+    publicKey = 'fakeky'
+    getIdentityStub = sinon.stub().returns({
+      publicKey
+    })
+
+    brokerStub = sinon.stub()
+    brokerStub.prototype.adminService = { getIdentity: getIdentityStub }
+
+    revert = program.__set__('BrokerDaemonClient', brokerStub)
+
+    logger = {
+      info: infoSpy,
+      error: errorSpy
+    }
+  })
+
+  afterEach(() => {
+    revert()
+  })
+
+  it('makes a request to the broker', async () => {
+    await getIdentity(args, opts, logger)
+    expect(getIdentityStub).to.have.been.calledOnce()
+    expect(getIdentityStub).to.have.been.calledWith(sinon.match({}))
+    expect(getIdentityStub).to.have.been.calledOn(brokerStub.prototype.adminService)
+  })
+
+  it('logs the output from the broker', async () => {
+    await getIdentity(args, opts, logger)
+    expect(infoSpy).to.have.been.calledOnce()
+    expect(infoSpy).to.have.been.calledWith(publicKey)
+  })
+})

--- a/broker-cli/commands/index.js
+++ b/broker-cli/commands/index.js
@@ -12,6 +12,7 @@ const healthCheckCommand = require('./health-check')
 const walletCommand = require('./wallet')
 const orderCommand = require('./order')
 const infoCommand = require('./info')
+const identityCommand = require('./identity')
 
 module.exports = {
   buyCommand,
@@ -20,5 +21,6 @@ module.exports = {
   healthCheckCommand,
   walletCommand,
   orderCommand,
-  infoCommand
+  infoCommand,
+  identityCommand
 }

--- a/broker-cli/commands/index.spec.js
+++ b/broker-cli/commands/index.spec.js
@@ -47,7 +47,6 @@ describe('broker index', () => {
     expect(infoCommand).to.not.be.undefined()
   })
 
-
   it('defines identityCommand', () => {
     expect(identityCommand).to.not.be.null()
     expect(identityCommand).to.not.be.undefined()

--- a/broker-cli/commands/index.spec.js
+++ b/broker-cli/commands/index.spec.js
@@ -7,7 +7,8 @@ const {
   healthCheckCommand,
   walletCommand,
   orderCommand,
-  infoCommand
+  infoCommand,
+  identityCommand
 } = require('./index')
 
 describe('broker index', () => {
@@ -44,5 +45,11 @@ describe('broker index', () => {
   it('defines infoCommand', () => {
     expect(infoCommand).to.not.be.null()
     expect(infoCommand).to.not.be.undefined()
+  })
+
+
+  it('defines identityCommand', () => {
+    expect(identityCommand).to.not.be.null()
+    expect(identityCommand).to.not.be.undefined()
   })
 })

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -90,6 +90,14 @@ message HealthCheckResponse {
 }
 
 /**
+ * GetIdentityResponse provides the Public Key of the BrokerDaemon
+ */
+message GetIdentityResponse {
+  // The public key of the BrokerDaemon used to authenticate interactions with the Relayer
+  string public_key = 1;
+}
+
+/**
  * The AdminService performs administrative tasks on the BrokerDaemon.
  *
  * ```javascript
@@ -145,6 +153,38 @@ service AdminService {
   rpc HealthCheck (google.protobuf.Empty) returns (HealthCheckResponse) {
     option (google.api.http) = {
       get: "/v1/admin/healthcheck"
+    };
+  }
+
+  /**
+   * GetIdentity returns the Public Key the BrokerDaemon uses to interact with the Relayer.
+   *
+   * ```javascript
+   * const deadline = new Date().setSeconds(new Date().getSeconds() + 5)
+   * adminService.getIdentity({}, { deadline }, (err, { publicKey }) => {
+   *   if (err) return console.error(err)
+   *   console.log({ publicKey })
+   * })
+   * ```
+   *
+   * ```shell
+   * > sparkswap id
+   * ```
+   *
+   * > The above command will print:
+   *
+   * ```javascript
+   * {
+   *   "publicKey": ""
+   * }
+   * ```
+   *
+   * ```shell
+   * ```
+   */
+  rpc GetIdentity (google.protobuf.Empty) returns (GetIdentityResponse) {
+    option (google.api.http) = {
+      get: "/v1/admin/identity"
     };
   }
 }

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -175,11 +175,15 @@ service AdminService {
    *
    * ```javascript
    * {
-   *   "publicKey": ""
+   *   "publicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEVbt2b1JHw7Kg2I9340n8jA5ycbyH\neucZq00VNANqsoUSfw2iqRkM4OLVdUZ22YGR+mN/0CgIIwiWxNE6g58V+g==\n-----END PUBLIC KEY-----\n"
    * }
    * ```
    *
    * ```shell
+   * -----BEGIN PUBLIC KEY-----
+   * MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEVbt2b1JHw7Kg2I9340n8jA5ycbyH
+   * eucZq00VNANqsoUSfw2iqRkM4OLVdUZ22YGR+mN/0CgIIwiWxNE6g58V+g==
+   * -----END PUBLIC KEY-----
    * ```
    */
   rpc GetIdentity (google.protobuf.Empty) returns (GetIdentityResponse) {

--- a/broker-daemon/broker-rpc/admin-service/get-identity.js
+++ b/broker-daemon/broker-rpc/admin-service/get-identity.js
@@ -1,0 +1,17 @@
+/**
+ * Get the identity of the Broker
+ *
+ * @param {GrpcUnaryMethod~request} request - request object
+ * @param {RelayerClient} request.relayer - grpc Client for interacting with the Relayer
+ * @param {Object} request.logger
+ * @param {Object} responses
+ * @param {function} responses.GetIdentityResponse - constructor for GetIdentityResponse messages
+ * @return {responses.GetIdentityResponse}
+ */
+async function getIdentity ({ relayer, logger }, { GetIdentityResponse }) {
+  const publicKey = relayer.identity.pubKey
+
+  return new GetIdentityResponse({ publicKey })
+}
+
+module.exports = getIdentity

--- a/broker-daemon/broker-rpc/admin-service/get-identity.spec.js
+++ b/broker-daemon/broker-rpc/admin-service/get-identity.spec.js
@@ -1,0 +1,43 @@
+const path = require('path')
+const {
+  sinon,
+  rewire,
+  expect
+} = require('test/test-helper')
+
+const getIdentity = rewire(path.resolve(__dirname, 'get-identity'))
+
+describe('get-identity', () => {
+  describe('getIdentity', () => {
+    let GetIdentityResponse
+    let relayerStub
+    let pubKey
+    let loggerStub
+    let result
+
+    beforeEach(() => {
+      pubKey = 'fakekey'
+      relayerStub = {
+        identity: {
+          pubKey
+        }
+      }
+      loggerStub = {
+        info: sinon.stub(),
+        debug: sinon.stub()
+      }
+      GetIdentityResponse = sinon.stub()
+    })
+
+    beforeEach(async () => {
+      result = await getIdentity({ relayer: relayerStub, logger: loggerStub }, { GetIdentityResponse })
+    })
+
+    it('returns the public key', async () => {
+      expect(result).to.be.an.instanceOf(GetIdentityResponse)
+      expect(GetIdentityResponse).to.have.been.calledOnce()
+      expect(GetIdentityResponse).to.have.been.calledWithNew()
+      expect(GetIdentityResponse).to.have.been.calledWith(sinon.match({ publicKey: pubKey }))
+    })
+  })
+})

--- a/broker-daemon/broker-rpc/admin-service/index.js
+++ b/broker-daemon/broker-rpc/admin-service/index.js
@@ -2,6 +2,7 @@ const { GrpcUnaryMethod } = require('grpc-methods')
 const { loadProto } = require('../../utils')
 
 const healthCheck = require('./health-check')
+const getIdentity = require('./get-identity')
 
 class AdminService {
   /**
@@ -21,11 +22,13 @@ class AdminService {
     this.serviceName = 'AdminService'
 
     const {
-      HealthCheckResponse
+      HealthCheckResponse,
+      GetIdentityResponse
     } = this.proto.broker.rpc
 
     this.implementation = {
-      healthCheck: new GrpcUnaryMethod(healthCheck, this.messageId('healthCheck'), { logger, relayer, engines, auth }, { HealthCheckResponse }).register()
+      healthCheck: new GrpcUnaryMethod(healthCheck, this.messageId('healthCheck'), { logger, relayer, engines, auth }, { HealthCheckResponse }).register(),
+      getIdentity: new GrpcUnaryMethod(getIdentity, this.messageId('getIdentity'), { logger, relayer, auth }, { GetIdentityResponse }).register()
     }
   }
 

--- a/broker-daemon/broker-rpc/admin-service/index.spec.js
+++ b/broker-daemon/broker-rpc/admin-service/index.spec.js
@@ -5,6 +5,7 @@ const AdminService = rewire(path.resolve(__dirname))
 
 describe('AdminService', () => {
   let healthCheckStub
+  let getIdentityStub
 
   let GrpcMethod
   let register
@@ -29,7 +30,8 @@ describe('AdminService', () => {
           AdminService: {
             service: 'fakeService'
           },
-          HealthCheckResponse: sinon.stub()
+          HealthCheckResponse: sinon.stub(),
+          GetIdentityResponse: sinon.stub()
         }
       }
     }
@@ -53,6 +55,7 @@ describe('AdminService', () => {
 
     healthCheckStub = sinon.stub()
     AdminService.__set__('healthCheck', healthCheckStub)
+    AdminService.__set__('getIdentity', getIdentityStub)
   })
 
   beforeEach(() => {
@@ -142,6 +145,52 @@ describe('AdminService', () => {
 
     it('passes in the response', () => {
       expect(callArgs[3]).to.be.eql({ HealthCheckResponse: proto.broker.rpc.HealthCheckResponse })
+    })
+  })
+
+  describe('#getIdentity', () => {
+    let callOrder = 1
+    let callArgs
+
+    beforeEach(() => {
+      callArgs = GrpcMethod.args[callOrder]
+    })
+
+    it('exposes an implementation', () => {
+      expect(server.implementation).to.have.property('getIdentity')
+      expect(server.implementation.getIdentity).to.be.a('function')
+    })
+
+    it('creates a GrpcMethod', () => {
+      expect(GrpcMethod).to.have.been.called()
+      expect(GrpcMethod).to.have.been.calledWithNew()
+      expect(server.implementation.getIdentity).to.be.equal(fakeRegistered)
+    })
+
+    it('provides the method', () => {
+      expect(callArgs[0]).to.be.equal(getIdentityStub)
+    })
+
+    it('provides a message id', () => {
+      expect(callArgs[1]).to.be.equal('[AdminService:getIdentity]')
+    })
+
+    describe('request options', () => {
+      it('passes in the logger', () => {
+        expect(callArgs[2]).to.have.property('logger', logger)
+      })
+
+      it('passes in a relayer', () => {
+        expect(callArgs[2]).to.have.property('relayer', relayer)
+      })
+
+      it('passes in auth', () => {
+        expect(callArgs[2]).to.have.property('auth', auth)
+      })
+    })
+
+    it('passes in the response', () => {
+      expect(callArgs[3]).to.be.eql({ GetIdentityResponse: proto.broker.rpc.GetIdentityResponse })
     })
   })
 })

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -90,6 +90,14 @@ message HealthCheckResponse {
 }
 
 /**
+ * GetIdentityResponse provides the Public Key of the BrokerDaemon
+ */
+message GetIdentityResponse {
+  // The public key of the BrokerDaemon used to authenticate interactions with the Relayer
+  string public_key = 1;
+}
+
+/**
  * The AdminService performs administrative tasks on the BrokerDaemon.
  *
  * ```javascript
@@ -145,6 +153,38 @@ service AdminService {
   rpc HealthCheck (google.protobuf.Empty) returns (HealthCheckResponse) {
     option (google.api.http) = {
       get: "/v1/admin/healthcheck"
+    };
+  }
+
+  /**
+   * GetIdentity returns the Public Key the BrokerDaemon uses to interact with the Relayer.
+   *
+   * ```javascript
+   * const deadline = new Date().setSeconds(new Date().getSeconds() + 5)
+   * adminService.getIdentity({}, { deadline }, (err, { publicKey }) => {
+   *   if (err) return console.error(err)
+   *   console.log({ publicKey })
+   * })
+   * ```
+   *
+   * ```shell
+   * > sparkswap id
+   * ```
+   *
+   * > The above command will print:
+   *
+   * ```javascript
+   * {
+   *   "publicKey": ""
+   * }
+   * ```
+   *
+   * ```shell
+   * ```
+   */
+  rpc GetIdentity (google.protobuf.Empty) returns (GetIdentityResponse) {
+    option (google.api.http) = {
+      get: "/v1/admin/identity"
     };
   }
 }

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -175,11 +175,15 @@ service AdminService {
    *
    * ```javascript
    * {
-   *   "publicKey": ""
+   *   "publicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEVbt2b1JHw7Kg2I9340n8jA5ycbyH\neucZq00VNANqsoUSfw2iqRkM4OLVdUZ22YGR+mN/0CgIIwiWxNE6g58V+g==\n-----END PUBLIC KEY-----\n"
    * }
    * ```
    *
    * ```shell
+   * -----BEGIN PUBLIC KEY-----
+   * MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEVbt2b1JHw7Kg2I9340n8jA5ycbyH
+   * eucZq00VNANqsoUSfw2iqRkM4OLVdUZ22YGR+mN/0CgIIwiWxNE6g58V+g==
+   * -----END PUBLIC KEY-----
    * ```
    */
   rpc GetIdentity (google.protobuf.Empty) returns (GetIdentityResponse) {


### PR DESCRIPTION
## Description
This PR exposes a CLI command to retrieve the broker's public key used for interacting with the Relayer.

## Todos
- [x] Tests
- [x] Documentation