### PR TITLE
FIX - Wallet balances resilience

### DIFF
--- a/broker-cli/broker-daemon-client/index.js
+++ b/broker-cli/broker-daemon-client/index.js
@@ -67,7 +67,7 @@ class BrokerDaemonClient {
 
     if (this.disableAuth) {
       // TODO: Eventually allow broker daemon client to use the cli's logger
-      console.warn('`disableAuth` is set to true. The CLI will try to connect to the daemon without SSL/TLS'.yellow)
+      console.warn('\n`disableAuth` is set to true. The CLI will try to connect to the daemon without SSL/TLS\n'.yellow)
       this.credentials = grpc.credentials.createInsecure()
     } else {
       if (!this.username) throw new Error('No username is specified for authentication')

--- a/broker-cli/broker-daemon-client/index.js
+++ b/broker-cli/broker-daemon-client/index.js
@@ -67,7 +67,7 @@ class BrokerDaemonClient {
 
     if (this.disableAuth) {
       // TODO: Eventually allow broker daemon client to use the cli's logger
-      console.warn('\n`disableAuth` is set to true. The CLI will try to connect to the daemon without SSL/TLS\n'.yellow)
+      console.warn('`disableAuth` is set to true. The CLI will try to connect to the daemon without SSL/TLS'.yellow)
       this.credentials = grpc.credentials.createInsecure()
     } else {
       if (!this.username) throw new Error('No username is specified for authentication')

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -19,6 +19,13 @@ const ACCEPTED_ANSWERS = Object.freeze(['y', 'yes'])
 
 /**
  * @constant
+ * @type {String}
+ * @default
+ */
+const NOT_AVAILABLE = 'Not Available'
+
+/**
+ * @constant
  * @type {Array<string>}
  * @default
  */
@@ -69,12 +76,18 @@ async function balance (args, opts, logger) {
     })
 
     balances.forEach(({ symbol, uncommittedBalance, totalChannelBalance, totalPendingChannelBalance, uncommittedPendingBalance }) => {
+      totalChannelBalance = totalChannelBalance ? totalChannelBalance.green : NOT_AVAILABLE.yellow
+      uncommittedBalance = uncommittedBalance || NOT_AVAILABLE.yellow
+
+      // We fix all pending balances to 8 decimal places due to aesthetics. Since
+      // this balance should only be temporary, we do not care as much about precision
+      totalPendingChannelBalance = totalPendingChannelBalance ? ` (${Big(totalPendingChannelBalance).toFixed(8)})`.grey : ''
+      uncommittedPendingBalance = uncommittedPendingBalance ? ` (${Big(uncommittedPendingBalance).toFixed(8)})`.grey : ''
+
       balancesTable.push([
         symbol,
-        // We fix all pending balances to 8 decimal places due to aesthetics. Since
-        // this balance should only be temporary, we do not care as much about precision
-        `${totalChannelBalance.green}` + ` (${Big(totalPendingChannelBalance).toFixed(8)})`.grey,
-        uncommittedBalance + ` (${Big(uncommittedPendingBalance).toFixed(8)})`.grey
+        totalChannelBalance + totalPendingChannelBalance,
+        uncommittedBalance + uncommittedPendingBalance
       ])
     })
 

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -19,13 +19,6 @@ const ACCEPTED_ANSWERS = Object.freeze(['y', 'yes'])
 
 /**
  * @constant
- * @type {String}
- * @default
- */
-const NOT_AVAILABLE = 'Not Available'
-
-/**
- * @constant
  * @type {Array<string>}
  * @default
  */
@@ -76,18 +69,18 @@ async function balance (args, opts, logger) {
     })
 
     balances.forEach(({ symbol, uncommittedBalance, totalChannelBalance, totalPendingChannelBalance, uncommittedPendingBalance }) => {
-      totalChannelBalance = totalChannelBalance ? totalChannelBalance.green : NOT_AVAILABLE.yellow
-      uncommittedBalance = uncommittedBalance || NOT_AVAILABLE.yellow
+      totalChannelBalance = totalChannelBalance ? totalChannelBalance.green : 'Not Available'.yellow
+      uncommittedBalance = uncommittedBalance || 'Not Available'.yellow
 
       // We fix all pending balances to 8 decimal places due to aesthetics. Since
       // this balance should only be temporary, we do not care as much about precision
-      totalPendingChannelBalance = totalPendingChannelBalance ? ` (${Big(totalPendingChannelBalance).toFixed(8)})`.grey : ''
-      uncommittedPendingBalance = uncommittedPendingBalance ? ` (${Big(uncommittedPendingBalance).toFixed(8)})`.grey : ''
+      totalPendingChannelBalance = totalPendingChannelBalance ? `(${Big(totalPendingChannelBalance).toFixed(8)})`.grey : ''
+      uncommittedPendingBalance = uncommittedPendingBalance ? `(${Big(uncommittedPendingBalance).toFixed(8)})`.grey : ''
 
       balancesTable.push([
         symbol,
-        totalChannelBalance + totalPendingChannelBalance,
-        uncommittedBalance + uncommittedPendingBalance
+        `${totalChannelBalance} ${totalPendingChannelBalance}`,
+        `${uncommittedBalance} ${uncommittedPendingBalance}`
       ])
     })
 

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -68,14 +68,23 @@ async function balance (args, opts, logger) {
       style: { head: ['gray'] }
     })
 
-    balances.forEach(({ symbol, uncommittedBalance, totalChannelBalance, totalPendingChannelBalance, uncommittedPendingBalance }) => {
-      totalChannelBalance = totalChannelBalance ? totalChannelBalance.green : 'Not Available'.yellow
-      uncommittedBalance = uncommittedBalance || 'Not Available'.yellow
+    balances.forEach((balance) => {
+      let {
+        symbol,
+        error = null,
+        totalChannelBalance,
+        totalPendingChannelBalance,
+        uncommittedBalance,
+        uncommittedPendingBalance
+      } = balance
+
+      totalChannelBalance = error ? 'Not Available'.yellow : totalChannelBalance.green
+      uncommittedBalance = error ? 'Not Available'.yellow : uncommittedBalance
 
       // We fix all pending balances to 8 decimal places due to aesthetics. Since
       // this balance should only be temporary, we do not care as much about precision
-      totalPendingChannelBalance = totalPendingChannelBalance ? `(${Big(totalPendingChannelBalance).toFixed(8)})`.grey : ''
-      uncommittedPendingBalance = uncommittedPendingBalance ? `(${Big(uncommittedPendingBalance).toFixed(8)})`.grey : ''
+      totalPendingChannelBalance = error ? '' : `(${Big(totalPendingChannelBalance).toFixed(8)})`.grey
+      uncommittedPendingBalance = error ? '' : `(${Big(uncommittedPendingBalance).toFixed(8)})`.grey
 
       balancesTable.push([
         symbol,

--- a/broker-cli/commands/wallet.spec.js
+++ b/broker-cli/commands/wallet.spec.js
@@ -114,7 +114,7 @@ describe('cli wallet', () => {
       }
       balances = [btcBalance, ltcBalance]
 
-      walletBalanceStub = sinon.stub().returns({ balances })
+      walletBalanceStub = sinon.stub().resolves({ balances })
       tablePushStub = sinon.stub()
       tableStub = sinon.stub()
       tableStub.prototype.push = tablePushStub
@@ -125,16 +125,14 @@ describe('cli wallet', () => {
       program.__set__('Table', tableStub)
     })
 
-    beforeEach(async () => {
+    it('calls broker daemon for a wallet balance', async () => {
       await balance(args, opts, logger)
-    })
-
-    it('calls broker daemon for a wallet balance', () => {
       expect(daemonStub).to.have.been.calledWith(rpcAddress)
       expect(walletBalanceStub).to.have.been.calledOnce()
     })
 
-    it('adds a correct balance for BTC', () => {
+    it('adds a correct balance for BTC', async () => {
+      await balance(args, opts, logger)
       const expectedResult = ['BTC', '0.0000200000000000', '0.000100000000000']
       const result = tablePushStub.args[0][0]
       // Since the text in the result contains colors (non-TTY) we have to use
@@ -147,22 +145,54 @@ describe('cli wallet', () => {
       })
     })
 
-    it('adds a correct balance for LTC', () => {
+    it('adds a correct balance for LTC', async () => {
+      await balance(args, opts, logger)
       const expectedResult = ['LTC', '0.0000020000000000', '0.0000020000000000']
       const result = tablePushStub.args[1][0]
 
       // Since the text in the result contains colors (non-TTY) we have to use
       // an includes matcher instead of importing the color lib for testing.
-      //
-      // TODO: If this becomes an issue in the future, we can omit the code and cast
-      //       a color on the string
       result.forEach((r, i) => {
         expect(r).to.include(expectedResult[i])
       })
     })
 
-    it('adds balances to the cli table', () => {
+    it('adds balances to the cli table', async () => {
+      await balance(args, opts, logger)
       expect(tablePushStub).to.have.been.calledTwice()
+    })
+
+    context('an unavailable engine', () => {
+      let emptyLtcBalance
+
+      beforeEach(() => {
+        emptyLtcBalance = {
+          symbol: 'LTC',
+          uncommittedBalance: '',
+          totalChannelBalance: '',
+          totalPendingChannelBalance: '',
+          uncommittedPendingBalance: ''
+        }
+        balances = [btcBalance, emptyLtcBalance]
+
+        walletBalanceStub.resolves({ balances })
+      })
+
+      beforeEach(async () => {
+        await balance(args, opts, logger)
+      })
+
+      it('adds a `Not Available` placeholder', () => {
+        const expectedResult = ['LTC', 'Not Available', 'Not Available']
+        const result = tablePushStub.args[1][0]
+
+        // Since the text in the result contains colors (non-TTY) we have to use
+        // an includes matcher instead of importing the color lib for testing.
+        result.forEach((r, i) => {
+          expect(r).to.include(expectedResult[i])
+        })
+        expect(tablePushStub).to.have.been.calledTwice()
+      })
     })
   })
 

--- a/broker-cli/commands/wallet.spec.js
+++ b/broker-cli/commands/wallet.spec.js
@@ -100,6 +100,7 @@ describe('cli wallet', () => {
       logger = { info: sinon.stub(), error: sinon.stub() }
       btcBalance = {
         symbol,
+        error: '',
         uncommittedBalance: '0.0001000000000000',
         totalChannelBalance: '0.0000200000000000',
         totalPendingChannelBalance: '0.0000100000000000',
@@ -107,6 +108,7 @@ describe('cli wallet', () => {
       }
       ltcBalance = {
         symbol: 'LTC',
+        error: '',
         uncommittedBalance: '0.0000020000000000',
         totalChannelBalance: '0.0000020000000000',
         totalPendingChannelBalance: '0.0000050000000000',
@@ -162,12 +164,28 @@ describe('cli wallet', () => {
       expect(tablePushStub).to.have.been.calledTwice()
     })
 
+    it('throws an error for bad data', async () => {
+      const badLtcBalance = {
+        symbol: 'LTC',
+        error: '',
+        uncommittedBalance: '',
+        totalChannelBalance: '',
+        totalPendingChannelBalance: '',
+        uncommittedPendingBalance: ''
+      }
+      balances = [badLtcBalance]
+      walletBalanceStub.resolves({ balances })
+      await balance(args, opts, logger)
+      expect(logger.error).to.have.been.called()
+    })
+
     context('an unavailable engine', () => {
       let emptyLtcBalance
 
       beforeEach(() => {
         emptyLtcBalance = {
           symbol: 'LTC',
+          error: 'Something Happened',
           uncommittedBalance: '',
           totalChannelBalance: '',
           totalPendingChannelBalance: '',
@@ -182,7 +200,7 @@ describe('cli wallet', () => {
         await balance(args, opts, logger)
       })
 
-      it('adds a `Not Available` placeholder', () => {
+      it('adds a `Not Available` placeholder', async () => {
         const expectedResult = ['LTC', 'Not Available', 'Not Available']
         const result = tablePushStub.args[1][0]
 

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -855,6 +855,8 @@ message Balance {
   string total_pending_channel_balance = 4;
   // Balance in the listed currency that is currently in pending closing channels and unconfirmed wallet balance. This is currently in common units (e.g. 0.5 BTC)
   string uncommitted_pending_balance = 5;
+  // Error message if balances are not available
+  string error = 10;
 }
 
 /**

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -1040,6 +1040,8 @@ service WalletService {
    * `totalPendingChannelBalance`, i.e. funds in channels that have finished the funding workflow and are waiting for confirmations for the funding txn, and
    * `uncommittedPendingBalance`, i.e funds in channels that are pending closure or unconfirmed unspent outputs under control of the wallet.
    *
+   * NOTE: If an engine is unavailable, the balances for the particular engine will be empty `''`
+   *
    * ```javascript
    * const deadline = new Date().setSeconds(new Date().getSeconds() + 5)
    * walletService.getBalances({}, { deadline }, (err, { balances }) => {

--- a/broker-daemon/broker-rpc/wallet-service/get-balances.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-balances.js
@@ -39,8 +39,7 @@ async function getEngineBalances ([symbol, engine], logger) {
       engine.getUncommittedPendingBalance()
     ])
   } catch (e) {
-    logger.error(`Failed to get balances for ${symbol} engine`)
-    logger.error(e)
+    logger.error(`Failed to get balances for ${symbol} engine`, { error: e.toString() })
 
     return {
       symbol,

--- a/broker-daemon/broker-rpc/wallet-service/get-balances.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-balances.js
@@ -22,7 +22,7 @@ const BALANCE_PRECISION = 16
  * @return {String} res.totalChannelBalance
  * @return {String} res.totalPendingChannelBalance
  */
-async function getEngineBalances ([symbol, engine], logger) {
+async function getEngineBalances (symbol, engine, logger) {
   const { quantumsPerCommon } = currencyConfig.find(({ symbol: configSymbol }) => configSymbol === symbol) || {}
 
   if (!quantumsPerCommon) {
@@ -72,12 +72,11 @@ async function getBalances ({ logger, engines }, { GetBalancesResponse }) {
   // If an engine is unavailable or offline, we will still receive a response
   // however the values will be blank. This information will then need to be
   // handled by the consumer
-  const enginePromises = Array.from(engines).map(async (engine) => {
-    const [symbol, _] = engine // eslint-disable-line
+  const enginePromises = Array.from(engines).map(async ([symbol, engine]) => {
     let res = { symbol }
 
     try {
-      const balance = await getEngineBalances(engine, logger)
+      const balance = await getEngineBalances(symbol, engine, logger)
       res = Object.assign(res, balance)
     } catch (e) {
       logger.error(`Failed to get engine balances for ${symbol}`)

--- a/broker-daemon/broker-rpc/wallet-service/get-balances.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-balances.js
@@ -77,7 +77,7 @@ async function getBalances ({ logger, engines }, { GetBalancesResponse }) {
 
     try {
       const balance = await getEngineBalances(symbol, engine, logger)
-      res = Object.assign(res, balance)
+      Object.assign(res, balance)
     } catch (e) {
       logger.error(`Failed to get engine balances for ${symbol}`)
       res.error = e.toString()
@@ -95,25 +95,25 @@ async function getBalances ({ logger, engines }, { GetBalancesResponse }) {
   const engineBalances = balances.map((data) => {
     const {
       symbol,
-      error = undefined,
-      uncommittedBalance = undefined,
-      uncommittedPendingBalance = undefined,
-      totalChannelBalance = undefined,
-      totalPendingChannelBalance = undefined
+      error = '',
+      uncommittedBalance = '',
+      uncommittedPendingBalance = '',
+      totalChannelBalance = '',
+      totalPendingChannelBalance = ''
     } = data
 
     // If there is no symbol, then we will not be able to identify which currency
     // information this belongs to which could lead to providing the consumer with
     // incorrect data.
     if (!symbol) {
-      throw new Error('Issue with balances payload. No symbol is available', { data })
+      throw new Error('Issue with balances payload. No symbol is available', data)
     }
 
     // If data is not available AND there is no error, then we are in a weird state
     // and will not be able to provide the consumer of this service with correct
     // balance information.
     if (!error && !uncommittedBalance) {
-      throw new Error('Unexpected response for balance', { data })
+      throw new Error('Unexpected response for balance', data)
     }
 
     return {

--- a/broker-daemon/broker-rpc/wallet-service/get-balances.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-balances.spec.js
@@ -46,8 +46,10 @@ describe('get-balances', () => {
 
     it('gets the balances from a particular engine', async () => {
       await getBalances({ logger, engines }, { GetBalancesResponse })
+      // The next line gets the first engine value
+      const [symbol, engine] = engines.entries().next().value
       expect(balancesStub).to.have.been.calledOnce()
-      expect(balancesStub).to.have.been.calledWith([sinon.match.string, engineStub], logger)
+      expect(balancesStub).to.have.been.calledWith(symbol, engine, logger)
     })
 
     it('returns all balances for the broker daemon', async () => {
@@ -88,7 +90,6 @@ describe('get-balances', () => {
     let totalChannelBalanceStub
     let engineStub
     let symbol
-    let engine
     let getEngineBalances
     let totalPendingChannelBalance
     let uncommittedPendingBalance
@@ -119,24 +120,23 @@ describe('get-balances', () => {
         getTotalPendingChannelBalance: totalPendingBalanceStub,
         getUncommittedPendingBalance: uncommittedPendingBalanceStub
       }
-      engine = [symbol, engineStub]
 
       getEngineBalances = getBalances.__get__('getEngineBalances')
       getBalances.__set__('currencyConfig', currencyConfig)
     })
 
     it('gets the total balance of an engine', async () => {
-      await getEngineBalances(engine, logger)
+      await getEngineBalances(symbol, engineStub, logger)
       expect(uncommittedBalanceStub).to.have.been.calledOnce()
     })
 
     it('gets the total channel balance of an engine', async () => {
-      await getEngineBalances(engine, logger)
+      await getEngineBalances(symbol, engineStub, logger)
       expect(totalChannelBalanceStub).to.have.been.calledOnce()
     })
 
     it('returns balances for an engine', async () => {
-      const res = await getEngineBalances(engine, logger)
+      const res = await getEngineBalances(symbol, engineStub, logger)
       expect(res).to.eql({
         uncommittedBalance: '0.0100000000000000',
         totalChannelBalance: '0.0001000000000000',
@@ -146,8 +146,8 @@ describe('get-balances', () => {
     })
 
     it('returns an error if a currencies config is not found', () => {
-      engine = ['LTC', engineStub]
-      return expect(getEngineBalances(engine, logger)).to.eventually.be.rejectedWith('Currency not supported')
+      const badSymbol = 'LTC'
+      return expect(getEngineBalances(badSymbol, engineStub, logger)).to.eventually.be.rejectedWith('Currency not supported')
     })
   })
 })

--- a/broker-daemon/broker-rpc/wallet-service/get-balances.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-balances.spec.js
@@ -57,8 +57,25 @@ describe('get-balances', () => {
       const expectedBalances = [
         sinon.match({
           symbol: 'BTC',
-          error: undefined,
+          error: '',
           ...balance
+        })
+      ]
+      expect(GetBalancesResponse).to.have.been.calledWith({ balances: expectedBalances })
+    })
+
+    it('returns a blank payload if an engine is unavailable', async () => {
+      const error = 'Engine not available'
+      balancesStub.rejects(error)
+      await getBalances({ logger, engines }, { GetBalancesResponse })
+      const expectedBalances = [
+        sinon.match({
+          symbol: 'BTC',
+          error,
+          uncommittedBalance: '',
+          uncommittedPendingBalance: '',
+          totalChannelBalance: '',
+          totalPendingChannelBalance: ''
         })
       ]
       expect(GetBalancesResponse).to.have.been.calledWith({ balances: expectedBalances })

--- a/broker-daemon/broker-rpc/wallet-service/get-balances.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-balances.spec.js
@@ -57,7 +57,6 @@ describe('get-balances', () => {
     let symbol
     let engine
     let getEngineBalances
-    let res
     let totalPendingChannelBalance
     let uncommittedPendingBalance
     let uncommittedPendingBalanceStub
@@ -93,19 +92,18 @@ describe('get-balances', () => {
       getBalances.__set__('currencyConfig', currencyConfig)
     })
 
-    beforeEach(async () => {
-      res = await getEngineBalances(engine, logger)
-    })
-
-    it('gets the total balance of an engine', () => {
+    it('gets the total balance of an engine', async () => {
+      await getEngineBalances(engine, logger)
       expect(uncommittedBalanceStub).to.have.been.calledOnce()
     })
 
-    it('gets the total channel balance of an engine', () => {
+    it('gets the total channel balance of an engine', async () => {
+      await getEngineBalances(engine, logger)
       expect(totalChannelBalanceStub).to.have.been.calledOnce()
     })
 
-    it('returns balances for an engine', () => {
+    it('returns balances for an engine', async () => {
+      const res = await getEngineBalances(engine, logger)
       expect(res).to.eql({
         symbol,
         uncommittedBalance: '0.0100000000000000',
@@ -118,6 +116,18 @@ describe('get-balances', () => {
     it('returns an error if a currencies config is not found', () => {
       engine = ['LTC', engineStub]
       return expect(getEngineBalances(engine, logger)).to.eventually.be.rejectedWith('Currency not supported')
+    })
+
+    it('returns empty values if an engine is not available', async () => {
+      uncommittedBalanceStub.rejects()
+      const res = await getEngineBalances(engine, logger)
+      expect(res).to.eql({
+        symbol,
+        uncommittedBalance: '',
+        totalChannelBalance: '',
+        totalPendingChannelBalance: '',
+        uncommittedPendingBalance: ''
+      })
     })
   })
 })

--- a/broker-daemon/broker-rpc/wallet-service/get-balances.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-balances.spec.js
@@ -57,7 +57,6 @@ describe('get-balances', () => {
       const expectedBalances = [
         sinon.match({
           symbol: 'BTC',
-          error: '',
           ...balance
         })
       ]
@@ -71,32 +70,10 @@ describe('get-balances', () => {
       const expectedBalances = [
         sinon.match({
           symbol: 'BTC',
-          error,
-          uncommittedBalance: '',
-          uncommittedPendingBalance: '',
-          totalChannelBalance: '',
-          totalPendingChannelBalance: ''
+          error
         })
       ]
       expect(GetBalancesResponse).to.have.been.calledWith({ balances: expectedBalances })
-    })
-
-    context('incorrect engine balance information', () => {
-      it('errors if a symbol is missing', () => {
-        const badEngines = new Map([['', engineStub]])
-        return expect(getBalances({ logger, engines: badEngines }, { GetBalancesResponse })).to.be.rejectedWith('No symbol is available')
-      })
-
-      it('errors if no data is present', () => {
-        balance = {
-          uncommittedBalance: '',
-          totalChannelBalance: '',
-          totalPendingChannelBalance: '',
-          uncommittedPendingBalance: ''
-        }
-        balancesStub.resolves(balance)
-        return expect(getBalances({ logger, engines }, { GetBalancesResponse })).to.be.rejectedWith('Unexpected response for balance')
-      })
     })
   })
 

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -855,6 +855,8 @@ message Balance {
   string total_pending_channel_balance = 4;
   // Balance in the listed currency that is currently in pending closing channels and unconfirmed wallet balance. This is currently in common units (e.g. 0.5 BTC)
   string uncommitted_pending_balance = 5;
+  // Error message if balances are not available
+  string error = 10;
 }
 
 /**

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -1040,6 +1040,8 @@ service WalletService {
    * `totalPendingChannelBalance`, i.e. funds in channels that have finished the funding workflow and are waiting for confirmations for the funding txn, and
    * `uncommittedPendingBalance`, i.e funds in channels that are pending closure or unconfirmed unspent outputs under control of the wallet.
    *
+   * NOTE: If an engine is unavailable, the balances for the particular engine will be empty `''`
+   *
    * ```javascript
    * const deadline = new Date().setSeconds(new Date().getSeconds() + 5)
    * walletService.getBalances({}, { deadline }, (err, { balances }) => {


### PR DESCRIPTION
## Description
This PR fixes an issue where the CLI/Broker will prevent all wallet balances from showing even if some (not all) engines are available.

As a note: Not all engines on the broker are required to be active, so we should provide feedback letting the user know when an engine is unavailable instead of failing the `sparkswap wallet balance` call.

![screen shot 2018-12-03 at 1 15 11 pm](https://user-images.githubusercontent.com/5478311/49401995-872f8f80-f6fd-11e8-818c-6ef58dfecc0a.png)


## Related PRs
List related PRs if applicable


## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
