### PR TITLE
Bugfix/counter amount should exist

### DIFF
--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -116,7 +116,7 @@ class BlockOrderWorker extends EventEmitter {
       const { orders, depth } = await orderbook.getBestOrders({ side: blockOrder.inverseSide, depth: Big(blockOrder.baseAmount).toString() })
       if (Big(depth).lt(blockOrder.baseAmount)) {
         this.logger.error(`Insufficient depth`)
-        throw new Error(`Insufficient depth in ${blockOrder.inverseSide} to fill ${blockOrder.baseAmount.toString()}`)
+        throw new Error(`Insufficient depth`)
       }
       counterAmount = await orderbook.getAveragePrice(orders, Big(depth))
 

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -140,8 +140,8 @@ class BlockOrderWorker extends EventEmitter {
     // If the blockOrder is a market order we will not have a counterAmount and therefore will not be
     // able to calculate if the funds in channels are sufficient. So we calculate an average price for this.
     if (blockOrder.isMarketOrder) {
-      const averageBaseAmount = await orderbook.getAveragePrice(blockOrder.inverseSide, blockOrder.baseAmount)
-      counterAmount = averageBaseAmount.times(blockOrder.counterCurrencyConfig.quantumsPerCommon).round(0).toString()
+      const averagePrice = await orderbook.getAveragePrice(blockOrder.inverseSide, blockOrder.baseAmount)
+      counterAmount = averagePrice.times(blockOrder.amount).times(blockOrder.counterCurrencyConfig.quantumsPerCommon).round(0).toString()
       if (blockOrder.isBid) {
         outboundAmount = counterAmount
         inboundAmount = blockOrder.inboundAmount

--- a/broker-daemon/models/block-order.js
+++ b/broker-daemon/models/block-order.js
@@ -239,7 +239,7 @@ class BlockOrder {
   }
 
   get isMarketOrder () {
-    return !!this.price
+    return !this.price
   }
 
   /**

--- a/broker-daemon/models/block-order.js
+++ b/broker-daemon/models/block-order.js
@@ -238,6 +238,10 @@ class BlockOrder {
     return this.side === BlockOrder.SIDES.ASK
   }
 
+  get isMarketOrder () {
+    return !!this.price
+  }
+
   /**
    * Move the block order to a failed status
    * @return {BlockOrder} Modified block order instance

--- a/broker-daemon/models/block-order.js
+++ b/broker-daemon/models/block-order.js
@@ -238,6 +238,10 @@ class BlockOrder {
     return this.side === BlockOrder.SIDES.ASK
   }
 
+  /**
+  * get boolean for if the blockOrder is a marketOrder
+  * @return {Boolean}
+   */
   get isMarketOrder () {
     return !this.price
   }

--- a/broker-daemon/models/block-order.spec.js
+++ b/broker-daemon/models/block-order.spec.js
@@ -717,6 +717,17 @@ describe('BlockOrder', () => {
       })
     })
 
+    describe('get isMarketOrder', () => {
+      it('gets true if block order is a market order', () => {
+        blockOrder.price = null
+        expect(blockOrder).to.have.property('isMarketOrder', true)
+      })
+
+      it('gets false if block order is not a market order', () => {
+        expect(blockOrder).to.have.property('isMarketOrder', false)
+      })
+    })
+
     describe('get activeFills', () => {
       let fills
       let createdFill

--- a/broker-daemon/orderbook/index.js
+++ b/broker-daemon/orderbook/index.js
@@ -219,21 +219,22 @@ class Orderbook {
 
   async getAveragePrice (orders, targetDepth) {
     targetDepth = Big(targetDepth)
-    let currentDepth = Big('0')
-    const weightedPrice = orders.reduce((acc, order) => {
+    let currentDepth = Big(0)
+    let weightedPrice = Big(0)
+    orders.forEach((order) => {
       const depthRemaining = targetDepth.minus(currentDepth)
 
       // if we have already reached our target depth, create no further fills
       if (depthRemaining.lte(0)) {
-        return acc
+        return
       }
 
       // Take the smaller of the remaining desired depth or the base amount of the order
       const fillAmount = depthRemaining.gt(order.baseAmount) ? order.baseAmount : depthRemaining.toString()
       // track our current depth so we know what to fill on the next order
       currentDepth = currentDepth.plus(fillAmount)
-      return acc.plus(order.price.times(fillAmount))
-    }, Big(0))
+      weightedPrice = weightedPrice.plus(order.price.times(fillAmount))
+    })
 
     return Big(weightedPrice).div(targetDepth)
   }

--- a/broker-daemon/orderbook/index.js
+++ b/broker-daemon/orderbook/index.js
@@ -233,7 +233,7 @@ class Orderbook {
       // track our current depth so we know what to fill on the next order
       currentDepth = currentDepth.plus(fillAmount)
       return acc.plus(order.price.times(fillAmount))
-    })
+    }, Big(0))
 
     return Big(weightedPrice).div(targetDepth)
   }

--- a/broker-daemon/orderbook/index.js
+++ b/broker-daemon/orderbook/index.js
@@ -226,8 +226,14 @@ class Orderbook {
   async getAveragePrice (side, targetDepth) {
     const { orders, depth } = await this.getBestOrders({ side, depth: targetDepth })
     if (Big(depth).lt(targetDepth)) {
-      this.logger.error(`Insufficient depth`)
-      throw new Error(`Insufficient depth`)
+      const params = {
+        market: this.marketName,
+        side: this.side,
+        depth,
+        targetDepth
+      }
+      this.logger.error('Insufficient depth to find averagePrice', params)
+      throw new Error('Insufficient depth to find averagePrice', params)
     }
     targetDepth = Big(targetDepth)
     let currentDepth = Big(0)

--- a/broker-daemon/orderbook/index.spec.js
+++ b/broker-daemon/orderbook/index.spec.js
@@ -689,7 +689,7 @@ describe('Orderbook', () => {
 
     it('throws an error if there is not sufficient depth in the orderbook', () => {
       orderbook.getBestOrders.resolves({orders, depth: 8})
-      return expect(orderbook.getAveragePrice(side, targetDepth)).to.eventually.be.rejectedWith('Insufficient depth')
+      return expect(orderbook.getAveragePrice(side, targetDepth)).to.eventually.be.rejectedWith('Insufficient depth to find averagePrice')
     })
 
     it('returns the average weighted price', async () => {

--- a/broker-daemon/orderbook/index.spec.js
+++ b/broker-daemon/orderbook/index.spec.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const { rewire, sinon, expect } = require('test/test-helper')
+const { Big } = require('../utils')
 
 const Orderbook = rewire(path.resolve('broker-daemon', 'orderbook', 'index'))
 
@@ -100,7 +101,8 @@ describe('Orderbook', () => {
 
     logger = {
       info: sinon.stub(),
-      debug: sinon.stub()
+      debug: sinon.stub(),
+      error: sinon.stub()
     }
   })
 
@@ -653,6 +655,46 @@ describe('Orderbook', () => {
       await orderbook.getBestOrders({ side: 'ASK', depth: '100' })
 
       expect(askIndex.streamOrdersAtPriceOrBetter).to.have.been.calledWith(undefined)
+    })
+  })
+
+  describe('getAveragePrice', () => {
+    let side
+    let targetDepth
+    let orders
+    let orderbook
+
+    beforeEach(() => {
+      side = 'BID'
+      targetDepth = 10
+      orders = [
+        {
+          baseAmount: 1,
+          price: 10
+        },
+        {
+          baseAmount: 2,
+          price: 3
+        }
+      ]
+      orderbook = new Orderbook('BTC/LTC', relayer, baseStore, logger)
+      orderbook.getBestOrders = sinon.stub().resolves({orders, depth: targetDepth})
+    })
+
+    it('gets the best orders given the side and depth', async () => {
+      await orderbook.getAveragePrice(side, targetDepth)
+      expect(orderbook.getBestOrders).to.have.been.called()
+      expect(orderbook.getBestOrders).to.have.been.calledWith({side, depth: targetDepth})
+    })
+
+    it('throws an error if there is not sufficient depth in the orderbook', () => {
+      orderbook.getBestOrders.resolves({orders, depth: 8})
+      return expect(orderbook.getAveragePrice(side, targetDepth)).to.eventually.be.rejectedWith('Insufficient depth')
+    })
+
+    it('returns the average weighted price', async () => {
+      const res = await orderbook.getAveragePrice(side, targetDepth)
+      expect(res).to.eql(Big(1.6))
     })
   })
 


### PR DESCRIPTION
## Description
With the new check for sufficient funds, we have a case where the counterAmount to check with does not exist (if the order is a market order). 
This PR defines a function that finds the average weighted price so that we can approximate a counter amount when checking if the engine has sufficient funds.

## Related PRs



## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
