### PR TITLE
throw error if get balances returns an error

### DIFF
--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -154,7 +154,11 @@ async function commit (args, opts, logger) {
 
     const { balances } = await client.walletService.getBalances({})
 
-    const { uncommittedBalance } = balances.find(({ symbol: s }) => s === symbol)
+    const { uncommittedBalance, error } = balances.find(({ symbol: s }) => s === symbol)
+
+    if (error) {
+      throw new Error(`Error fetching current balances from ${symbol} engine`)
+    }
 
     const totalUncommittedBalance = Big(uncommittedBalance)
 


### PR DESCRIPTION
## Description
There is a bug in commit where we call Big on an empty string if the engine is down because the getBalances call returns empty strings and an error. Before calling Big on the uncommitted balance, we should see if there is an error in the balances object, and throw an error if there is.


## Related PRs
List related PRs if applicable


## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
