### PR TITLE
Cancel outstanding orders on failed block orders

### DIFF
--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -175,6 +175,11 @@ class BlockOrderWorker extends EventEmitter {
     return blockOrder
   }
 
+  /**
+   * Cancels all outstanding orders for the given block order
+   * @param {BlockOrder}
+   * @return {Void}
+   */
   async cancelOutstandingOrders (blockOrder) {
     await blockOrder.populateOrders(this.ordersStore)
 
@@ -268,7 +273,10 @@ class BlockOrderWorker extends EventEmitter {
   async workBlockOrder (blockOrder, targetDepth) {
     this.logger.info('Working block order', { blockOrderId: blockOrder.id })
 
-    if (!blockOrder.isInWorkableState) throw new Error('BlockOrder is not in a state to be worked')
+    if (!blockOrder.isInWorkableState) {
+      this.logger.info('BlockOrder is not in a state to be worked', { blockOrderId: blockOrder.id })
+      return
+    }
 
     const orderbook = this.orderbooks.get(blockOrder.marketName)
 

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -210,7 +210,7 @@ class BlockOrderWorker extends EventEmitter {
     const blockOrder = await BlockOrder.fromStore(this.store, blockOrderId)
 
     try {
-      await this.cancelOutstandingOrders()
+      await this.cancelOutstandingOrders(blockOrder)
     } catch (e) {
       this.logger.error('Failed to cancel all orders for block order: ', { blockOrderId: blockOrder.id, error: e })
       blockOrder.fail()
@@ -252,7 +252,7 @@ class BlockOrderWorker extends EventEmitter {
     const blockOrder = await BlockOrder.fromStore(this.store, blockOrderId)
 
     try {
-      await this.cancelOutstandingOrders()
+      await this.cancelOutstandingOrders(blockOrder)
     } catch (e) {
       this.logger.error('Failed to cancel all orders for block order: ', { blockOrderId: blockOrder.id, error: e })
     }

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -212,7 +212,7 @@ class BlockOrderWorker extends EventEmitter {
     try {
       await this.cancelOutstandingOrders()
     } catch (e) {
-      this.logger.error('Failed to cancel all orders for block order: ', { blockOrderId: blockOrder.id })
+      this.logger.error('Failed to cancel all orders for block order: ', { blockOrderId: blockOrder.id, error: e })
       blockOrder.fail()
       await promisify(this.store.put)(blockOrder.key, blockOrder.value)
       throw e
@@ -254,7 +254,7 @@ class BlockOrderWorker extends EventEmitter {
     try {
       await this.cancelOutstandingOrders()
     } catch (e) {
-      this.logger.error('Failed to cancel all orders for block order: ', { blockOrderId: blockOrder.id })
+      this.logger.error('Failed to cancel all orders for block order: ', { blockOrderId: blockOrder.id, error: e })
     }
 
     blockOrder.fail()

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -574,24 +574,21 @@ describe('BlockOrderWorker', () => {
       expect(worker.cancelOutstandingOrders).to.have.been.calledOnce()
     })
 
-    // it('l', async () => {
-    //   const fakeError = new Error('myerror')
-    //   const fakeId = 'myid'
-    //
-    //   worker.cancelOutstandingOrders.rejects(fakeError)
-    //
-    //   try {
-    //     await worker.cancelBlockOrder(fakeId)
-    //   } catch (e) {
-    //     expect(blockOrderFail).to.have.been.calledOnce()
-    //     expect(store.put).to.have.been.calledOnce()
-    //     expect(store.put).to.have.been.calledWith(blockOrderKey, blockOrderValue)
-    //     expect(e).to.be.eql(fakeError)
-    //     return
-    //   }
-    //
-    //   throw new Error('Expected relayer cancellation to throw an error')
-    // })
+    it('logs error if cancelling outstanding orders fails', async () => {
+      const fakeError = new Error('myerror')
+      const fakeId = 'myid'
+
+      worker.cancelOutstandingOrders.rejects(fakeError)
+
+      try {
+        await worker.cancelBlockOrder(fakeId)
+      } catch (e) {
+        expect(logger.error).to.have.been.calledWith('Failed to cancel all orders for block order: ')
+        return
+      }
+
+      throw new Error('Expected relayer cancellation to throw an error')
+    })
 
     it('updates the block order to failed status', async () => {
       await worker.failBlockOrder(fakeId, fakeErr)

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -556,6 +556,7 @@ describe('BlockOrderWorker', () => {
 
       BlockOrder.fromStore.resolves(fakeBlockOrder)
       worker = new BlockOrderWorker({ orderbooks, store, logger, relayer, engines })
+      worker.cancelOutstandingOrders = sinon.stub().resolves()
       fakeErr = new Error('fake')
       fakeId = 'myid'
     })
@@ -566,6 +567,31 @@ describe('BlockOrderWorker', () => {
       expect(BlockOrder.fromStore).to.have.been.calledOnce()
       expect(BlockOrder.fromStore).to.have.been.calledWith(store, fakeId)
     })
+
+    it('cancels outstanding orders associated with the block order', async () => {
+      await worker.failBlockOrder(fakeId, fakeErr)
+
+      expect(worker.cancelOutstandingOrders).to.have.been.calledOnce()
+    })
+
+    // it('l', async () => {
+    //   const fakeError = new Error('myerror')
+    //   const fakeId = 'myid'
+    //
+    //   worker.cancelOutstandingOrders.rejects(fakeError)
+    //
+    //   try {
+    //     await worker.cancelBlockOrder(fakeId)
+    //   } catch (e) {
+    //     expect(blockOrderFail).to.have.been.calledOnce()
+    //     expect(store.put).to.have.been.calledOnce()
+    //     expect(store.put).to.have.been.calledWith(blockOrderKey, blockOrderValue)
+    //     expect(e).to.be.eql(fakeError)
+    //     return
+    //   }
+    //
+    //   throw new Error('Expected relayer cancellation to throw an error')
+    // })
 
     it('updates the block order to failed status', async () => {
       await worker.failBlockOrder(fakeId, fakeErr)
@@ -652,6 +678,7 @@ describe('BlockOrderWorker', () => {
     let blockOrderValue = blockOrder
     let orders
     let identityStub
+    let blockOrderFail
 
     beforeEach(() => {
       orders = [
@@ -663,15 +690,105 @@ describe('BlockOrderWorker', () => {
         }
       ]
       blockOrderCancel = sinon.stub()
+      blockOrderFail = sinon.stub()
       BlockOrder.fromStore.resolves({
         id: blockOrderId,
         cancel: blockOrderCancel,
         key: blockOrderKey,
         value: blockOrderValue,
+        orders,
+        openOrders: orders,
+        fail: blockOrderFail
+      })
+      identityStub = sinon.stub()
+
+      relayer.makerService = {
+        cancelOrder: sinon.stub().resolves()
+      }
+      relayer.identity = {
+        authorize: identityStub.returns('identity')
+      }
+
+      worker = new BlockOrderWorker({ orderbooks, store, logger, relayer, engines })
+      worker.cancelOutstandingOrders = sinon.stub().resolves()
+    })
+
+    it('retrieves a block order from the store', async () => {
+      const fakeId = 'myid'
+      await worker.cancelBlockOrder(fakeId)
+
+      expect(BlockOrder.fromStore).to.have.been.calledOnce()
+      expect(BlockOrder.fromStore).to.have.been.calledWith(store, fakeId)
+    })
+
+    it('cancels outstanding orders on the relayer', async () => {
+      const fakeId = 'myid'
+      await worker.cancelBlockOrder(fakeId)
+
+      expect(worker.cancelOutstandingOrders).to.have.been.calledOnce()
+    })
+
+    it('fails the block order if relayer cancellation fails', async () => {
+      const fakeError = new Error('myerror')
+      const fakeId = 'myid'
+
+      worker.cancelOutstandingOrders.rejects(fakeError)
+
+      try {
+        await worker.cancelBlockOrder(fakeId)
+      } catch (e) {
+        expect(blockOrderFail).to.have.been.calledOnce()
+        expect(store.put).to.have.been.calledOnce()
+        expect(store.put).to.have.been.calledWith(blockOrderKey, blockOrderValue)
+        expect(e).to.be.eql(fakeError)
+        return
+      }
+
+      throw new Error('Expected relayer cancellation to throw an error')
+    })
+
+    it('updates the block order to cancelled status', async () => {
+      const fakeId = 'myid'
+      await worker.cancelBlockOrder(fakeId)
+
+      expect(blockOrderCancel).to.have.been.calledOnce()
+    })
+
+    it('saves the updated block order with the cancelled status', async () => {
+      const fakeId = 'myid'
+      await worker.cancelBlockOrder(fakeId)
+
+      expect(store.put).to.have.been.calledOnce()
+      expect(store.put).to.have.been.calledWith(blockOrderKey, blockOrderValue)
+    })
+  })
+
+  describe('#cancelOutstandingOrders', () => {
+    let worker
+    let blockOrder
+    let blockOrderId = 'fakeId'
+    let blockOrderKey = blockOrderId
+    let blockOrderValue = blockOrder
+    let orders
+    let identityStub
+
+    beforeEach(() => {
+      orders = [
+        {
+          order: {
+            orderId: 'someId'
+          },
+          state: 'created'
+        }
+      ]
+      blockOrder = {
+        id: blockOrderId,
+        key: blockOrderKey,
+        value: blockOrderValue,
         populateOrders: sinon.stub().resolves(),
         orders,
         openOrders: orders
-      })
+      }
       identityStub = sinon.stub()
 
       relayer.makerService = {
@@ -684,61 +801,22 @@ describe('BlockOrderWorker', () => {
       worker = new BlockOrderWorker({ orderbooks, store, logger, relayer, engines })
     })
 
-    it('retrieves a block order from the store', async () => {
-      const fakeId = 'myid'
-      await worker.cancelBlockOrder(fakeId)
-
-      expect(BlockOrder.fromStore).to.have.been.calledOnce()
-      expect(BlockOrder.fromStore).to.have.been.calledWith(store, fakeId)
-    })
-
-    it('cancels all of the orders on the relayer', async () => {
-      const fakeId = 'myid'
-
-      await worker.cancelBlockOrder(fakeId)
-
-      expect(relayer.makerService.cancelOrder).to.have.been.calledOnce()
-      expect(relayer.makerService.cancelOrder).to.have.been.calledWith(sinon.match({ orderId: orders[0].order.orderId }))
-    })
-
-    it('fails the block order if relayer cancellation fails', async () => {
-      const fakeError = new Error('myerror')
-      const fakeId = 'myid'
-
-      worker.failBlockOrder = sinon.stub()
-      relayer.makerService.cancelOrder.rejects(fakeError)
-
-      try {
-        await worker.cancelBlockOrder(fakeId)
-      } catch (e) {
-        expect(e).to.be.eql(fakeError)
-        expect(worker.failBlockOrder).to.have.been.calledOnce()
-        expect(worker.failBlockOrder).to.have.been.calledWith(fakeId, fakeError)
-        return
-      }
-
-      throw new Error('Expected relayer cancellation to throw an error')
-    })
-
-    it('updates the block order to failed status', async () => {
-      const fakeId = 'myid'
-      await worker.cancelBlockOrder(fakeId)
-
-      expect(blockOrderCancel).to.have.been.calledOnce()
-    })
-
-    it('saves the updated block order', async () => {
-      const fakeId = 'myid'
-      await worker.cancelBlockOrder(fakeId)
-
-      expect(store.put).to.have.been.calledOnce()
-      expect(store.put).to.have.been.calledWith(blockOrderKey, blockOrderValue)
+    it('populates orders for the blockOrder', async () => {
+      await worker.cancelOutstandingOrders(blockOrder)
+      expect(blockOrder.populateOrders).to.have.been.calledWith(worker.ordersStore)
     })
 
     it('authorizes the request', async () => {
       const orderId = orders[0].order.orderId
-      await worker.cancelBlockOrder(orderId)
+      await worker.cancelOutstandingOrders(blockOrder)
       expect(relayer.identity.authorize).to.have.been.calledWith(orderId)
+    })
+
+    it('cancels all of the orders on the relayer', async () => {
+      await worker.cancelOutstandingOrders(blockOrder)
+
+      expect(relayer.makerService.cancelOrder).to.have.been.calledOnce()
+      expect(relayer.makerService.cancelOrder).to.have.been.calledWith(sinon.match({ orderId: orders[0].order.orderId }))
     })
   })
 
@@ -750,8 +828,20 @@ describe('BlockOrderWorker', () => {
       worker = new BlockOrderWorker({ orderbooks, store, logger, relayer, engines })
       blockOrder = {
         marketName: 'BTC/LTC',
-        price: Big('1000')
+        price: Big('1000'),
+        isInWorkableState: true
       }
+    })
+
+    it('returns early if blockOrder is not in a state to be worked', async () => {
+      blockOrder.isInWorkableState = false
+      worker.workMarketBlockOrder = sinon.stub().resolves()
+      worker.workLimitBlockOrder = sinon.stub().resolves()
+
+      await worker.workBlockOrder(blockOrder, Big('100'))
+
+      expect(worker.workMarketBlockOrder).to.not.have.been.called()
+      expect(worker.workLimitBlockOrder).to.not.have.been.called()
     })
 
     it('errors if the market is not supported', () => {

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -572,6 +572,7 @@ describe('BlockOrderWorker', () => {
       await worker.failBlockOrder(fakeId, fakeErr)
 
       expect(worker.cancelOutstandingOrders).to.have.been.calledOnce()
+      expect(worker.cancelOutstandingOrders).to.have.been.calledWith(fakeBlockOrder)
     })
 
     it('logs error if cancelling outstanding orders fails', async () => {
@@ -676,6 +677,7 @@ describe('BlockOrderWorker', () => {
     let orders
     let identityStub
     let blockOrderFail
+    let fakeBlockOrder
 
     beforeEach(() => {
       orders = [
@@ -688,7 +690,7 @@ describe('BlockOrderWorker', () => {
       ]
       blockOrderCancel = sinon.stub()
       blockOrderFail = sinon.stub()
-      BlockOrder.fromStore.resolves({
+      fakeBlockOrder = {
         id: blockOrderId,
         cancel: blockOrderCancel,
         key: blockOrderKey,
@@ -696,7 +698,8 @@ describe('BlockOrderWorker', () => {
         orders,
         openOrders: orders,
         fail: blockOrderFail
-      })
+      }
+      BlockOrder.fromStore.resolves(fakeBlockOrder)
       identityStub = sinon.stub()
 
       relayer.makerService = {
@@ -723,6 +726,7 @@ describe('BlockOrderWorker', () => {
       await worker.cancelBlockOrder(fakeId)
 
       expect(worker.cancelOutstandingOrders).to.have.been.calledOnce()
+      expect(worker.cancelOutstandingOrders).to.have.been.calledWith(fakeBlockOrder)
     })
 
     it('fails the block order if relayer cancellation fails', async () => {

--- a/broker-daemon/models/block-order.js
+++ b/broker-daemon/models/block-order.js
@@ -239,6 +239,14 @@ class BlockOrder {
   }
 
   /**
+  * get boolean for if the blockOrder is an ask
+  * @return {Boolean}
+   */
+  get isInWorkableState () {
+    return this.status === BlockOrder.STATUSES.ACTIVE
+  }
+
+  /**
    * Move the block order to a failed status
    * @return {BlockOrder} Modified block order instance
    */

--- a/broker-daemon/models/block-order.js
+++ b/broker-daemon/models/block-order.js
@@ -239,7 +239,7 @@ class BlockOrder {
   }
 
   /**
-  * get boolean for if the blockOrder is an ask
+  * get boolean for if the blockOrder is an a state to be worked
   * @return {Boolean}
    */
   get isInWorkableState () {

--- a/broker-daemon/models/block-order.spec.js
+++ b/broker-daemon/models/block-order.spec.js
@@ -717,6 +717,16 @@ describe('BlockOrder', () => {
       })
     })
 
+    describe('get isInWorkableState', () => {
+      it('returns true if blockOrder is active', () => {
+        expect(blockOrder).to.have.property('isInWorkableState', true)
+      })
+
+      it('returns false if order is not active', () => {
+        blockOrder.status = 'CANCELLED'
+        expect(blockOrder).to.have.property('isInWorkableState', false)
+      })
+    })
     describe('get activeFills', () => {
       let fills
       let createdFill


### PR DESCRIPTION
## Description
We want to cancel all outstanding orders associated with a failed block order. Currently we do this for cancelled orders. We also should not try to work a block order if it is not in an active state.

- Cancel outstanding orders if we are failing the block orders
- Do not call failBlockOrder from cancelBlockOrder, just directly fail the blockOrder if cancelling the outstanding orders failed to avoid a cycle.
- Check the status of a blockOrder before working it

## Related PRs
List related PRs if applicable


## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
