### PR TITLE
make eventHandler per instance of stateMachine instead of singleton

### DIFF
--- a/broker-daemon/state-machines/plugins/state-machine-events.js
+++ b/broker-daemon/state-machines/plugins/state-machine-events.js
@@ -10,10 +10,15 @@ class StateMachineEvents extends StateMachinePlugin {
    * Setup for configuration of StateMachineEvents plugin
    * @returns {StateMachineEvents}
    */
-  constructor () {
-    super()
 
-    this.eventHandler = new EventEmitter()
+  /**
+   * Set the event handler on the instance
+   * @param  {Object} instance State machine instance being initialized
+   * @return {void}
+   */
+  init (instance) {
+    super.init(instance)
+    instance.eventHandler = new EventEmitter()
   }
 
   /**
@@ -21,8 +26,6 @@ class StateMachineEvents extends StateMachinePlugin {
    * to external workers (BlockOrderWorker)
    */
   get observers () {
-    const plugin = this
-
     return {
       /**
        * Emit an event before a transition (prefixed by 'before:')
@@ -31,7 +34,8 @@ class StateMachineEvents extends StateMachinePlugin {
        * @return {void}
        */
       onBeforeTransition: function (lifecycle) {
-        plugin.eventHandler.emit(`before:${lifecycle.transition}`)
+        const stateMachineInstance = this
+        stateMachineInstance.eventHandler.emit(`before:${lifecycle.transition}`)
       },
       /**
        * Emit an event after a transition
@@ -40,7 +44,8 @@ class StateMachineEvents extends StateMachinePlugin {
        * @returns {void}
        */
       onAfterTransition: function (lifecycle) {
-        plugin.eventHandler.emit(lifecycle.transition)
+        const stateMachineInstance = this
+        stateMachineInstance.eventHandler.emit(lifecycle.transition)
       }
     }
   }
@@ -49,11 +54,15 @@ class StateMachineEvents extends StateMachinePlugin {
    * Alias methods on a StateMachine for event handling
    */
   get methods () {
-    const { eventHandler } = this
-
     return {
-      once: (type, cb) => eventHandler.once(type, cb),
-      removeAllListeners: () => eventHandler.removeAllListeners()
+      once: function (type, cb) {
+        const stateMachineInstance = this
+        stateMachineInstance.eventHandler.once(type, cb)
+      },
+      removeAllListeners: function () {
+        const stateMachineInstance = this
+        stateMachineInstance.eventHandler.removeAllListeners()
+      }
     }
   }
 }

--- a/broker-daemon/state-machines/plugins/state-machine-events.spec.js
+++ b/broker-daemon/state-machines/plugins/state-machine-events.spec.js
@@ -2,21 +2,35 @@ const path = require('path')
 const { expect, sinon, rewire } = require('test/test-helper')
 
 const StateMachineEvents = rewire(path.resolve(__dirname, 'state-machine-events'))
+const StateMachine = require('../state-machine')
 
 describe('StateMachineEvents', () => {
-  describe('constructor', () => {
-    it('has an event handler', () => {
-      const sme = new StateMachineEvents()
-      expect(sme).to.have.property('eventHandler')
+  describe('init', () => {
+    let stateMachine
+    let Machine
+
+    before(() => {
+      Machine = StateMachine.factory({
+        plugins: [
+          new StateMachineEvents()
+        ]
+      })
+
+      stateMachine = new Machine()
+    })
+
+    it('should set an eventHandler on the instance of the state machine', () => {
+      expect(stateMachine).to.have.property('eventHandler')
     })
   })
 
   describe('observers', () => {
     let emitStub
     let removeListenersStub
-    let stateMachine
-    let observers
     let eventEmitterStub
+    let stateMachineEvents
+    let Machine
+    let stateMachine
 
     beforeEach(() => {
       emitStub = sinon.stub()
@@ -26,33 +40,31 @@ describe('StateMachineEvents', () => {
       eventEmitterStub.prototype.removeAllListeners = removeListenersStub
 
       StateMachineEvents.__set__('EventEmitter', eventEmitterStub)
-
-      stateMachine = new StateMachineEvents()
-    })
-
-    beforeEach(() => {
-      observers = stateMachine.observers
+      stateMachineEvents = new StateMachineEvents()
+      Machine = StateMachine.factory()
+      stateMachine = new Machine()
+      stateMachineEvents.init(stateMachine)
     })
 
     it('should have property onAfterTransition', () => {
-      expect(observers).to.have.property('onAfterTransition')
+      expect(stateMachineEvents.observers).to.have.property('onAfterTransition')
     })
 
     it('should emit an event on each transition', () => {
       const lifecycle = { transition: 'start' }
-      const { onAfterTransition } = observers
-      onAfterTransition(lifecycle)
+      const { onAfterTransition } = stateMachineEvents.observers
+      onAfterTransition.call(stateMachine, lifecycle)
       expect(emitStub).to.have.been.calledWith(lifecycle.transition)
     })
 
     it('should have property onBeforeTransition', () => {
-      expect(observers).to.have.property('onBeforeTransition')
+      expect(stateMachineEvents.observers).to.have.property('onBeforeTransition')
     })
 
     it('should emit an event before each transition', () => {
       const lifecycle = { transition: 'start' }
-      const { onBeforeTransition } = observers
-      onBeforeTransition(lifecycle)
+      const { onBeforeTransition } = stateMachineEvents.observers
+      onBeforeTransition.call(stateMachine, lifecycle)
       expect(emitStub).to.have.been.calledWith(`before:${lifecycle.transition}`)
     })
   })
@@ -63,6 +75,8 @@ describe('StateMachineEvents', () => {
     let methods
     let eventEmitterStub
     let removeAllListenersStub
+    let stateMachineEvents
+    let Machine
 
     beforeEach(() => {
       onceStub = sinon.stub()
@@ -73,11 +87,11 @@ describe('StateMachineEvents', () => {
 
       StateMachineEvents.__set__('EventEmitter', eventEmitterStub)
 
-      stateMachine = new StateMachineEvents()
-    })
-
-    beforeEach(() => {
-      methods = stateMachine.methods
+      stateMachineEvents = new StateMachineEvents()
+      Machine = StateMachine.factory()
+      stateMachine = new Machine()
+      stateMachineEvents.init(stateMachine)
+      methods = stateMachineEvents.methods
     })
 
     it('should have property once', () => {
@@ -89,7 +103,7 @@ describe('StateMachineEvents', () => {
         const cb = sinon.stub()
         const type = 'cancel'
         const { once: stateMachineEventsOnce } = methods
-        stateMachineEventsOnce(type, cb)
+        stateMachineEventsOnce.call(stateMachine, type, cb)
         expect(onceStub).to.have.been.calledWith(type, cb)
       })
     })
@@ -97,7 +111,7 @@ describe('StateMachineEvents', () => {
     describe('#removeAllListeners', () => {
       it('should call an event emitters method', () => {
         const { removeAllListeners: stateMachineEventsRemove } = methods
-        stateMachineEventsRemove()
+        stateMachineEventsRemove.call(stateMachine)
         expect(removeAllListenersStub).to.have.been.calledOnce()
       })
     })


### PR DESCRIPTION
## Description
We had a bug where the eventHandler was a singleton instead of per instance of a state machine, this made it so removing listeners from one state machine removed the listeners from all state machines.

This fix makes eventHandlers per instance. 

## Related PRs
List related PRs if applicable


## Todos
- [x] Tests
- [x] Documentation
- [ ] Link to Trello
