### PR TITLE
Feature: use a custom logger instead of message ID in grpc methods

### DIFF
--- a/broker-daemon/broker-rpc/admin-service/index.spec.js
+++ b/broker-daemon/broker-rpc/admin-service/index.spec.js
@@ -132,19 +132,19 @@ describe('AdminService', () => {
 
     describe('request options', () => {
       it('passes in the logger', () => {
-        expect(callArgs[2]).to.have.property('logger', transformedLogger)
+        expect(callArgs[1]).to.have.property('logger', transformedLogger)
       })
 
       it('passes in a relayer', () => {
-        expect(callArgs[2]).to.have.property('relayer', relayer)
+        expect(callArgs[1]).to.have.property('relayer', relayer)
       })
 
       it('passes in the engines', () => {
-        expect(callArgs[2]).to.have.property('engines', engines)
+        expect(callArgs[1]).to.have.property('engines', engines)
       })
 
       it('passes in auth', () => {
-        expect(callArgs[2]).to.have.property('auth', auth)
+        expect(callArgs[1]).to.have.property('auth', auth)
       })
     })
 
@@ -178,15 +178,15 @@ describe('AdminService', () => {
 
     describe('request options', () => {
       it('passes in the logger', () => {
-        expect(callArgs[2]).to.have.property('logger', transformedLogger)
+        expect(callArgs[1]).to.have.property('logger', transformedLogger)
       })
 
       it('passes in a relayer', () => {
-        expect(callArgs[2]).to.have.property('relayer', relayer)
+        expect(callArgs[1]).to.have.property('relayer', relayer)
       })
 
       it('passes in auth', () => {
-        expect(callArgs[2]).to.have.property('auth', auth)
+        expect(callArgs[1]).to.have.property('auth', auth)
       })
     })
 

--- a/broker-daemon/broker-rpc/admin-service/index.spec.js
+++ b/broker-daemon/broker-rpc/admin-service/index.spec.js
@@ -6,6 +6,8 @@ const AdminService = rewire(path.resolve(__dirname))
 describe('AdminService', () => {
   let healthCheckStub
   let getIdentityStub
+  let transformLoggerStub
+  let transformedLogger
 
   let GrpcMethod
   let register
@@ -56,6 +58,13 @@ describe('AdminService', () => {
     healthCheckStub = sinon.stub()
     AdminService.__set__('healthCheck', healthCheckStub)
     AdminService.__set__('getIdentity', getIdentityStub)
+
+    transformedLogger = {
+      info: sinon.stub(),
+      error: sinon.stub()
+    }
+    transformLoggerStub = sinon.stub().returns(transformedLogger)
+    AdminService.__set__('transformLogger', transformLoggerStub)
   })
 
   beforeEach(() => {
@@ -121,13 +130,9 @@ describe('AdminService', () => {
       expect(callArgs[0]).to.be.equal(healthCheckStub)
     })
 
-    it('provides a message id', () => {
-      expect(callArgs[1]).to.be.equal('[AdminService:healthCheck]')
-    })
-
     describe('request options', () => {
       it('passes in the logger', () => {
-        expect(callArgs[2]).to.have.property('logger', logger)
+        expect(callArgs[2]).to.have.property('logger', transformedLogger)
       })
 
       it('passes in a relayer', () => {
@@ -171,13 +176,9 @@ describe('AdminService', () => {
       expect(callArgs[0]).to.be.equal(getIdentityStub)
     })
 
-    it('provides a message id', () => {
-      expect(callArgs[1]).to.be.equal('[AdminService:getIdentity]')
-    })
-
     describe('request options', () => {
       it('passes in the logger', () => {
-        expect(callArgs[2]).to.have.property('logger', logger)
+        expect(callArgs[2]).to.have.property('logger', transformedLogger)
       })
 
       it('passes in a relayer', () => {

--- a/broker-daemon/utils/index.js
+++ b/broker-daemon/utils/index.js
@@ -18,6 +18,7 @@ const delay = require('./delay')
 const eachRecord = require('./each-record')
 const Checksum = require('./checksum')
 const payInvoice = require('./pay-invoice')
+const transformLogger = require('./transform-logger')
 
 module.exports = {
   getRecords,
@@ -39,5 +40,6 @@ module.exports = {
   delay,
   eachRecord,
   Checksum,
-  payInvoice
+  payInvoice,
+  transformLogger
 }

--- a/broker-daemon/utils/transform-logger.js
+++ b/broker-daemon/utils/transform-logger.js
@@ -1,0 +1,50 @@
+/**
+ * Default transform function which is a no-op
+ * @param  {Function} logFn function to call to log output
+ * @param  {...mixed} args  Arguments called on the log function
+ * @return {mixed}
+ */
+const passThrough = (logFn, ...args) => {
+  return logFn(...args)
+}
+
+/**
+ * Array of functions that we want to transform on a logger object
+ * @constant
+ * @type {Array}
+ */
+const logFns = [
+  'info',
+  'debug',
+  'warn',
+  'log',
+  'error'
+]
+
+/**
+ * Transform a logger object by applying a function to every input.
+ * @param  {Logger}   logger    Logger object to transform, e.g. `console`
+ * @param  {Function} transform Function to apply to every input of the logger
+ * @return {Logger}             New logger with the transform function applied
+ */
+function transformLogger (logger, transform = passThrough) {
+  // copy over every log function to a new object that keeps the
+  // original context of the logger, skipping unavailable functions
+  const boundLogger = logFns.reduce((obj, fnName) => {
+    if (logger[fnName]) {
+      obj[fnName] = logger[fnName].bind(logger)
+    }
+    return obj
+  }, {})
+
+  // map the `boundLogger` into an identical object with each
+  // function passing through the `transform` function
+  return Object.entries(boundLogger).map(([key, fn]) => {
+    return [key, (...args) => transform(fn, ...args)]
+  }).reduce((obj, [key, transformedFn]) => {
+    obj[key] = transformedFn
+    return obj
+  }, {})
+}
+
+module.exports = transformLogger

--- a/broker-daemon/utils/transform-logger.spec.js
+++ b/broker-daemon/utils/transform-logger.spec.js
@@ -1,0 +1,64 @@
+const { sinon, expect } = require('test/test-helper')
+const transformLogger = require('./transform-logger')
+
+describe('transformLogger', () => {
+  let logger
+
+  beforeEach(() => {
+    logger = {
+      info: sinon.stub(),
+      debug: sinon.stub(),
+      warn: sinon.stub(),
+      log: sinon.stub(),
+      error: sinon.stub()
+    }
+  })
+
+  it('creates a new object with all log properties of the old', () => {
+    const transformed = transformLogger(logger)
+
+    expect(transformed).to.be.an('object')
+    expect(transformed).to.not.be.equal(logger)
+    expect(transformed).to.have.property('info')
+    expect(transformed).to.have.property('debug')
+    expect(transformed).to.have.property('warn')
+    expect(transformed).to.have.property('log')
+    expect(transformed).to.have.property('error')
+  })
+
+  it('skips non-existent loggers', () => {
+    delete logger.info
+    const transformed = transformLogger(logger)
+
+    expect(transformed).to.not.have.property('info')
+  })
+
+  it('calls log functions in context of the logger', () => {
+    const transformed = transformLogger(logger)
+
+    transformed.log('fake message')
+
+    expect(logger.log).to.have.been.calledOnce()
+    expect(logger.log).to.have.been.calledOn(logger)
+  })
+
+  it('by default passes through unmutated', () => {
+    const transformed = transformLogger(logger)
+
+    transformed.log('fake message', { param: 7 })
+
+    expect(logger.log).to.have.been.calledOnce()
+    expect(logger.log).to.have.been.calledWith('fake message', { param: 7 })
+  })
+
+  it('applies the transform function', () => {
+    const transformed = transformLogger(logger, (logFn, msg, params) => {
+      logFn(msg + ': howdy', { param: params.param + 3 })
+    })
+
+    transformed.log('fake message', { param: 7 })
+
+    expect(logger.log).to.have.been.calledOnce()
+    expect(logger.log).to.have.been.calledWith('fake message: howdy', { param: 10 })
+  })
+})


### PR DESCRIPTION
## Description
We need to filter out some data from certain logs to prevent sensitive information from being accidentally persisted.

Rather than further complicate grpc methods, this change uses a custom logger object to do filtering our behalf.

This is a proof-of-concept of the approach.

## Related PRs
https://github.com/sparkswap/grpc-methods/pull/13

## Todos
- [x] AdminService
- [ ] InfoService
- [ ] OrderService
- [ ] OrderbookService
- [ ] WalletService
- [ ] Filter cipher payload