### PR TITLE
FIX - close channels on all available engines

### DIFF
--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -318,20 +318,28 @@ async function release (args, opts, logger) {
     if (!ACCEPTED_ANSWERS.includes(answer.toLowerCase())) return
 
     try {
-      await client.walletService.releaseChannels({ market, force })
-    } catch (e) {
-      logger.error(`Failed to release payment channels for ${market}`.red)
+      const { errors } = await client.walletService.releaseChannels({ market, force })
 
-      if (!force) {
-        logger.info('You can force the release of funds using the `--force` option, however')
-        logger.info('this has the potential to lock your funds for an extended period of time')
-        logger.info('and cost additional fees')
+      if (errors) {
+        logger.info(`Errors have occurred while trying to release channels for ${market}`.red)
+        errors.forEach(e => logger.info(`- ${e}`))
+        logger.info('')
       }
 
+      if (errors && !force) {
+        logger.info('If the error above suggests an uncooperative closing of any channels on')
+        logger.info('your daemon, you can force the release of funds using the `--force` option.')
+        logger.info('Using `--force` has the potential to lock your funds for an extended')
+        logger.info('period of time and cost additional fees')
+      }
+
+      if (!errors) {
+        logger.info(`Successfully closed channels on ${market} market!`)
+      }
+    } catch (e) {
+      logger.error(`Failed to release payment channels for ${market}`.red)
       throw e
     }
-
-    logger.info(`Successfully closed channels on ${market} market!`)
   } catch (e) {
     logger.error(handleError(e))
   }

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -358,7 +358,7 @@ async function release (args, opts, logger) {
 
       const { channels = [] } = await client.walletService.releaseChannels({ market, force })
 
-      if (!channels) {
+      if (!channels.length) {
         throw new Error('No information was retrieved from the daemon')
       }
 

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -320,16 +320,6 @@ function formatBalance (balance, status) {
 }
 
 /**
- * @constant
- * @type {Object<key, String>}
- * @default
- */
-const RELEASE_CHANNEL_ERRORS = Object.freeze({
-  UNABLE_TO_CLOSE: 'unable to gracefully close channel',
-  ACTIVE_PAYMENT: 'cannot co-op close channel'
-})
-
-/**
  * release
  *
  * ex: `sparkswap wallet release`
@@ -374,7 +364,7 @@ async function release (args, opts, logger) {
         const { symbol, status } = side
         let { error = '' } = side
 
-        if (error.includes(RELEASE_CHANNEL_ERRORS.UNABLE_TO_CLOSE) || error.includes(RELEASE_CHANNEL_ERRORS.ACTIVE_PAYMENT)) {
+        if (error.includes('Inactive/pending channels exist. You must use `force` to close')) {
           error = `Unable to release ${symbol}. Use '--force' and try again`
           shouldForceRelease = true
         }

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -335,7 +335,7 @@ async function release (args, opts, logger) {
 
         if (error) {
           channelHasError = true
-          logger.info(`${symbol}: ` + status.red)
+          logger.info(`${symbol}: ` + `${status}: ${error}`.red)
         } else {
           logger.info(`${symbol}: ` + status.green)
         }

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -318,6 +318,8 @@ async function release (args, opts, logger) {
     if (!ACCEPTED_ANSWERS.includes(answer.toLowerCase())) return
 
     try {
+      // We want to keep track if any returned channel had an error while attempting
+      // to be released so that we can display the proper error warnings below
       let channelHasError = false
 
       const { channels = [] } = await client.walletService.releaseChannels({ market, force })
@@ -329,10 +331,9 @@ async function release (args, opts, logger) {
       logger.info(`Released Market: ${market}`)
 
       channels.forEach((channel) => {
-        const { symbol, hasError } = channel
-        let { status } = channel
+        const { symbol, error, status } = channel
 
-        if (hasError) {
+        if (error) {
           channelHasError = true
           logger.info(`${symbol}: ` + status.red)
         } else {
@@ -341,15 +342,15 @@ async function release (args, opts, logger) {
       })
 
       if (channelHasError) {
-        logger.info(`Errors have occurred while trying to release channels for ${market}:`.red)
-        logger.info('')
+        logger.info(`\nErrors have occurred while trying to release channels for ${market}:`.red)
       }
 
       if (channelHasError && !force) {
         logger.info('If the error above suggests an uncooperative closing of any channels on')
         logger.info('your daemon, you can force the release of funds using the `--force` option.')
-        logger.info('Using `--force` has the potential to lock your funds for an extended')
-        logger.info('period of time and cost additional fees')
+        logger.info('')
+        logger.info('However, it is important to note that using `--force` has the potential to')
+        logger.info('lock your funds for an extended period of time and cost additional fees')
       }
     } catch (e) {
       logger.error(`Failed to release payment channels for ${market}`.red)

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -321,8 +321,8 @@ async function release (args, opts, logger) {
       const { errors } = await client.walletService.releaseChannels({ market, force })
 
       if (errors) {
-        logger.info(`Errors have occurred while trying to release channels for ${market}`.red)
-        errors.forEach(e => logger.info(`- ${e}`))
+        logger.info(`Errors have occurred while trying to release channels for ${market}:`.red)
+        errors.forEach(e => logger.info(e))
         logger.info('')
       }
 

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -374,13 +374,13 @@ async function release (args, opts, logger) {
         } else {
           logger.info(`${symbol}: ` + status.green)
         }
-
-        if (shouldForceRelease && !force) {
-          logger.info('')
-          logger.info('NOTE: using `--force` has the potential to lock your funds for an'.yellow)
-          logger.info('extended period of time (24/48 hours) and can cost additional fees.'.yellow)
-        }
       })
+
+      if (shouldForceRelease && !force) {
+        logger.info('')
+        logger.info('NOTE: using `--force` has the potential to lock your funds for an'.yellow)
+        logger.info('extended period of time (24/48 hours) and can cost additional fees.'.yellow)
+      }
     } catch (e) {
       logger.error(`Failed to release payment channels for ${market}`.red)
       throw e

--- a/broker-cli/commands/wallet.spec.js
+++ b/broker-cli/commands/wallet.spec.js
@@ -419,16 +419,41 @@ describe('cli wallet', () => {
     })
 
     it('shows errors to the user if release channels returns them', async () => {
-      const status = 'Engine is locked'
+      const status = 'FAILED'
       const symbol = 'BTC'
+      const error = 'Engine is locked'
       const channel = {
         symbol,
         status,
-        error: true
+        error: ''
       }
       releaseStub.resolves({ channels: [channel] })
       await release(args, opts, logger)
-      expect(logger.info).to.have.been.calledWith(sinon.match(symbol, status))
+      expect(logger.info).to.have.been.calledWith(sinon.match(symbol, status, error))
+    })
+
+    it('displays an informative message to user on errors', async () => {
+      const status = 'FAILED'
+      const symbol = 'BTC'
+      const error = 'Engine is locked'
+      const channel = { symbol, status, error }
+
+      releaseStub.resolves({ channels: [channel] })
+
+      await release(args, opts, logger)
+      expect(logger.info).to.have.been.calledWith(sinon.match('Errors have occurred'))
+    })
+
+    it('displays an informative message to user on errors if channels were not forced released', async () => {
+      const status = 'FAILED'
+      const symbol = 'BTC'
+      const error = 'Engine is locked'
+      const channel = { symbol, status, error }
+
+      releaseStub.resolves({ channels: [channel] })
+
+      await release(args, opts, logger)
+      expect(logger.info).to.have.been.calledWith(sinon.match('--force'))
     })
 
     context('force release of channels', () => {

--- a/broker-cli/commands/wallet.spec.js
+++ b/broker-cli/commands/wallet.spec.js
@@ -423,6 +423,14 @@ describe('cli wallet', () => {
       expect(logger.info).to.have.been.called()
     })
 
+    it('shows errors to the user if release channels returns them', async () => {
+      const error = 'Engine is locked'
+      const errors = [error]
+      releaseStub.resolves({ errors })
+      await release(args, opts, logger)
+      expect(logger.info).to.have.been.calledWith(error)
+    })
+
     context('force release of channels', () => {
       beforeEach(async () => {
         opts.force = true

--- a/broker-cli/commands/wallet.spec.js
+++ b/broker-cli/commands/wallet.spec.js
@@ -512,10 +512,9 @@ describe('cli wallet', () => {
     })
 
     it('displays an informative message to user on errors if channels can be force released', async () => {
-      const { UNABLE_TO_CLOSE } = program.__get__('RELEASE_CHANNEL_ERRORS')
       const status = 'FAILED'
       const symbol = 'BTC'
-      const error = UNABLE_TO_CLOSE
+      const error = 'Inactive/pending channels exist. You must use `force` to close'
       const channel = { symbol, status, error }
 
       releaseStub.resolves({ base: channel, counter: channel })
@@ -525,10 +524,9 @@ describe('cli wallet', () => {
     })
 
     it('displays a disclaimer to the user on errors if channels can be force released', async () => {
-      const { UNABLE_TO_CLOSE } = program.__get__('RELEASE_CHANNEL_ERRORS')
       const status = 'FAILED'
       const symbol = 'BTC'
-      const error = UNABLE_TO_CLOSE
+      const error = 'Inactive/pending channels exist. You must use `force` to close'
       const channel = { symbol, status, error }
 
       releaseStub.resolves({ base: channel, counter: channel })

--- a/broker-cli/commands/wallet.spec.js
+++ b/broker-cli/commands/wallet.spec.js
@@ -506,33 +506,35 @@ describe('cli wallet', () => {
         status,
         error: ''
       }
-      releaseStub.resolves({ channels: [channel] })
+      releaseStub.resolves({ base: channel, counter: channel })
       await release(args, opts, logger)
       expect(logger.info).to.have.been.calledWith(sinon.match(symbol, status, error))
     })
 
-    it('displays an informative message to user on errors', async () => {
+    it('displays an informative message to user on errors if channels can be force released', async () => {
+      const { UNABLE_TO_CLOSE } = program.__get__('RELEASE_CHANNEL_ERRORS')
       const status = 'FAILED'
       const symbol = 'BTC'
-      const error = 'Engine is locked'
+      const error = UNABLE_TO_CLOSE
       const channel = { symbol, status, error }
 
-      releaseStub.resolves({ channels: [channel] })
+      releaseStub.resolves({ base: channel, counter: channel })
 
       await release(args, opts, logger)
-      expect(logger.info).to.have.been.calledWith(sinon.match('Errors have occurred'))
+      expect(logger.info).to.have.been.calledWith(sinon.match('Use \'--force\''))
     })
 
-    it('displays an informative message to user on errors if channels were not forced released', async () => {
+    it('displays a disclaimer to the user on errors if channels can be force released', async () => {
+      const { UNABLE_TO_CLOSE } = program.__get__('RELEASE_CHANNEL_ERRORS')
       const status = 'FAILED'
       const symbol = 'BTC'
-      const error = 'Engine is locked'
+      const error = UNABLE_TO_CLOSE
       const channel = { symbol, status, error }
 
-      releaseStub.resolves({ channels: [channel] })
+      releaseStub.resolves({ base: channel, counter: channel })
 
       await release(args, opts, logger)
-      expect(logger.info).to.have.been.calledWith(sinon.match('--force'))
+      expect(logger.info).to.have.been.calledWith(sinon.match('has the potential to lock your funds'))
     })
 
     context('force release of channels', () => {

--- a/broker-cli/commands/wallet.spec.js
+++ b/broker-cli/commands/wallet.spec.js
@@ -418,17 +418,17 @@ describe('cli wallet', () => {
       expect(releaseStub).to.not.have.been.called()
     })
 
-    it('logs the number of channels closed', async () => {
-      await release(args, opts, logger)
-      expect(logger.info).to.have.been.called()
-    })
-
     it('shows errors to the user if release channels returns them', async () => {
-      const error = 'Engine is locked'
-      const errors = [error]
-      releaseStub.resolves({ errors })
+      const status = 'Engine is locked'
+      const symbol = 'BTC'
+      const channel = {
+        symbol,
+        status,
+        error: true
+      }
+      releaseStub.resolves({ channels: [channel] })
       await release(args, opts, logger)
-      expect(logger.info).to.have.been.calledWith(error)
+      expect(logger.info).to.have.been.calledWith(sinon.match(symbol, status))
     })
 
     context('force release of channels', () => {

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -925,6 +925,11 @@ message ReleaseChannelsRequest {
   bool force = 2;
 }
 
+message ReleaseChannelsResponse {
+  // Array of errors that may have occurred when releasing a specific market
+  repeated string errors = 1;
+}
+
 /**
  * Get the payment channel network address for a given currency.
  */
@@ -1161,7 +1166,7 @@ service WalletService {
    * ```
    *
    */
-  rpc ReleaseChannels (ReleaseChannelsRequest) returns (google.protobuf.Empty) {
+  rpc ReleaseChannels (ReleaseChannelsRequest) returns (ReleaseChannelsResponse) {
     option (google.api.http) = {
       post: "/v1/wallet/release"
       body: "*"

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -936,7 +936,7 @@ message ReleaseChannelsRequest {
  */
 message ReleasedCurrency {
   // Currency of the information
-  Symbol symbol = 1;
+  string symbol = 1;
   // Status of the channel. e.g. RELEASED or FAILED
   string status = 2;
   // Message that identifies an issue with a released channel. Only available if status of channel is not `RELEASED`

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -932,9 +932,9 @@ message ReleaseChannelsRequest {
 }
 
 /**
- * Container for channel information
+ * Container for channel information for a specific currency on a given market
  */
-message ReleasedChannel {
+message ReleasedCurrency {
   // Currency of the information
   Symbol symbol = 1;
   // Status of the channel. e.g. RELEASED or FAILED
@@ -944,8 +944,10 @@ message ReleasedChannel {
 }
 
 message ReleaseChannelsResponse {
-  // Channel status information for channels that have attempted to be released
-  repeated ReleasedChannel channels = 1;
+  // Channel status information for the base currency
+  ReleasedCurrency base = 1;
+  // Channel status information for the counter currency
+  ReleasedCurrency counter = 2;
 }
 
 /**

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -925,9 +925,21 @@ message ReleaseChannelsRequest {
   bool force = 2;
 }
 
+/**
+ * Container for channel information
+ */
+message ReleasedChannel {
+  // Currency of the information
+  Symbol symbol = 1;
+  // Status of the channel
+  string status = 2;
+  // Tag to identify if the attempt to release a channel produced an error
+  bool error = 10;
+}
+
 message ReleaseChannelsResponse {
-  // Array of errors that may have occurred when releasing a specific market
-  repeated string errors = 1;
+  // Channel status information for channels that have attempted to be released
+  repeated ReleasedChannel channels = 1;
 }
 
 /**

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -931,10 +931,10 @@ message ReleaseChannelsRequest {
 message ReleasedChannel {
   // Currency of the information
   Symbol symbol = 1;
-  // Status of the channel
+  // Status of the channel. e.g. RELEASED or FAILED
   string status = 2;
-  // Tag to identify if the attempt to release a channel produced an error
-  bool error = 10;
+  // Message that identifies an issue with a released channel. Only available if status of channel is not `RELEASED`
+  string error = 10;
 }
 
 message ReleaseChannelsResponse {

--- a/broker-daemon/broker-rpc/wallet-service/index.js
+++ b/broker-daemon/broker-rpc/wallet-service/index.js
@@ -39,6 +39,7 @@ class WalletService {
       GetTradingCapacitiesResponse,
       WithdrawFundsResponse,
       CreateWalletResponse,
+      ReleaseChannelsResponse,
       google: {
         protobuf: {
           Empty: EmptyResponse
@@ -52,7 +53,7 @@ class WalletService {
       commit: new GrpcUnaryMethod(commit, this.messageId('commit'), { logger, engines, relayer, orderbooks, auth }, { EmptyResponse }).register(),
       getPaymentChannelNetworkAddress: new GrpcUnaryMethod(getPaymentChannelNetworkAddress, this.messageId('getPaymentChannelNetworkAddress'), { logger, engines, auth }, { GetPaymentChannelNetworkAddressResponse }).register(),
       getTradingCapacities: new GrpcUnaryMethod(getTradingCapacities, this.messageId('getTradingCapacities'), { logger, engines, orderbooks, auth }, { GetTradingCapacitiesResponse }).register(),
-      releaseChannels: new GrpcUnaryMethod(releaseChannels, this.messageId('releaseChannels'), { logger, engines, orderbooks, auth }, { EmptyResponse }).register(),
+      releaseChannels: new GrpcUnaryMethod(releaseChannels, this.messageId('releaseChannels'), { logger, engines, orderbooks, auth }, { ReleaseChannelsResponse }).register(),
       withdrawFunds: new GrpcUnaryMethod(withdrawFunds, this.messageId('withdrawFunds'), { logger, engines, auth }, { WithdrawFundsResponse }).register(),
       createWallet: new GrpcUnaryMethod(createWallet, this.messageId('createWallet'), { logger, engines, auth }, { CreateWalletResponse }).register(),
       unlockWallet: new GrpcUnaryMethod(unlockWallet, this.messageId('unlockWallet'), { logger, engines, auth }, { EmptyResponse }).register()

--- a/broker-daemon/broker-rpc/wallet-service/index.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/index.spec.js
@@ -38,6 +38,7 @@ describe('WalletService', () => {
           GetTradingCapacitiesResponse: responseStub,
           WithdrawFundsResponse: responseStub,
           CreateWalletResponse: responseStub,
+          ReleaseChannelsResponse: responseStub,
           google: {
             protobuf: {
               Empty: responseStub
@@ -150,7 +151,7 @@ describe('WalletService', () => {
         releaseChannels,
         expectedMessageId,
         { logger, engines, orderbooks, auth },
-        { EmptyResponse: responseStub }
+        { ReleaseChannelsResponse: responseStub }
       )
     })
 

--- a/broker-daemon/broker-rpc/wallet-service/release-channels.js
+++ b/broker-daemon/broker-rpc/wallet-service/release-channels.js
@@ -43,7 +43,7 @@ async function releaseChannels ({ params, logger, engines, orderbooks }, { Relea
     const channels = await baseEngine.closeChannels({ force })
     logger.info(`Closed ${baseSymbol} channels`, { channels, force })
   } catch (e) {
-    logger.error(`Failed to close ${baseSymbol} channels`, { force })
+    logger.error(`Failed to close ${baseSymbol} channels`, { force, error: e.toString() })
     errors.push(`Failed to release ${baseSymbol} channels. Reason: ${e}`)
   }
 
@@ -51,7 +51,7 @@ async function releaseChannels ({ params, logger, engines, orderbooks }, { Relea
     const counterChannels = await counterEngine.closeChannels({ force })
     logger.info(`Closed ${counterSymbol} channels`, { counterChannels, force })
   } catch (e) {
-    logger.error(`Failed to close ${counterSymbol} channels`, { force })
+    logger.error(`Failed to close ${counterSymbol} channels`, { force, error: e.toString() })
     errors.push(`Failed to release ${counterSymbol} channels. Reason: ${e}`)
   }
 

--- a/broker-daemon/broker-rpc/wallet-service/release-channels.js
+++ b/broker-daemon/broker-rpc/wallet-service/release-channels.js
@@ -9,6 +9,39 @@ const RELEASE_STATE = Object.freeze({
   RELEASED: 'RELEASED',
   FAILED: 'FAILED'
 })
+/**
+ * Close channels on a specific engine
+ *
+ * @see {RELEASE_STATE}
+ * @param {Engine} engine
+ * @param {String} symbol - e.g. BTC or LTC
+ * @param {Boolean} force
+ * @param {Logger} logger
+ * @returns {Object} res
+ * @returns {String} res.symbol
+ * @returns {String} res.status - RELEASED or FAILED
+ * @returns {String} [res.error=undefined] - only present if status is FAILED
+ */
+async function closeChannels (engine, symbol, force, logger) {
+  try {
+    const channels = await engine.closeChannels({ force })
+
+    logger.info(`Closed ${symbol} channels`, { channels, force })
+
+    return {
+      symbol,
+      status: RELEASE_STATE.RELEASED
+    }
+  } catch (e) {
+    logger.error(`Failed to release channels for ${symbol}`, { force, error: e.toString() })
+
+    return {
+      symbol,
+      status: RELEASE_STATE.FAILED,
+      error: e.message
+    }
+  }
+}
 
 /**
  * Grabs public lightning network information from relayer and opens a channel
@@ -33,42 +66,27 @@ async function releaseChannels ({ params, logger, engines, orderbooks }, { Relea
     throw new PublicError(`${market} is not being tracked as a market.`)
   }
 
-  const symbols = market.split('/')
+  const [baseSymbol, counterSymbol] = market.split('/')
+
+  const baseEngine = engines.get(baseSymbol)
+  const counterEngine = engines.get(counterSymbol)
+
+  if (!baseEngine) throw new PublicError(`No engine available for ${baseSymbol}`)
+  if (!counterEngine) throw new PublicError(`No engine available for ${counterSymbol}`)
 
   // We want to try and close channels for both the base and counter engines
   // however if one of the engines fail to release channel, instead of failing
   // the gRPC call, we would like to notify the user through the `status` and `error`
-  // properties of the ReleaseChannelsResponse and continue execution
-  const releaseChannelPromises = symbols.map(async (symbol) => {
-    const engine = engines.get(symbol)
+  // properties of the ReleaseChannelsResponse.
+  const [base, counter] = await Promise.all([
+    closeChannels(baseEngine, baseSymbol, force, logger),
+    closeChannels(counterEngine, counterSymbol, force, logger)
+  ])
 
-    if (!engine) {
-      throw new PublicError(`No engine available for ${symbol}`)
-    }
-
-    try {
-      const channels = await engine.closeChannels({ force })
-
-      logger.info(`Closed ${symbol} channels`, { channels, force })
-
-      return {
-        symbol,
-        status: RELEASE_STATE.RELEASED
-      }
-    } catch (e) {
-      logger.error(`Failed to release channels for ${symbol}`, { force, error: e.toString() })
-
-      return {
-        symbol,
-        status: RELEASE_STATE.FAILED,
-        error: e.toString()
-      }
-    }
+  return new ReleaseChannelsResponse({
+    base,
+    counter
   })
-
-  const channels = await Promise.all(releaseChannelPromises)
-
-  return new ReleaseChannelsResponse({ channels })
 }
 
 module.exports = releaseChannels

--- a/broker-daemon/broker-rpc/wallet-service/release-channels.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/release-channels.spec.js
@@ -11,10 +11,10 @@ describe('releaseChannels', () => {
   let orderbooks
   let baseEngineStub
   let counterEngineStub
-  let EmptyResponse
+  let ReleaseChannelsResponse
 
   beforeEach(() => {
-    EmptyResponse = sinon.stub()
+    ReleaseChannelsResponse = sinon.stub()
     logger = {
       info: sinon.stub(),
       error: sinon.stub()
@@ -29,7 +29,7 @@ describe('releaseChannels', () => {
 
   describe('release channels from a specific market', () => {
     beforeEach(async () => {
-      res = await releaseChannels({ params, logger, engines, orderbooks }, { EmptyResponse })
+      res = await releaseChannels({ params, logger, engines, orderbooks }, { ReleaseChannelsResponse })
     })
 
     it('attempts to close channels on the base engine', async () => {
@@ -40,8 +40,8 @@ describe('releaseChannels', () => {
       expect(counterEngineStub.closeChannels).to.have.been.called()
     })
 
-    it('returns an EmptyResponse', async () => {
-      expect(EmptyResponse).to.have.been.called()
+    it('returns a ReleaseChannelsResponse', async () => {
+      expect(ReleaseChannelsResponse).to.have.been.called()
       expect(res).to.be.eql({})
     })
   })
@@ -49,7 +49,7 @@ describe('releaseChannels', () => {
   describe('force releasing channels from a specific market', () => {
     beforeEach(async () => {
       params.force = true
-      res = await releaseChannels({ params, logger, engines, orderbooks }, { EmptyResponse })
+      res = await releaseChannels({ params, logger, engines, orderbooks }, { ReleaseChannelsResponse })
     })
 
     it('force closes channels on the base engine', async () => {
@@ -66,20 +66,20 @@ describe('releaseChannels', () => {
       orderbooks = new Map([['ABC/DXS', { store: sinon.stub() }]])
 
       const errorMessage = `${params.market} is not being tracked as a market.`
-      return expect(releaseChannels({ params, logger, engines, orderbooks }, { EmptyResponse })).to.eventually.be.rejectedWith(errorMessage)
+      return expect(releaseChannels({ params, logger, engines, orderbooks }, { ReleaseChannelsResponse })).to.eventually.be.rejectedWith(errorMessage)
     })
 
     it('throws an error if the base engine does not exist for symbol', () => {
       engines = new Map([['LTC', counterEngineStub]])
       return expect(
-        releaseChannels({ params, logger, engines, orderbooks }, { EmptyResponse })
+        releaseChannels({ params, logger, engines, orderbooks }, { ReleaseChannelsResponse })
       ).to.eventually.be.rejectedWith(PublicError, `No engine available for BTC`)
     })
 
     it('throws an error if the counter engine does not exist for symbol', () => {
       engines = new Map([['BTC', baseEngineStub]])
       return expect(
-        releaseChannels({ params, logger, engines, orderbooks }, { EmptyResponse })
+        releaseChannels({ params, logger, engines, orderbooks }, { ReleaseChannelsResponse })
       ).to.be.rejectedWith(PublicError, `No engine available for LTC`)
     })
   })

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -925,6 +925,11 @@ message ReleaseChannelsRequest {
   bool force = 2;
 }
 
+message ReleaseChannelsResponse {
+  // Array of errors that may have occurred when releasing a specific market
+  repeated string errors = 1;
+}
+
 /**
  * Get the payment channel network address for a given currency.
  */
@@ -1161,7 +1166,7 @@ service WalletService {
    * ```
    *
    */
-  rpc ReleaseChannels (ReleaseChannelsRequest) returns (google.protobuf.Empty) {
+  rpc ReleaseChannels (ReleaseChannelsRequest) returns (ReleaseChannelsResponse) {
     option (google.api.http) = {
       post: "/v1/wallet/release"
       body: "*"

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -936,7 +936,7 @@ message ReleaseChannelsRequest {
  */
 message ReleasedCurrency {
   // Currency of the information
-  Symbol symbol = 1;
+  string symbol = 1;
   // Status of the channel. e.g. RELEASED or FAILED
   string status = 2;
   // Message that identifies an issue with a released channel. Only available if status of channel is not `RELEASED`

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -932,9 +932,9 @@ message ReleaseChannelsRequest {
 }
 
 /**
- * Container for channel information
+ * Container for channel information for a specific currency on a given market
  */
-message ReleasedChannel {
+message ReleasedCurrency {
   // Currency of the information
   Symbol symbol = 1;
   // Status of the channel. e.g. RELEASED or FAILED
@@ -944,8 +944,10 @@ message ReleasedChannel {
 }
 
 message ReleaseChannelsResponse {
-  // Channel status information for channels that have attempted to be released
-  repeated ReleasedChannel channels = 1;
+  // Channel status information for the base currency
+  ReleasedCurrency base = 1;
+  // Channel status information for the counter currency
+  ReleasedCurrency counter = 2;
 }
 
 /**

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -925,9 +925,21 @@ message ReleaseChannelsRequest {
   bool force = 2;
 }
 
+/**
+ * Container for channel information
+ */
+message ReleasedChannel {
+  // Currency of the information
+  Symbol symbol = 1;
+  // Status of the channel
+  string status = 2;
+  // Tag to identify if the attempt to release a channel produced an error
+  bool error = 10;
+}
+
 message ReleaseChannelsResponse {
-  // Array of errors that may have occurred when releasing a specific market
-  repeated string errors = 1;
+  // Channel status information for channels that have attempted to be released
+  repeated ReleasedChannel channels = 1;
 }
 
 /**

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -931,10 +931,10 @@ message ReleaseChannelsRequest {
 message ReleasedChannel {
   // Currency of the information
   Symbol symbol = 1;
-  // Status of the channel
+  // Status of the channel. e.g. RELEASED or FAILED
   string status = 2;
-  // Tag to identify if the attempt to release a channel produced an error
-  bool error = 10;
+  // Message that identifies an issue with a released channel. Only available if status of channel is not `RELEASED`
+  string error = 10;
 }
 
 message ReleaseChannelsResponse {


### PR DESCRIPTION
## Description
This PR updates the `sparkswap wallet release` command to close channels from all available engines AND additionally prompt the user if there had been errors when trying to release funds.

**Implementation Notes:**
I wanted this feature to be a simple as possible. Right now, we'll fail the call if engines/configuration is messed up and then we'll handle errors for each individual `closeChannel` call for the market. The user can check `network-status` to see what market/channels could potentially be open, but there may need to be an enhancement there.

Example:
![screen shot 2018-12-06 at 3 06 23 pm](https://user-images.githubusercontent.com/5478311/49617227-86e6fc80-f968-11e8-91e2-0d62c12d1e34.png)


## Related PRs
List related PRs if applicable


## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
