### PR TITLE
FEATURE - Add force release for channels

### DIFF
--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -547,7 +547,7 @@ module.exports = (program) => {
     .option('--market [marketName]', 'Relevant market name', validations.isMarketName)
     .command(`wallet ${SUPPORTED_COMMANDS.RELEASE}`, 'Closes channels open on the specified market')
     .option('--market <marketName>', 'Relevant market name', validations.isMarketName, null, true)
-    .option('--force [force]', 'Relevant market name', null, false)
+    .option('--force', 'Relevant market name', null, false)
     .command(`wallet ${SUPPORTED_COMMANDS.WITHDRAW}`, 'Withdraws specified amount of coin from wallet')
     .argument('<symbol>', `Supported currencies: ${SUPPORTED_SYMBOLS.join('/')}`)
     .argument('<amount>', 'Amount of currency to commit to the relayer', validations.isDecimal)

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -300,16 +300,37 @@ function formatBalance (balance, status) {
  * @return {Void}
  */
 async function release (args, opts, logger) {
-  const { rpcAddress, market } = opts
+  const { market } = args
+  const { rpcAddress, force } = opts
 
   try {
     const client = new BrokerDaemonClient(rpcAddress)
 
-    const answer = await askQuestion(`Are you sure you want to close all channels you have open on the ${market} market? (Y/N)`)
+    let question
+    if (force) {
+      question = `Are you sure you want to FORCE the release of all channels you have open on the ${market} market? (Y/N)`
+    } else {
+      question = `Are you sure you want to release all channels you have open on the ${market} market? (Y/N)`
+    }
+
+    const answer = await askQuestion(question)
 
     if (!ACCEPTED_ANSWERS.includes(answer.toLowerCase())) return
 
-    await client.walletService.releaseChannels({market})
+    try {
+      await client.walletService.releaseChannels({ market, force })
+    } catch (e) {
+      logger.info(`Failed to release payment channels for ${market}`.red)
+
+      if (!force) {
+        logger.info('You can force the release of funds using the `--force` option, however')
+        logger.info('this has the potential to lock your funds for an extended period of time')
+        logger.info('and cost additional fees')
+      }
+
+      throw e
+    }
+
     logger.info(`Successfully closed channels on ${market} market!`)
   } catch (e) {
     logger.error(handleError(e))
@@ -424,7 +445,10 @@ module.exports = (program) => {
     .argument('[sub-arguments...]')
     .option('--rpc-address [rpc-address]', 'Location of the RPC server to use.', validations.isHost)
     .option('--market [marketName]', 'Relevant market name', validations.isMarketName)
-    .option('--wallet-address [address]', 'Address to send the coins to', validations.isHost)
+    // We are required to add all options before the `action` portion the parameter
+    // will not be received in the `opts` object
+    .option('--wallet-address [address]', 'used in sparkswap withdraw ONLY')
+    .option('--force [force]', 'used in sparkswap release ONLY', null, false)
     .action(async (args, opts, logger) => {
       const { command, subArguments } = args
       const { market } = opts
@@ -472,7 +496,7 @@ module.exports = (program) => {
           opts.market = validations.isMarketName(market)
           return networkStatus(args, opts, logger)
         case SUPPORTED_COMMANDS.RELEASE:
-          opts.market = validations.isMarketName(market)
+          args.market = validations.isMarketName(market)
           return release(args, opts, logger)
         case SUPPORTED_COMMANDS.WITHDRAW:
           symbol = symbol.toUpperCase()
@@ -521,7 +545,8 @@ module.exports = (program) => {
     .command(`wallet ${SUPPORTED_COMMANDS.NETWORK_STATUS}`, 'Payment Channel Network status for trading in different markets')
     .option('--market [marketName]', 'Relevant market name', validations.isMarketName)
     .command(`wallet ${SUPPORTED_COMMANDS.RELEASE}`, 'Closes channels open on the specified market')
-    .option('--market [marketName]', 'Relevant market name', validations.isMarketName)
+    .option('--market <marketName>', 'Relevant market name', validations.isMarketName, null, true)
+    .option('--force [force]', 'Relevant market name', null, false)
     .command(`wallet ${SUPPORTED_COMMANDS.WITHDRAW}`, 'Withdraws specified amount of coin from wallet')
     .argument('<symbol>', `Supported currencies: ${SUPPORTED_SYMBOLS.join('/')}`)
     .argument('<amount>', 'Amount of currency to commit to the relayer', validations.isDecimal)

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -449,7 +449,7 @@ module.exports = (program) => {
     // hook has been added in caporal. If the option is omitted, the subcommand will
     // not receive the variable in the `opts` object
     .option('--wallet-address [address]', 'used in sparkswap withdraw ONLY')
-    .option('--force', 'used in sparkswap release ONLY', null, false)
+    .option('--force', 'Force close all channels. This options is only used in the sparkswap release command', null, false)
     .action(async (args, opts, logger) => {
       const { command, subArguments } = args
       const { market } = opts
@@ -547,7 +547,7 @@ module.exports = (program) => {
     .option('--market [marketName]', 'Relevant market name', validations.isMarketName)
     .command(`wallet ${SUPPORTED_COMMANDS.RELEASE}`, 'Closes channels open on the specified market')
     .option('--market <marketName>', 'Relevant market name', validations.isMarketName, null, true)
-    .option('--force', 'Relevant market name', null, false)
+    .option('--force', 'Force close all channels', null, false)
     .command(`wallet ${SUPPORTED_COMMANDS.WITHDRAW}`, 'Withdraws specified amount of coin from wallet')
     .argument('<symbol>', `Supported currencies: ${SUPPORTED_SYMBOLS.join('/')}`)
     .argument('<amount>', 'Amount of currency to commit to the relayer', validations.isDecimal)

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -320,7 +320,7 @@ async function release (args, opts, logger) {
     try {
       await client.walletService.releaseChannels({ market, force })
     } catch (e) {
-      logger.info(`Failed to release payment channels for ${market}`.red)
+      logger.error(`Failed to release payment channels for ${market}`.red)
 
       if (!force) {
         logger.info('You can force the release of funds using the `--force` option, however')

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -449,7 +449,7 @@ module.exports = (program) => {
     // hook has been added in caporal. If the option is omitted, the subcommand will
     // not receive the variable in the `opts` object
     .option('--wallet-address [address]', 'used in sparkswap withdraw ONLY')
-    .option('--force [force]', 'used in sparkswap release ONLY', null, false)
+    .option('--force', 'used in sparkswap release ONLY', null, false)
     .action(async (args, opts, logger) => {
       const { command, subArguments } = args
       const { market } = opts

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -445,8 +445,9 @@ module.exports = (program) => {
     .argument('[sub-arguments...]')
     .option('--rpc-address [rpc-address]', 'Location of the RPC server to use.', validations.isHost)
     .option('--market [marketName]', 'Relevant market name', validations.isMarketName)
-    // We are required to add all options before the `action` portion the parameter
-    // will not be received in the `opts` object
+    // For each subcommand, we are required to add any `.options` before the `.action`
+    // hook has been added in caporal. If the option is omitted, the subcommand will
+    // not receive the variable in the `opts` object
     .option('--wallet-address [address]', 'used in sparkswap withdraw ONLY')
     .option('--force [force]', 'used in sparkswap release ONLY', null, false)
     .action(async (args, opts, logger) => {

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -921,7 +921,7 @@ message CommitRequest {
 message ReleaseChannelsRequest {
   // Market to close channels on
   string market = 1;
-  // Force channels to close which may result in funds being locked for additional time and fees
+  // Force channels (active, inactive and pending) to close, which may result in funds being locked for additional time and fees
   bool force = 2;
 }
 

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -1148,7 +1148,7 @@ service WalletService {
    * > sparkswap wallet release --market BTC/LTC
    * ```
    *
-   * > Additionally, you can pass a `force` flag which will force close channels on the channels
+   * > Additionally, you can pass a `force` flag which will force close channels on a specific market
    *
    * ```javascript
    * walletService.releaseChannels( { market: 'BTC/LTC', force: true }, (err) => {

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -925,6 +925,8 @@ message CommitRequest {
 message ReleaseChannelsRequest {
   // Market to close channels on
   string market = 1;
+  // Force channels to close which may result in funds being locked for additional time and fees
+  bool force = 2;
 }
 
 /**
@@ -1138,11 +1140,10 @@ service WalletService {
    * If you pass in `BTC/LTC` as the market to releaseChannels, closeChannels will be called on both the BTC and LTC engines. If channels were closed,
    * there will an empty response unless an error is encountered.
    *
-   *
    * > The below command has no output, but will throw an error if one is encountered.
    *
    * ```javascript
-   * walletService.releaseChannels( { market: 'BTC/LTC' }, (err, { numChannels }) => {
+   * walletService.releaseChannels( { market: 'BTC/LTC' }, (err) => {
    *   if (err) return console.error(err)
    * })
    * ```
@@ -1150,6 +1151,19 @@ service WalletService {
    * ```shell
    * > sparkswap wallet release --market BTC/LTC
    * ```
+   *
+   * > Additionally, you can pass a `force` flag which will force close channels on the channels
+   *
+   * ```javascript
+   * walletService.releaseChannels( { market: 'BTC/LTC', force: true }, (err) => {
+   *   if (err) return console.error(err)
+   * })
+   * ```
+   *
+   * ```shell
+   * > sparkswap wallet release --market BTC/LTC --force
+   * ```
+   *
    */
   rpc ReleaseChannels (ReleaseChannelsRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -921,7 +921,7 @@ message CommitRequest {
 message ReleaseChannelsRequest {
   // Market to close channels on
   string market = 1;
-  // Force channels to close which may result in funds being locked for additional time and fees
+  // Force channels (active, inactive and pending) to close, which may result in funds being locked for additional time and fees
   bool force = 2;
 }
 

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -1148,7 +1148,7 @@ service WalletService {
    * > sparkswap wallet release --market BTC/LTC
    * ```
    *
-   * > Additionally, you can pass a `force` flag which will force close channels on the channels
+   * > Additionally, you can pass a `force` flag which will force close channels on a specific market
    *
    * ```javascript
    * walletService.releaseChannels( { market: 'BTC/LTC', force: true }, (err) => {

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -925,6 +925,8 @@ message CommitRequest {
 message ReleaseChannelsRequest {
   // Market to close channels on
   string market = 1;
+  // Force channels to close which may result in funds being locked for additional time and fees
+  bool force = 2;
 }
 
 /**
@@ -1138,11 +1140,10 @@ service WalletService {
    * If you pass in `BTC/LTC` as the market to releaseChannels, closeChannels will be called on both the BTC and LTC engines. If channels were closed,
    * there will an empty response unless an error is encountered.
    *
-   *
    * > The below command has no output, but will throw an error if one is encountered.
    *
    * ```javascript
-   * walletService.releaseChannels( { market: 'BTC/LTC' }, (err, { numChannels }) => {
+   * walletService.releaseChannels( { market: 'BTC/LTC' }, (err) => {
    *   if (err) return console.error(err)
    * })
    * ```
@@ -1150,6 +1151,19 @@ service WalletService {
    * ```shell
    * > sparkswap wallet release --market BTC/LTC
    * ```
+   *
+   * > Additionally, you can pass a `force` flag which will force close channels on the channels
+   *
+   * ```javascript
+   * walletService.releaseChannels( { market: 'BTC/LTC', force: true }, (err) => {
+   *   if (err) return console.error(err)
+   * })
+   * ```
+   *
+   * ```shell
+   * > sparkswap wallet release --market BTC/LTC --force
+   * ```
+   *
    */
   rpc ReleaseChannels (ReleaseChannelsRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4105,8 +4105,8 @@
       }
     },
     "lnd-engine": {
-      "version": "github:sparkswap/lnd-engine#5f12dc8b6b89f46e425a8cf93732308616e08584",
-      "from": "github:sparkswap/lnd-engine#5f12dc8b6b89f46e425a8cf93732308616e08584",
+      "version": "github:sparkswap/lnd-engine#abfb0053691b064b5f77eafe08911da5f38e397f",
+      "from": "github:sparkswap/lnd-engine",
       "requires": {
         "@grpc/proto-loader": "0.3.0",
         "big.js": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "level": "3.0.1",
     "level-live-stream": "1.4.12",
     "level-sublevel": "6.6.1",
-    "lnd-engine": "sparkswap/lnd-engine#5f12dc8b6b89f46e425a8cf93732308616e08584",
+    "lnd-engine": "sparkswap/lnd-engine",
     "nano-seconds": "1.2.2",
     "pm2": "2.10.3",
     "protocol-buffers-schema": "3.3.2",


### PR DESCRIPTION
## Description
This PR adds a `force` flag to the `sparkswap wallet release` command that allows the user to force close all channels that are open w/ the exchange.

The Broker may run into an issue where it has open channels with the relayer, however the relayer may be down or offline. We want the broker to be able to close those channels HOWEVER the only way possible is by forcing the closing of the channel through the engines.

if the call to `sparkswap wallet release` fails, we will prompt the user to the user the `--force` flag if they understand that force releasing could take an extended amount of time AND this may add additional fees to the closing tx of the channel.

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
