### PR TITLE
Fix - Multi-engine support for network status

### DIFF
--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -250,8 +250,11 @@ const NETWORK_STATUSES = Object.freeze({
  * @param {String} status
  * @return {String} balance - formatted with size and color
  */
-function formatBalance (balance, status) {
-  if (!balance) {
+function formatBalance (balance, status, errorPresent) {
+  // If there were errors when receiving balances, the balance will come back
+  // as either a blank string or null. We set the balance to `Not Available` in this
+  // case, but should make sure we dont treat `0` as the same type.
+  if (balance === '' || balance === null) {
     return 'Not Available'.yellow
   }
 
@@ -272,6 +275,15 @@ function formatBalance (balance, status) {
 
   return fixedBalance
 }
+
+/**
+ * @constant
+ * @type {Object<key, String>}
+ * @default
+ */
+const CAPACITY_STATUSES = Object.freeze({
+  OK: 'OK'
+})
 
 /**
  * network-status
@@ -302,7 +314,7 @@ async function networkStatus (args, opts, logger) {
     })
 
     // If any balances in the following table are empty (which occurs if the engine is unavailable)
-    // then the text will show up as `N/A`.
+    // then the text will show up as `Not Available`.
     //
     // The user will then be prompted with a warning letting them know that we failed
     // to receive a balance for a particular currency
@@ -326,11 +338,11 @@ async function networkStatus (args, opts, logger) {
     logger.info(statusTable.toString())
     logger.info('')
 
-    if (baseSymbolCapacities.status !== 'OK') {
+    if (baseSymbolCapacities.status !== CAPACITY_STATUSES.OK) {
       logger.error(`${baseSymbol}: Received errors when requesting network status: ${baseSymbolCapacities.error}`.red)
     }
 
-    if (counterSymbolCapacities.status !== 'OK') {
+    if (counterSymbolCapacities.status !== CAPACITY_STATUSES.OK) {
       logger.error(`${counterSymbol}: Received errors when requesting network status: ${counterSymbolCapacities.error}`.red)
     }
   } catch (e) {

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -252,9 +252,9 @@ const NETWORK_STATUSES = Object.freeze({
  */
 function formatBalance (balance, status) {
   // If there were errors when receiving balances, the balance will come back
-  // as either a blank string or null. We set the balance to `Not Available` in this
-  // case, but should make sure we dont treat `0` as the same type.
-  if (balance === '' || balance === null || balance === undefined) {
+  // as either a blank string, undefined or null. We set the balance to `Not Available`
+  // in this case, but should make sure we dont treat `0` as the same type.
+  if (balance === '' || balance == null) {
     return 'Not Available'.yellow
   }
 

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -252,7 +252,7 @@ const NETWORK_STATUSES = Object.freeze({
  */
 function formatBalance (balance, status) {
   if (!balance) {
-    return 'N/A'.yellow
+    return 'Not Available'.yellow
   }
 
   const fixedBalance = Big(balance).toFixed(16)
@@ -301,14 +301,6 @@ async function networkStatus (args, opts, logger) {
       style: { head: ['gray'] }
     })
 
-    if (baseSymbolCapacities.error) {
-      logger.info(`Received errors when requesting ${baseSymbol} status. Please check your ${baseSymbol} daemon`.red)
-    }
-
-    if (counterSymbolCapacities.error) {
-      logger.info(`Received errors when requesting ${baseSymbol} status. Please check your ${counterSymbol} daemon`.red)
-    }
-
     // If any balances in the following table are empty (which occurs if the engine is unavailable)
     // then the text will show up as `N/A`.
     //
@@ -330,8 +322,17 @@ async function networkStatus (args, opts, logger) {
     statusTable.push([`  Buy ${baseSymbol}`, formatBalance(baseSymbolCapacities.inactiveReceiveCapacity, NETWORK_STATUSES.INACTIVE), formatBalance(counterSymbolCapacities.inactiveSendCapacity, NETWORK_STATUSES.INACTIVE)])
     statusTable.push([`  Sell ${baseSymbol}`, formatBalance(baseSymbolCapacities.inactiveSendCapacity, NETWORK_STATUSES.INACTIVE), formatBalance(counterSymbolCapacities.inactiveReceiveCapacity, NETWORK_STATUSES.INACTIVE)])
 
-    logger.info(` ${market.bold.white}`)
+    logger.info(` Market: ${market.bold.white}`)
     logger.info(statusTable.toString())
+    logger.info('')
+
+    if (baseSymbolCapacities.error) {
+      logger.info(`${baseSymbol}: Received errors when requesting network status. Please check your ${baseSymbol} daemon`.red)
+    }
+
+    if (counterSymbolCapacities.error) {
+      logger.info(`${counterSymbol}: Received errors when requesting network status. Please check your ${counterSymbol} daemon`.red)
+    }
   } catch (e) {
     logger.error(handleError(e))
   }

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -326,12 +326,12 @@ async function networkStatus (args, opts, logger) {
     logger.info(statusTable.toString())
     logger.info('')
 
-    if (baseSymbolCapacities.error) {
-      logger.info(`${baseSymbol}: Received errors when requesting network status. Please check your ${baseSymbol} daemon`.red)
+    if (baseSymbolCapacities.status !== 'OK') {
+      logger.error(`${baseSymbol}: Received errors when requesting network status: ${baseSymbolCapacities.error}`.red)
     }
 
-    if (counterSymbolCapacities.error) {
-      logger.info(`${counterSymbol}: Received errors when requesting network status. Please check your ${counterSymbol} daemon`.red)
+    if (counterSymbolCapacities.status !== 'OK') {
+      logger.error(`${counterSymbol}: Received errors when requesting network status: ${counterSymbolCapacities.error}`.red)
     }
   } catch (e) {
     logger.error(handleError(e))

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -250,11 +250,11 @@ const NETWORK_STATUSES = Object.freeze({
  * @param {String} status
  * @return {String} balance - formatted with size and color
  */
-function formatBalance (balance, status, errorPresent) {
+function formatBalance (balance, status) {
   // If there were errors when receiving balances, the balance will come back
   // as either a blank string or null. We set the balance to `Not Available` in this
   // case, but should make sure we dont treat `0` as the same type.
-  if (balance === '' || balance === null) {
+  if (balance === '' || balance === null || balance === undefined) {
     return 'Not Available'.yellow
   }
 

--- a/broker-cli/commands/wallet.spec.js
+++ b/broker-cli/commands/wallet.spec.js
@@ -377,7 +377,7 @@ describe('cli wallet', () => {
     })
   })
 
-  describe('formatBalance', () => {
+  describe.only('formatBalance', () => {
     const NETWORK_STATUSES = program.__get__('NETWORK_STATUSES')
     const formatBalance = program.__get__('formatBalance')
 
@@ -403,6 +403,10 @@ describe('cli wallet', () => {
 
     it('returns `Not Available` if balance is not provided', () => {
       expect(formatBalance(null, NETWORK_STATUSES.AVAILABLE)).to.eql('Not Available'.yellow)
+    })
+
+    it('returns `Not Available` if balance is blank', () => {
+      expect(formatBalance('', NETWORK_STATUSES.AVAILABLE)).to.eql('Not Available'.yellow)
     })
   })
 

--- a/broker-cli/commands/wallet.spec.js
+++ b/broker-cli/commands/wallet.spec.js
@@ -377,7 +377,7 @@ describe('cli wallet', () => {
     })
   })
 
-  describe.only('formatBalance', () => {
+  describe('formatBalance', () => {
     const NETWORK_STATUSES = program.__get__('NETWORK_STATUSES')
     const formatBalance = program.__get__('formatBalance')
 

--- a/broker-cli/commands/wallet.spec.js
+++ b/broker-cli/commands/wallet.spec.js
@@ -343,6 +343,38 @@ describe('cli wallet', () => {
       const expectedResult = ['  Sell BTC', formatBalance('0.000002', NETWORK_STATUSES.INACTIVE), formatBalance('0.00002', NETWORK_STATUSES.INACTIVE)]
       expect(tablePushStub).to.have.been.calledWith(expectedResult)
     })
+
+    it('displays a message if there were errors in base capacities', async () => {
+      const status = 'FAILED'
+      const error = 'Something Happened'
+      const badBaseCapacities = {
+        symbol: baseSymbolCapacities.symbol,
+        status,
+        error
+      }
+      getTradingCapacitiesStub.resolves({ baseSymbolCapacities: badBaseCapacities, counterSymbolCapacities })
+
+      await networkStatus({}, opts, logger)
+
+      expect(logger.error).to.have.been.calledWith(sinon.match(`${badBaseCapacities.symbol}: Received errors`))
+      expect(logger.error).to.have.been.calledWith(sinon.match(error))
+    })
+
+    it('displays a message if there were errors in counter capacities', async () => {
+      const status = 'FAILED'
+      const error = 'Something Happened'
+      const badCounterCapacities = {
+        symbol: counterSymbolCapacities.symbol,
+        status,
+        error
+      }
+      getTradingCapacitiesStub.resolves({ baseSymbolCapacities: badCounterCapacities, counterSymbolCapacities })
+
+      await networkStatus({}, opts, logger)
+
+      expect(logger.error).to.have.been.calledWith(sinon.match(`${badCounterCapacities.symbol}: Received errors`))
+      expect(logger.error).to.have.been.calledWith(sinon.match(error))
+    })
   })
 
   describe('formatBalance', () => {
@@ -367,6 +399,10 @@ describe('cli wallet', () => {
 
     it('colors the balance red if the balance is greater than 0 and the status is inactive', () => {
       expect(formatBalance('0.004', NETWORK_STATUSES.INACTIVE)).to.eql('0.0040000000000000'.red)
+    })
+
+    it('returns `Not Available` if balance is not provided', () => {
+      expect(formatBalance(null, NETWORK_STATUSES.AVAILABLE)).to.eql('Not Available'.yellow)
     })
   })
 

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -889,6 +889,8 @@ message Capacity {
   string outstanding_send_capacity = 10;
   // Total outbound outstanding amount. This is currently in base units (e.g. Satoshis/Litoshis)
   string outstanding_receive_capacity = 11;
+  // true/false for any errors that may have occurred when requesting capacity for a particular currency
+  bool error = 20;
 }
 
 /**

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -889,8 +889,10 @@ message Capacity {
   string outstanding_send_capacity = 10;
   // Total outbound outstanding amount. This is currently in base units (e.g. Satoshis/Litoshis)
   string outstanding_receive_capacity = 11;
-  // true/false for any errors that may have occurred when requesting capacity for a particular currency
-  bool error = 20;
+  // Status of capacities. OK for success or FAILED if an error occurred when requesting capacities
+  string status = 20;
+  // Error message if status is FAILED
+  string error = 21;
 }
 
 /**

--- a/broker-daemon/broker-rpc/wallet-service/commit.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.js
@@ -79,6 +79,11 @@ async function commit ({ params, relayer, logger, engines, orderbooks }, { Empty
   // If maxOutboundBalance or maxInboundBalance exist, we need to check if the balances are greater or less than the balance of the channel
   // we are trying to open. If neither maxOutboundBalance nor maxInboundBalance exist, it means there are no channels open and we can safely
   // attempt to create channels with the balance
+
+  logger.debug('------HERE MARTINE------')
+  logger.debug(maxOutboundBalance)
+  logger.debug(maxInboundBalance)
+
   if (maxOutboundBalance || maxInboundBalance) {
     const insufficientOutboundBalance = maxOutboundBalance && Big(maxOutboundBalance).lt(balance)
     const insufficientInboundBalance = maxInboundBalance && Big(maxInboundBalance).lt(convertedBalance)

--- a/broker-daemon/broker-rpc/wallet-service/commit.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.js
@@ -79,11 +79,6 @@ async function commit ({ params, relayer, logger, engines, orderbooks }, { Empty
   // If maxOutboundBalance or maxInboundBalance exist, we need to check if the balances are greater or less than the balance of the channel
   // we are trying to open. If neither maxOutboundBalance nor maxInboundBalance exist, it means there are no channels open and we can safely
   // attempt to create channels with the balance
-
-  logger.debug('------HERE MARTINE------')
-  logger.debug(maxOutboundBalance)
-  logger.debug(maxInboundBalance)
-
   if (maxOutboundBalance || maxInboundBalance) {
     const insufficientOutboundBalance = maxOutboundBalance && Big(maxOutboundBalance).lt(balance)
     const insufficientInboundBalance = maxInboundBalance && Big(maxInboundBalance).lt(convertedBalance)

--- a/broker-daemon/broker-rpc/wallet-service/get-trading-capacities.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-trading-capacities.js
@@ -12,6 +12,16 @@ const SIDES = Object.freeze({
 })
 
 /**
+ * @constant
+ * @type {Object}
+ * @default
+ */
+const CAPACITY_STATE = Object.freeze({
+  OK: 'OK',
+  FAILED: 'FAILED'
+})
+
+/**
  * Grabs the total balance and total channel balance from a specified engine
  *
  * @param {Engine} SparkSwap Payment Channel Network Engine
@@ -22,6 +32,7 @@ const SIDES = Object.freeze({
  * @param {Logger} opts.logger
  * @return {Object} res
  * @return {String} res.symbol - currency symbol e.g. BTC
+ * @return {String} res.status - OK for success or FAILED if engine call fails
  * @return {Boolean} res.error - true if errors occurred during request for capacities
  * @return {String} res.availableReceiveCapacity
  * @return {String} res.availableSendCapacity
@@ -55,6 +66,7 @@ async function getCapacities (engine, symbol, outstandingSendCapacity, outstandi
 
     return {
       symbol,
+      status: CAPACITY_STATE.OK,
       availableReceiveCapacity: Big(activeChannelCapacities.remoteBalance).minus(outstandingReceiveCapacity).div(quantumsPerCommon).toString(),
       availableSendCapacity: Big(activeChannelCapacities.localBalance).minus(outstandingSendCapacity).div(quantumsPerCommon).toString(),
       pendingSendCapacity: Big(pendingChannelCapacities.localBalance).div(quantumsPerCommon).toString(),
@@ -69,7 +81,8 @@ async function getCapacities (engine, symbol, outstandingSendCapacity, outstandi
 
     return {
       symbol,
-      error: true
+      status: CAPACITY_STATE.FAILED,
+      error: e.message
     }
   }
 }

--- a/broker-daemon/broker-rpc/wallet-service/get-trading-capacities.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-trading-capacities.js
@@ -1,6 +1,11 @@
 const { currencies } = require('../../config')
 const { Big } = require('../../utils')
 
+/**
+ * @constant
+ * @type {Object<key, String>}
+ * @default
+ */
 const SIDES = Object.freeze({
   BID: 'BID',
   ASK: 'ASK'
@@ -14,7 +19,7 @@ const SIDES = Object.freeze({
  * @param {String} outstandingSendCapacity - amount of outstanding send capacity for the given currency
  * @param {String} outstandingReceiveCapacity - amount of outstanding receive capacity for the given currency
  * @param {Object} opts
- * @param {Logger} logger
+ * @param {Logger} opts.logger
  * @return {Object} res
  * @return {String} res.symbol - currency symbol e.g. BTC
  * @return {Boolean} res.error - true if errors occurred during request for capacities
@@ -60,7 +65,7 @@ async function getCapacities (engine, symbol, outstandingSendCapacity, outstandi
       outstandingSendCapacity: Big(outstandingSendCapacity).div(quantumsPerCommon).toString()
     }
   } catch (e) {
-    console.log('Martine is going to work on the next ticket')
+    logger.debug(`Received error when trying to get engine capacities for ${symbol}`, { outstandingReceiveCapacity, outstandingSendCapacity })
 
     return {
       symbol,

--- a/broker-daemon/broker-rpc/wallet-service/get-trading-capacities.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-trading-capacities.js
@@ -5,40 +5,67 @@ const SIDES = Object.freeze({
   BID: 'BID',
   ASK: 'ASK'
 })
+
 /**
  * Grabs the total balance and total channel balance from a specified engine
  *
  * @param {Engine} SparkSwap Payment Channel Network Engine
  * @param {String} symbol
- * @param {String} amount of outstanding send capacity for the given currency
- * @param {String} amount of outstanding receive capacity for the given currency
- * @return {Object} including symbol and available, pending, outstanding, and inactive capacties for sending and receiving
+ * @param {String} outstandingSendCapacity - amount of outstanding send capacity for the given currency
+ * @param {String} outstandingReceiveCapacity - amount of outstanding receive capacity for the given currency
+ * @param {Object} opts
+ * @param {Logger} logger
+ * @return {Object} res
+ * @return {String} res.symbol - currency symbol e.g. BTC
+ * @return {Boolean} res.error - true if errors occurred during request for capacities
+ * @return {String} res.availableReceiveCapacity
+ * @return {String} res.availableSendCapacity
+ * @return {String} res.pendingSendCapacity
+ * @return {String} res.pendingReceiveCapacity
+ * @return {String} res.inactiveSendCapacity
+ * @return {String} res.inactiveReceiveCapacity
+ * @return {String} res.outstandingReceiveCapacity
+ * @return {String} res.outstandingSendCapacity
  */
-async function getCapacities (engine, symbol, outstandingSendCapacity, outstandingReceiveCapacity) {
-  const { quantumsPerCommon: divideBy } = currencies.find(({ symbol: configSymbol }) => configSymbol === symbol) || {}
-  if (!divideBy) throw new Error(`Currency was not found when trying to get trading capacities: ${this.symbol}`)
+async function getCapacities (engine, symbol, outstandingSendCapacity, outstandingReceiveCapacity, { logger }) {
+  const { quantumsPerCommon } = currencies.find(({ symbol: configSymbol }) => configSymbol === symbol) || {}
 
-  const [
-    openChannelCapacities,
-    pendingChannelCapacities
-  ] = await Promise.all([
-    engine.getOpenChannelCapacities(),
-    engine.getPendingChannelCapacities()
-  ])
+  if (!quantumsPerCommon) {
+    throw new Error(`Currency was not found when trying to get trading capacities: ${this.symbol}`)
+  }
 
-  const activeChannelCapacities = openChannelCapacities.active
-  const inactiveChannelCapacities = openChannelCapacities.inactive
+  try {
+    const [
+      openChannelCapacities,
+      pendingChannelCapacities
+    ] = await Promise.all([
+      engine.getOpenChannelCapacities(),
+      engine.getPendingChannelCapacities()
+    ])
 
-  return {
-    symbol,
-    availableReceiveCapacity: Big(activeChannelCapacities.remoteBalance).minus(outstandingReceiveCapacity).div(divideBy).toString(),
-    availableSendCapacity: Big(activeChannelCapacities.localBalance).minus(outstandingSendCapacity).div(divideBy).toString(),
-    pendingSendCapacity: Big(pendingChannelCapacities.localBalance).div(divideBy).toString(),
-    pendingReceiveCapacity: Big(pendingChannelCapacities.remoteBalance).div(divideBy).toString(),
-    inactiveSendCapacity: Big(inactiveChannelCapacities.localBalance).div(divideBy).toString(),
-    inactiveReceiveCapacity: Big(inactiveChannelCapacities.remoteBalance).div(divideBy).toString(),
-    outstandingReceiveCapacity: Big(outstandingReceiveCapacity).div(divideBy).toString(),
-    outstandingSendCapacity: Big(outstandingSendCapacity).div(divideBy).toString()
+    const {
+      active: activeChannelCapacities,
+      inactive: inactiveChannelCapacities
+    } = openChannelCapacities
+
+    return {
+      symbol,
+      availableReceiveCapacity: Big(activeChannelCapacities.remoteBalance).minus(outstandingReceiveCapacity).div(quantumsPerCommon).toString(),
+      availableSendCapacity: Big(activeChannelCapacities.localBalance).minus(outstandingSendCapacity).div(quantumsPerCommon).toString(),
+      pendingSendCapacity: Big(pendingChannelCapacities.localBalance).div(quantumsPerCommon).toString(),
+      pendingReceiveCapacity: Big(pendingChannelCapacities.remoteBalance).div(quantumsPerCommon).toString(),
+      inactiveSendCapacity: Big(inactiveChannelCapacities.localBalance).div(quantumsPerCommon).toString(),
+      inactiveReceiveCapacity: Big(inactiveChannelCapacities.remoteBalance).div(quantumsPerCommon).toString(),
+      outstandingReceiveCapacity: Big(outstandingReceiveCapacity).div(quantumsPerCommon).toString(),
+      outstandingSendCapacity: Big(outstandingSendCapacity).div(quantumsPerCommon).toString()
+    }
+  } catch (e) {
+    console.log('Martine is going to work on the next ticket')
+
+    return {
+      symbol,
+      error: true
+    }
   }
 }
 
@@ -48,13 +75,14 @@ async function getCapacities (engine, symbol, outstandingSendCapacity, outstandi
  * @function
  * @param {GrpcUnaryMethod~request} request - request object
  * @param {Object} request.params
- * @param {Map} request.engines
- * @param {Logger} request.logger
+ * @param {Map<symbol, Engine>} request.engines
  * @param {Object} request.orderbooks - initialized orderbooks
+ * @param {BlockOrderWorker} request.blockOrderWorker
+ * @param {Logger} request.logger
  * @param {function} responses.GetTradingCapacitiesResponse
  * @return {GetTradingCapacitiesResponse}
  */
-async function getTradingCapacities ({ params, logger, engines, orderbooks, blockOrderWorker }, { GetTradingCapacitiesResponse }) {
+async function getTradingCapacities ({ params, engines, orderbooks, blockOrderWorker, logger }, { GetTradingCapacitiesResponse }) {
   const { market } = params
   const orderbook = orderbooks.get(market)
 
@@ -73,6 +101,8 @@ async function getTradingCapacities ({ params, logger, engines, orderbooks, bloc
     throw new Error(`No engine available for ${counterSymbol}`)
   }
 
+  logger.debug(`Calculating active funds for ${market}`)
+
   const [
     { activeOutboundAmount: committedCounterSendCapacity, activeInboundAmount: committedBaseReceiveCapacity },
     { activeOutboundAmount: committedBaseSendCapacity, activeInboundAmount: committedCounterReceiveCapacity }
@@ -81,10 +111,18 @@ async function getTradingCapacities ({ params, logger, engines, orderbooks, bloc
     blockOrderWorker.calculateActiveFunds(market, SIDES.ASK)
   ])
 
-  const [baseSymbolCapacities, counterSymbolCapacities] = await Promise.all([
-    getCapacities(baseEngine, baseSymbol, committedBaseSendCapacity, committedBaseReceiveCapacity),
-    getCapacities(counterEngine, counterSymbol, committedCounterSendCapacity, committedCounterReceiveCapacity)
+  // Capacities will always be returned for each side of the market, however if
+  // the engine is unavailable, we will receive blank capacities w/ an `error` property
+  // in the payload of the returned data
+  const [
+    baseSymbolCapacities,
+    counterSymbolCapacities
+  ] = await Promise.all([
+    getCapacities(baseEngine, baseSymbol, committedBaseSendCapacity, committedBaseReceiveCapacity, { logger }),
+    getCapacities(counterEngine, counterSymbol, committedCounterSendCapacity, committedCounterReceiveCapacity, { logger })
   ])
+
+  logger.debug(`Received capacities for market ${market}`, { baseSymbolCapacities, counterSymbolCapacities })
 
   return new GetTradingCapacitiesResponse({ baseSymbolCapacities, counterSymbolCapacities })
 }

--- a/broker-daemon/broker-rpc/wallet-service/release-channels.js
+++ b/broker-daemon/broker-rpc/wallet-service/release-channels.js
@@ -9,6 +9,7 @@ const RELEASE_STATE = Object.freeze({
   RELEASED: 'RELEASED',
   FAILED: 'FAILED'
 })
+
 /**
  * Close channels on a specific engine
  *

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -889,6 +889,8 @@ message Capacity {
   string outstanding_send_capacity = 10;
   // Total outbound outstanding amount. This is currently in base units (e.g. Satoshis/Litoshis)
   string outstanding_receive_capacity = 11;
+  // true/false for any errors that may have occurred when requesting capacity for a particular currency
+  bool error = 20;
 }
 
 /**

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -889,8 +889,10 @@ message Capacity {
   string outstanding_send_capacity = 10;
   // Total outbound outstanding amount. This is currently in base units (e.g. Satoshis/Litoshis)
   string outstanding_receive_capacity = 11;
-  // true/false for any errors that may have occurred when requesting capacity for a particular currency
-  bool error = 20;
+  // Status of capacities. OK for success or FAILED if an error occurred when requesting capacities
+  string status = 20;
+  // Error message if status is FAILED
+  string error = 21;
 }
 
 /**


### PR DESCRIPTION
## Description
If a single daemon is down, the network-status call will fail to display information for all currencies. We should make the `wallet network-status` call resilient to engine failures to show information for daemons that are running.

![screen shot 2018-12-07 at 6 08 16 pm](https://user-images.githubusercontent.com/5478311/49680602-1bc22680-fa4b-11e8-98de-b08f63c2df4e.png)



## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
