### PR TITLE
Fix - Invoices not being paid for Fill

### DIFF
--- a/broker-daemon/state-machines/fill-state-machine.js
+++ b/broker-daemon/state-machines/fill-state-machine.js
@@ -102,7 +102,7 @@ const FillStateMachine = StateMachine.factory({
    */
   transitions: [
     /**
-     * create transition: the first transtion, from 'none' (the default state) to 'created'
+     * create transition: the first transition, from 'none' (the default state) to 'created'
      * @type {Object}
      */
     { name: 'create', from: 'none', to: 'created' },
@@ -159,17 +159,17 @@ const FillStateMachine = StateMachine.factory({
 
       const inboundEngine = this.engines.get(inboundSymbol)
       if (!inboundEngine) {
-        throw new Error(`No engine avialable for ${inboundEngine}`)
+        throw new Error(`No engine available for ${inboundEngine}`)
       }
 
       const baseEngine = this.engines.get(baseSymbol)
       if (!baseEngine) {
-        throw new Error(`No engine avialable for ${baseEngine}`)
+        throw new Error(`No engine available for ${baseEngine}`)
       }
 
       const counterEngine = this.engines.get(counterSymbol)
       if (!counterEngine) {
-        throw new Error(`No engine avialable for ${counterEngine}`)
+        throw new Error(`No engine available for ${counterEngine}`)
       }
 
       this.fill.takerBaseAddress = await baseEngine.getPaymentChannelNetworkAddress()
@@ -178,14 +178,27 @@ const FillStateMachine = StateMachine.factory({
       const swapHash = await inboundEngine.createSwapHash(this.fill.order.orderId, inboundAmount)
       this.fill.setSwapHash(swapHash)
 
-      const { fillId, feePaymentRequest, depositPaymentRequest, fillError } = await this.relayer.takerService.createFill(this.fill.paramsForCreate)
+      const {
+        fillId,
+        feePaymentRequest,
+        depositPaymentRequest,
+        feeRequired,
+        depositRequired,
+        fillError
+      } = await this.relayer.takerService.createFill(this.fill.paramsForCreate)
 
       if (fillError) {
         this.logger.error(`Encountered error with fill: ${fillError.message}`)
         throw new Error(fillError.code)
       }
 
-      this.fill.setCreatedParams({ fillId, feePaymentRequest, depositPaymentRequest })
+      this.fill.setCreatedParams({
+        fillId,
+        feePaymentRequest,
+        depositPaymentRequest,
+        feeRequired,
+        depositRequired
+      })
 
       this.logger.info(`Created fill ${this.fill.fillId} on the relayer`)
     },
@@ -214,7 +227,7 @@ const FillStateMachine = StateMachine.factory({
      * if filling on the Relayer fails.
      *
      * @param  {Object} lifecycle Lifecycle object passed by javascript-state-machine
-     * @return {Promise}          romise that rejects if filling on the relayer fails
+     * @return {Promise} promise that rejects if filling on the relayer fails
      */
     onBeforeFillOrder: async function (lifecycle) {
       const {
@@ -323,7 +336,7 @@ const FillStateMachine = StateMachine.factory({
 
     /**
      * Execute the swap on the Payment Channel Network
-     * This function gets called before the `exuecte` transition (triggered by a call to `exuecte`)
+     * This function gets called before the `execute` transition (triggered by a call to `execute`)
      * Actual execution is done in `onBeforeFill` so that the transition can be cancelled if execution fails
      *
      * @param  {Object} lifecycle Lifecycle object passed by javascript-state-machine

--- a/broker-daemon/state-machines/fill-state-machine.spec.js
+++ b/broker-daemon/state-machines/fill-state-machine.spec.js
@@ -180,7 +180,7 @@ describe('FillStateMachine', () => {
     })
   })
 
-  describe('#create', () => {
+  describe.only('#create', () => {
     let fsm
     let blockOrderId
     let orderParams
@@ -198,7 +198,9 @@ describe('FillStateMachine', () => {
       createFillResponse = {
         fillId: 'fakeFillId',
         feePaymentRequest: 'lnbcas9df0as9fu',
-        depositPaymentRequest: 'lnbcasd9fuas90f'
+        depositPaymentRequest: 'lnbcasd9fuas90f',
+        feeRequired: true,
+        depositRequired: false
       }
       Fill.prototype.key = fakeKey
       Fill.prototype.valueObject = fakeValueObject

--- a/broker-daemon/state-machines/fill-state-machine.spec.js
+++ b/broker-daemon/state-machines/fill-state-machine.spec.js
@@ -180,7 +180,7 @@ describe('FillStateMachine', () => {
     })
   })
 
-  describe.only('#create', () => {
+  describe('#create', () => {
     let fsm
     let blockOrderId
     let orderParams


### PR DESCRIPTION
## Description
When attempting a `Fill`, the broker will receive an error from the Relayer stating that "Deposit Invoice Has Not Been Paid". This is due to the broker thinking that fees/deposits are not required, because of Fill#feeRequired and Fill#depositRequired being set to null.

This PR consumes the `feeRequired` and `depositRequired` params from the relayer and adds them to each `Fill` during the creation process.

## Related PRs
List related PRs if applicable


## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
