### PR TITLE
Feature/recreate state machines on startup

### DIFF
--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -69,10 +69,10 @@ class BlockOrderWorker extends EventEmitter {
   async initialize () {
     await this.ordersByHash.ensureIndex()
     await this.ordersByOrderId.ensureIndex()
-    await this.retryIndeterminateOrdersFills()
+    await this.settleIndeterminateOrdersFills()
   }
 
-  async retryIndeterminateOrdersFills () {
+  async settleIndeterminateOrdersFills () {
     const blockOrders = await getRecords(this.store, BlockOrder.fromStorage.bind(BlockOrder))
 
     for (let blockOrder of blockOrders) {

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -125,9 +125,11 @@ class BlockOrderWorker extends EventEmitter {
         // its prefix range.
         Fill.rangeForBlockOrder(blockOrder.id)
       )
-      for (let fsm in fillStateMachines) {
-        fsm.applyFsmListeners(fsm, blockOrder)
-      }
+      const { FILLED, EXECUTED } = FillStateMachine.STATES
+      fillStateMachines.filter((fsm) => [FILLED, EXECUTED].includes(fsm.state)).forEach((fsm) => {
+        this.applyOsmListeners(fsm, blockOrder)
+        fsm.triggerState()
+      })
     }
   }
 

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -96,8 +96,11 @@ class BlockOrderWorker extends EventEmitter {
         // its prefix range.
         Order.rangeForBlockOrder(blockOrder.id)
       )
-      orderStateMachines.forEach((osm) => {
+
+      const { CREATED, PLACED, EXECUTING } = OrderStateMachine.STATES
+      orderStateMachines.filter((osm) => [CREATED, PLACED, EXECUTING].includes(osm.state)).forEach((osm) => {
         this.applyOsmListeners(osm, blockOrder)
+        osm.triggerState()
       })
 
       const fillStateMachines = await getRecords(

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -72,6 +72,11 @@ class BlockOrderWorker extends EventEmitter {
     await this.settleIndeterminateOrdersFills()
   }
 
+  /**
+   * When the broker goes down, there can be orders and fills in an unresolved state. We should rehydrate the state machines
+   * from the database and attempt to trigger them into a resolved state
+   * @return {Void}
+   */
   async settleIndeterminateOrdersFills () {
     const blockOrders = await getRecords(this.store, BlockOrder.fromStorage.bind(BlockOrder))
     for (let blockOrder of blockOrders) {
@@ -93,6 +98,11 @@ class BlockOrderWorker extends EventEmitter {
     }
   }
 
+  /**
+   * Given a blockOrder, return associated OrderStateMachines
+   * @param {BlockOrder}
+   * @return {Array<OrderStateMachine>}
+   */
   async getInterderminateOrderStateMachines (blockOrder) {
     const osms = await getRecords(
       this.ordersStore,
@@ -117,6 +127,11 @@ class BlockOrderWorker extends EventEmitter {
     return osms
   }
 
+  /**
+   * Given a blockOrder, return associated FillStateMachines
+   * @param {BlockOrder}
+   * @return {Array<FillStateMachine>}
+   */
   async getInterderminateFillStateMachines (blockOrder) {
     const fsms = await getRecords(
       this.fillsStore,

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -527,6 +527,11 @@ class BlockOrderWorker extends EventEmitter {
       osm.removeAllListeners()
     })
 
+    // remove listeners if the osm is cancelled, should not affect block order status
+    osm.once('cancel', async () => {
+      osm.removeAllListeners()
+    })
+
     return osm
   }
 
@@ -678,6 +683,11 @@ class BlockOrderWorker extends EventEmitter {
           this.logger.error(`BlockOrder failed on setting a failed status from fill`, { id: blockOrder.id, error: e.stack })
         })
       }
+    })
+
+    // remove listeners if the fsm is cancelled, should not affect block order status
+    fsm.once('cancel', async () => {
+      fsm.removeAllListeners()
     })
   }
 }

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -265,6 +265,7 @@ describe('BlockOrderWorker', () => {
       worker = new BlockOrderWorker({ orderbooks, store, logger, relayer, engines })
       worker.ordersByHash = { ensureIndex: sinon.stub().resolves() }
       worker.ordersByOrderId = { ensureIndex: sinon.stub().resolves() }
+      worker.settleIndeterminateOrdersFills = sinon.stub().resolves()
     })
 
     it('rebuilds the ordersByHash index', async () => {
@@ -283,6 +284,218 @@ describe('BlockOrderWorker', () => {
       worker.ordersByHash.ensureIndex.rejects()
 
       return expect(worker.initialize()).to.eventually.be.rejectedWith(Error)
+    })
+
+    it('settles orders and fills in indeterminate states', async () => {
+      await worker.initialize()
+
+      expect(worker.settleIndeterminateOrdersFills).to.have.been.calledOnce()
+    })
+  })
+
+  describe('settleIndeterminateOrdersFills', () => {
+    let worker
+    let createdOsm
+    let cancelledOsm
+    let orderStateMachines
+    let createdFsm
+    let executedFsm
+    let fillStateMachines
+    let getRecords
+
+    beforeEach(() => {
+      cancelledOsm = { state: 'cancelled', triggerState: sinon.stub() }
+      createdOsm = { state: 'created', triggerState: sinon.stub() }
+      createdFsm = { state: 'created', triggerState: sinon.stub() }
+      executedFsm = { state: 'executed', triggerState: sinon.stub() }
+      orderStateMachines = [cancelledOsm, createdOsm]
+      fillStateMachines = [createdFsm, executedFsm]
+
+      getRecords = sinon.stub()
+      getRecords = sinon.stub().resolves([{blockOrderId: '1234'}])
+      BlockOrderWorker.__set__('getRecords', getRecords)
+      BlockOrder.fromStorage = {
+        bind: sinon.stub()
+      }
+      worker = new BlockOrderWorker({ orderbooks, store, logger, relayer, engines })
+      worker.getInterderminateOrderStateMachines = sinon.stub().resolves(orderStateMachines)
+      worker.getInterderminateFillStateMachines = sinon.stub().resolves(fillStateMachines)
+      worker.applyOsmListeners = sinon.stub()
+      worker.applyFsmListeners = sinon.stub()
+    })
+
+    it('retrieves all blockOrders from the store', async () => {
+      await worker.settleIndeterminateOrdersFills()
+
+      expect(getRecords).to.have.been.calledWith(store, BlockOrder.fromStorage.bind(BlockOrder))
+    })
+
+    it('retrieves orderStateMachines for each blockOrder', async () => {
+      await worker.settleIndeterminateOrdersFills()
+
+      expect(worker.getInterderminateFillStateMachines).to.have.been.calledWith({blockOrderId: '1234'})
+    })
+
+    it('does not apply listeners to osm in finished state', async () => {
+      await worker.settleIndeterminateOrdersFills()
+
+      expect(worker.applyOsmListeners).to.not.have.been.calledWith(cancelledOsm, {blockOrderId: '1234'})
+    })
+
+    it('applies listeners to each osm in an indeterminate state', async () => {
+      await worker.settleIndeterminateOrdersFills()
+
+      expect(worker.applyOsmListeners).to.have.been.calledWith(createdOsm, {blockOrderId: '1234'})
+    })
+
+    it('triggers the osm to the next state if the osm is in an indeterminate state', async () => {
+      await worker.settleIndeterminateOrdersFills()
+
+      expect(createdOsm.triggerState).to.have.been.called()
+    })
+
+    it('does not trigger the osm to the next state if the osm is in a finished state', async () => {
+      await worker.settleIndeterminateOrdersFills()
+
+      expect(cancelledOsm.triggerState).to.not.have.been.called()
+    })
+
+    it('retrieves fillStateMachines for each blockOrder', async () => {
+      await worker.settleIndeterminateOrdersFills()
+
+      expect(worker.getInterderminateOrderStateMachines).to.have.been.calledWith({blockOrderId: '1234'})
+    })
+
+    it('does not apply listeners to fsm in finished state', async () => {
+      await worker.settleIndeterminateOrdersFills()
+
+      expect(worker.applyFsmListeners).to.not.have.been.calledWith(executedFsm, {blockOrderId: '1234'})
+    })
+
+    it('applies listeners to each fsm in an indeterminate state', async () => {
+      await worker.settleIndeterminateOrdersFills()
+
+      expect(worker.applyFsmListeners).to.have.been.calledWith(createdFsm, {blockOrderId: '1234'})
+    })
+
+    it('triggers the fsm to the next state if the fsm is in an indeterminate state', async () => {
+      await worker.settleIndeterminateOrdersFills()
+
+      expect(createdFsm.triggerState).to.have.been.called()
+    })
+
+    it('does not trigger the fsm to the next state if the fsm is in a finished state', async () => {
+      await worker.settleIndeterminateOrdersFills()
+
+      expect(executedFsm.triggerState).to.not.have.been.called()
+    })
+  })
+
+  describe('getInterderminateOrderStateMachines', () => {
+    let ordersStore
+    let getRecords
+    let orderStateMachines = [
+      {
+        id: 'someId'
+      }
+    ]
+    let worker
+    let blockOrder
+
+    beforeEach(() => {
+      ordersStore = {
+        put: sinon.stub()
+      }
+      blockOrder = {id: '1234'}
+      getRecords = sinon.stub().resolves(orderStateMachines)
+
+      getRecords.withArgs(ordersStore).resolves(orderStateMachines)
+
+      BlockOrderWorker.__set__('getRecords', getRecords)
+
+      worker = new BlockOrderWorker({ orderbooks, store, logger, relayer, engines })
+      worker.ordersStore = ordersStore
+    })
+
+    it('retrieves all open orders associated with the block order', async () => {
+      const fakeRange = 'myrange'
+      Order.rangeForBlockOrder.returns(fakeRange)
+
+      await worker.getInterderminateOrderStateMachines(blockOrder)
+
+      expect(Order.rangeForBlockOrder).to.have.been.calledOnce()
+      expect(Order.rangeForBlockOrder).to.have.been.calledWith(blockOrder.id)
+      expect(getRecords).to.have.been.calledOnce()
+      expect(getRecords).to.have.been.calledWith(ordersStore, sinon.match.func, fakeRange)
+    })
+
+    it('inflates orderStateMachines', async () => {
+      const fakeKey = 'mykey'
+      const fakeOSM = 'somestate'
+      const fakeValue = JSON.stringify({ orderStateMachine: fakeOSM })
+      OrderStateMachine.fromStore = sinon.stub()
+
+      await worker.getInterderminateOrderStateMachines(blockOrder)
+
+      const eachOrder = getRecords.withArgs(ordersStore).args[0][1]
+
+      eachOrder(fakeKey, fakeValue)
+      expect(OrderStateMachine.fromStore).to.have.been.calledOnce()
+      expect(OrderStateMachine.fromStore).to.have.been.calledWith({store: ordersStore, logger, relayer, engines}, {key: fakeKey, value: fakeValue})
+    })
+  })
+
+  describe('getInterderminateFillStateMachines', () => {
+    let fillsStore
+    let getRecords
+    let fillStateMachines = [
+      {
+        id: 'someId'
+      }
+    ]
+    let worker
+    let blockOrder
+
+    beforeEach(() => {
+      fillsStore = {
+        put: sinon.stub()
+      }
+      blockOrder = {id: '1234'}
+      getRecords = sinon.stub().resolves(fillStateMachines)
+
+      getRecords.withArgs(fillsStore).resolves(fillStateMachines)
+
+      BlockOrderWorker.__set__('getRecords', getRecords)
+
+      worker = new BlockOrderWorker({ orderbooks, store, logger, relayer, engines })
+      worker.fillsStore = fillsStore
+    })
+
+    it('retrieves all open fills associated with the block order', async () => {
+      const fakeRange = 'myrange'
+      Fill.rangeForBlockOrder.returns(fakeRange)
+
+      await worker.getInterderminateFillStateMachines(blockOrder)
+
+      expect(Fill.rangeForBlockOrder).to.have.been.calledOnce()
+      expect(Fill.rangeForBlockOrder).to.have.been.calledWith(blockOrder.id)
+      expect(getRecords).to.have.been.calledOnce()
+      expect(getRecords).to.have.been.calledWith(fillsStore, sinon.match.func, fakeRange)
+    })
+
+    it('inflates orderStateMachines', async () => {
+      const fakeKey = 'mykey'
+      const fakeFSM = 'somestate'
+      const fakeValue = JSON.stringify({ fillStateMachine: fakeFSM })
+      FillStateMachine.fromStore = sinon.stub()
+
+      await worker.getInterderminateFillStateMachines(blockOrder)
+
+      const eachOrder = getRecords.withArgs(fillsStore).args[0][1]
+
+      eachOrder(fakeKey, fakeValue)
+      expect(FillStateMachine.fromStore).to.have.been.calledOnce()
+      expect(FillStateMachine.fromStore).to.have.been.calledWith({store: fillsStore, logger, relayer, engines}, {key: fakeKey, value: fakeValue})
     })
   })
 
@@ -1678,6 +1891,24 @@ describe('BlockOrderWorker', () => {
         expect(loggerErrorStub).to.have.been.calledWith(sinon.match('BlockOrder failed'), sinon.match.any)
       })
     })
+
+    describe('cancel event', async () => {
+      let cancelListener
+
+      it('registers an event on an order for order cancellation', async () => {
+        await worker._fillOrders(blockOrder, orders, targetDepth)
+
+        expect(onceStub).to.have.been.calledWith('cancel', sinon.match.func)
+      })
+
+      it('registers an event on an order for order cancellation', async () => {
+        await worker._fillOrders(blockOrder, orders, targetDepth)
+        cancelListener = onceStub.withArgs('cancel').args[1][1]
+        await cancelListener()
+
+        expect(removeAllListenersStub).to.have.been.called()
+      })
+    })
   })
 
   describe('#applyOsmListeners', () => {
@@ -1809,6 +2040,24 @@ describe('BlockOrderWorker', () => {
         await rejectListener()
         expect(failBlockOrderStub).to.have.been.calledOnce()
         expect(loggerErrorStub).to.have.been.calledWith(sinon.match('BlockOrder failed'), sinon.match.any)
+      })
+    })
+
+    describe('cancel event', () => {
+      let cancelListener
+
+      beforeEach(() => {
+        cancelListener = onceStub.withArgs('cancel').args[0][1]
+      })
+
+      it('registers an event on an order for order cancellation', async () => {
+        expect(onceStub).to.have.been.calledWith('cancel', sinon.match.func)
+      })
+
+      it('registers an event on an order for order cancellation', async () => {
+        await cancelListener()
+
+        expect(removeAllListenersStub).to.have.been.called()
       })
     })
   })

--- a/broker-daemon/state-machines/fill-state-machine.js
+++ b/broker-daemon/state-machines/fill-state-machine.js
@@ -391,7 +391,8 @@ FillStateMachine.create = async function (initParams, ...createParams) {
 FillStateMachine.STATES = Object.freeze({
   NONE: 'none',
   CREATED: 'created',
-  FILLED: 'filled'
+  FILLED: 'filled',
+  EXECUTED: 'executed'
 })
 
 module.exports = FillStateMachine

--- a/broker-daemon/state-machines/fill-state-machine.js
+++ b/broker-daemon/state-machines/fill-state-machine.js
@@ -39,7 +39,7 @@ const FillStateMachine = StateMachine.factory({
     new StateMachineHistory(),
     new StateMachineRejection(),
     new StateMachineEvents(),
-    new StateMachineLogging(),
+    new StateMachineLogging({skipTransitions: ['goto']}),
     new StateMachinePersistence({
       /**
        * @type {StateMachinePersistence~KeyAccessor}

--- a/broker-daemon/state-machines/fill-state-machine.js
+++ b/broker-daemon/state-machines/fill-state-machine.js
@@ -116,7 +116,12 @@ const FillStateMachine = StateMachine.factory({
      * execute transition: execute the swap itself
      * @type {Object}
      */
-    { name: 'execute', from: 'filled', to: 'executed' }
+    { name: 'execute', from: 'filled', to: 'executed' },
+    /**
+     * execute transition: execute the swap itself
+     * @type {Object}
+     */
+    { name: 'cancel', from: 'created', to: 'cancelled' }
   ],
   /**
    * Instantiate the data on the state machine
@@ -284,13 +289,20 @@ const FillStateMachine = StateMachine.factory({
     },
 
     /**
-     * Listen for order executions
-     * This is done based on the state and not the transition so that it gets actioned when being re-hydrated from storage
-     * [is that the right thing to do?]
+     * Call the trigger execution function. This is done this way so that we do not execute automatically if we are rehydrating
+     * a fill state machine in a filled state
      * @param  {Object} lifecycle Lifecycle object passed by javascript-state-machine
      * @return {void}
      */
-    onEnterFilled: function (lifecycle) {
+    onAfterFillOrder: function (lifecycle) {
+      this.triggerExecute(lifecycle)
+    },
+    /**
+     * Listen for order executions
+     * @param  {Object} lifecycle Lifecycle object passed by javascript-state-machine
+     * @return {void}
+     */
+    triggerExecute: function (lifecycle) {
       const { fillId } = this.fill
       this.logger.info(`In filled state, attempting to listen for executions on fill ${fillId}`)
 
@@ -369,6 +381,18 @@ const FillStateMachine = StateMachine.factory({
      */
     shouldRetry: function () {
       return !!this.fill.error && this.fill.error.message === FILL_ERROR_CODES.ORDER_NOT_PLACED
+    },
+    /**
+     * Trigger settle if we are re-hydrating state into the executing state
+     * @param  {Object} lifecycle Lifecycle object passed by javascript-state-machine
+     * @return {void}
+     */
+    triggerState: function (lifecycle) {
+      if (this.state === 'created') {
+        process.nextTick(() => this.tryTo('cancel'))
+      } else if (this.state === 'filled') {
+        this.triggerExecute()
+      }
     }
   }
 })
@@ -392,7 +416,8 @@ FillStateMachine.STATES = Object.freeze({
   NONE: 'none',
   CREATED: 'created',
   FILLED: 'filled',
-  EXECUTED: 'executed'
+  EXECUTED: 'executed',
+  CANCELLED: 'cancelled'
 })
 
 module.exports = FillStateMachine

--- a/broker-daemon/state-machines/fill-state-machine.js
+++ b/broker-daemon/state-machines/fill-state-machine.js
@@ -120,7 +120,7 @@ const FillStateMachine = StateMachine.factory({
      */
     { name: 'execute', from: 'filled', to: 'executed' },
     /**
-     * execute transition: execute the swap itself
+     * cancel transition: cancel the fill
      * @type {Object}
      */
     { name: 'cancel', from: 'created', to: 'cancelled' }

--- a/broker-daemon/state-machines/fill-state-machine.js
+++ b/broker-daemon/state-machines/fill-state-machine.js
@@ -39,7 +39,9 @@ const FillStateMachine = StateMachine.factory({
     new StateMachineHistory(),
     new StateMachineRejection(),
     new StateMachineEvents(),
-    new StateMachineLogging({skipTransitions: ['goto']}),
+    new StateMachineLogging({
+      skipTransitions: [ 'goto' ]
+    }),
     new StateMachinePersistence({
       /**
        * @type {StateMachinePersistence~KeyAccessor}
@@ -418,6 +420,11 @@ FillStateMachine.STATES = Object.freeze({
   FILLED: 'filled',
   EXECUTED: 'executed',
   CANCELLED: 'cancelled'
+})
+
+FillStateMachine.INDETERMINATE_STATES = Object.freeze({
+  CREATED: 'created',
+  FILLED: 'filled'
 })
 
 module.exports = FillStateMachine

--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -351,7 +351,7 @@ const OrderStateMachine = StateMachine.factory({
     triggerState: function (lifecycle) {
       if (this.state === 'executing') {
         this.triggerComplete()
-      } else if (this.state === 'placed' || this.state === 'created') {
+      } else if (this.state === 'created' || this.state === 'placed') {
         process.nextTick(() => this.tryTo('cancel'))
       }
     },

--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -29,7 +29,9 @@ const OrderStateMachine = StateMachine.factory({
   plugins: [
     new StateMachineHistory(),
     new StateMachineRejection(),
-    new StateMachineLogging({ skipTransitions: ['goto'] }),
+    new StateMachineLogging({
+      skipTransitions: [ 'goto' ]
+    }),
     new StateMachineEvents(),
     new StateMachinePersistence({
       /**
@@ -430,6 +432,12 @@ OrderStateMachine.STATES = Object.freeze({
   CREATED: 'created',
   PLACED: 'placed',
   CANCELLED: 'cancelled',
+  EXECUTING: 'executing'
+})
+
+OrderStateMachine.INDETERMINATE_STATES = Object.freeze({
+  CREATED: 'created',
+  PLACED: 'placed',
   EXECUTING: 'executing'
 })
 

--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -29,7 +29,7 @@ const OrderStateMachine = StateMachine.factory({
   plugins: [
     new StateMachineHistory(),
     new StateMachineRejection(),
-    new StateMachineLogging(),
+    new StateMachineLogging({ skipTransitions: ['goto'] }),
     new StateMachineEvents(),
     new StateMachinePersistence({
       /**
@@ -348,10 +348,10 @@ const OrderStateMachine = StateMachine.factory({
      * @param  {Object} lifecycle Lifecycle object passed by javascript-state-machine
      * @return {void}
      */
-    onAfterGoto: function (lifecycle) {
-      if (lifecycle.to === 'executing') {
+    triggerState: function (lifecycle) {
+      if (this.state === 'executing') {
         this.triggerComplete()
-      } else if (lifecycle.to === 'placed' || lifecycle.to === 'created') {
+      } else if (this.state === 'placed' || this.state === 'created') {
         process.nextTick(() => this.tryTo('cancel'))
       }
     },

--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -93,7 +93,7 @@ const OrderStateMachine = StateMachine.factory({
    */
   transitions: [
     /**
-     * create transition: the first transtion, from 'none' (the default state) to 'created'
+     * create transition: the first transition, from 'none' (the default state) to 'created'
      * @type {Object}
      */
     { name: 'create', from: 'none', to: 'created' },

--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -351,6 +351,8 @@ const OrderStateMachine = StateMachine.factory({
     onAfterGoto: function (lifecycle) {
       if (lifecycle.to === 'executing') {
         this.triggerComplete()
+      } else if (lifecycle.to === 'placed' || lifecycle.to === 'created') {
+        process.nextTick(() => this.tryTo('cancel'))
       }
     },
     /**

--- a/broker-daemon/state-machines/plugins/logging.js
+++ b/broker-daemon/state-machines/plugins/logging.js
@@ -9,9 +9,10 @@ class StateMachineLogging extends StateMachinePlugin {
    * @param  {String} options.loggerName    Property of the host state machine that holds the logger
    * @return {StateMachineRejection}
    */
-  constructor ({ loggerName = 'logger' } = {}) {
+  constructor ({ loggerName = 'logger', skipTransitions = [] } = {}) {
     super()
     this.loggerName = loggerName
+    this.skipTransitions = skipTransitions
   }
 
   /**
@@ -24,19 +25,29 @@ class StateMachineLogging extends StateMachinePlugin {
 
     return {
       onBeforeTransition: function (lifecycle) {
-        this[plugin.loggerName].info(`BEFORE: ${lifecycle.transition}`)
+        if (!plugin.skipTransitions.includes(lifecycle.transition)) {
+          this[plugin.loggerName].info(`BEFORE: ${lifecycle.transition}`)
+        }
       },
       onLeaveState: function (lifecycle) {
-        this[plugin.loggerName].info(`LEAVE: ${lifecycle.from}`)
+        if (!plugin.skipTransitions.includes(lifecycle.transition)) {
+          this[plugin.loggerName].info(`LEAVE: ${lifecycle.from}`)
+        }
       },
       onEnterState: async function (lifecycle) {
-        this[plugin.loggerName].info(`ENTER: ${lifecycle.to}`)
+        if (!plugin.skipTransitions.includes(lifecycle.transition)) {
+          this[plugin.loggerName].info(`ENTER: ${lifecycle.to}`)
+        }
       },
       onAfterTransition: function (lifecycle) {
-        this[plugin.loggerName].info(`AFTER: ${lifecycle.transition}`)
+        if (!plugin.skipTransitions.includes(lifecycle.transition)) {
+          this[plugin.loggerName].info(`AFTER: ${lifecycle.transition}`)
+        }
       },
       onTransition: function (lifecycle) {
-        this[plugin.loggerName].info(`DURING: ${lifecycle.transition} (from ${lifecycle.from} to ${lifecycle.to})`)
+        if (!plugin.skipTransitions.includes(lifecycle.transition)) {
+          this[plugin.loggerName].info(`DURING: ${lifecycle.transition} (from ${lifecycle.from} to ${lifecycle.to})`)
+        }
       }
     }
   }

--- a/broker-daemon/state-machines/plugins/logging.spec.js
+++ b/broker-daemon/state-machines/plugins/logging.spec.js
@@ -1,0 +1,120 @@
+const { expect, sinon } = require('test/test-helper')
+
+const StateMachineLogging = require('./logging')
+const StateMachine = require('../state-machine')
+
+describe.only('StateMachineLogging', () => {
+  describe('observers', () => {
+    let stateMachineLogging
+    let Machine
+    let stateMachine
+    let logger
+    let skipTransitions
+
+    beforeEach(() => {
+      skipTransitions = ['goto']
+      stateMachineLogging = new StateMachineLogging({ skipTransitions })
+      logger = { info: sinon.stub() }
+      Machine = StateMachine.factory({
+        plugins: [
+          stateMachineLogging
+        ],
+        data: function ({ logger }) {
+          return { logger }
+        }
+      })
+
+      stateMachine = new Machine({ logger })
+    })
+
+    it('should have property onBeforeTransition', () => {
+      expect(stateMachineLogging.observers).to.have.property('onBeforeTransition')
+    })
+
+    it('should log onBeforeTransition if transition should not be skipped', () => {
+      const { onBeforeTransition } = stateMachineLogging.observers
+      const lifecycle = { transition: 'start' }
+      onBeforeTransition.call(stateMachine, lifecycle)
+      expect(logger.info).to.have.been.calledWith(`BEFORE: ${lifecycle.transition}`)
+    })
+
+    it('should not log the onBeforeTransition if the transition should be skipped', () => {
+      const { onBeforeTransition } = stateMachineLogging.observers
+      const lifecycle = { transition: 'goto' }
+      onBeforeTransition.call(stateMachine, lifecycle)
+      expect(logger.info).to.not.have.been.called()
+    })
+
+    it('should have property onLeaveState', () => {
+      expect(stateMachineLogging.observers).to.have.property('onLeaveState')
+    })
+
+    it('should log onLeaveState if transition should not be skipped', () => {
+      const { onLeaveState } = stateMachineLogging.observers
+      const lifecycle = { transition: 'start', from: 'something' }
+      onLeaveState.call(stateMachine, lifecycle)
+      expect(logger.info).to.have.been.calledWith(`LEAVE: ${lifecycle.from}`)
+    })
+
+    it('should not log the onLeaveState if the transition should be skipped', () => {
+      const { onLeaveState } = stateMachineLogging.observers
+      const lifecycle = { transition: 'goto' }
+      onLeaveState.call(stateMachine, lifecycle)
+      expect(logger.info).to.not.have.been.called()
+    })
+
+    it('should have property onEnterState', () => {
+      expect(stateMachineLogging.observers).to.have.property('onEnterState')
+    })
+
+    it('should log onEnterState if transition should not be skipped', () => {
+      const { onEnterState } = stateMachineLogging.observers
+      const lifecycle = { transition: 'start', to: 'something' }
+      onEnterState.call(stateMachine, lifecycle)
+      expect(logger.info).to.have.been.calledWith(`ENTER: ${lifecycle.to}`)
+    })
+
+    it('should not log the onEnterState if the transition should be skipped', () => {
+      const { onEnterState } = stateMachineLogging.observers
+      const lifecycle = { transition: 'goto' }
+      onEnterState.call(stateMachine, lifecycle)
+      expect(logger.info).to.not.have.been.called()
+    })
+
+    it('should have property onAfterTransition', () => {
+      expect(stateMachineLogging.observers).to.have.property('onAfterTransition')
+    })
+
+    it('should log onAfterTransition if transition should not be skipped', () => {
+      const { onAfterTransition } = stateMachineLogging.observers
+      const lifecycle = { transition: 'start', to: 'something' }
+      onAfterTransition.call(stateMachine, lifecycle)
+      expect(logger.info).to.have.been.calledWith(`AFTER: ${lifecycle.transition}`)
+    })
+
+    it('should not log the onAfterTransition if the transition should be skipped', () => {
+      const { onAfterTransition } = stateMachineLogging.observers
+      const lifecycle = { transition: 'goto' }
+      onAfterTransition.call(stateMachine, lifecycle)
+      expect(logger.info).to.not.have.been.called()
+    })
+
+    it('should have property onTransition', () => {
+      expect(stateMachineLogging.observers).to.have.property('onTransition')
+    })
+
+    it('should log onTransition if transition should not be skipped', () => {
+      const { onTransition } = stateMachineLogging.observers
+      const lifecycle = { transition: 'start', to: 'something', from: 'somethingElse' }
+      onTransition.call(stateMachine, lifecycle)
+      expect(logger.info).to.have.been.calledWith(`DURING: ${lifecycle.transition} (from ${lifecycle.from} to ${lifecycle.to})`)
+    })
+
+    it('should not log the onTransition if the transition should be skipped', () => {
+      const { onTransition } = stateMachineLogging.observers
+      const lifecycle = { transition: 'goto' }
+      onTransition.call(stateMachine, lifecycle)
+      expect(logger.info).to.not.have.been.called()
+    })
+  })
+})

--- a/broker-daemon/state-machines/plugins/logging.spec.js
+++ b/broker-daemon/state-machines/plugins/logging.spec.js
@@ -3,7 +3,7 @@ const { expect, sinon } = require('test/test-helper')
 const StateMachineLogging = require('./logging')
 const StateMachine = require('../state-machine')
 
-describe.only('StateMachineLogging', () => {
+describe('StateMachineLogging', () => {
   describe('observers', () => {
     let stateMachineLogging
     let Machine

--- a/broker-daemon/state-machines/plugins/persistence.js
+++ b/broker-daemon/state-machines/plugins/persistence.js
@@ -86,10 +86,11 @@ class StateMachinePersistence extends StateMachinePlugin {
   get persistedFields () {
     const fields = {
       state: function (state) {
-        if (state) {
-          this.goto(state)
-        } else {
+        const completedStates = ['rejected', 'cancelled']
+        if (state && completedStates.includes(state)) {
           return this.state
+        } else if (state) {
+          this.goto(state)
         }
       }
     }

--- a/broker-daemon/state-machines/plugins/persistence.js
+++ b/broker-daemon/state-machines/plugins/persistence.js
@@ -86,11 +86,10 @@ class StateMachinePersistence extends StateMachinePlugin {
   get persistedFields () {
     const fields = {
       state: function (state) {
-        const completedStates = ['rejected', 'cancelled']
-        if (state && completedStates.includes(state)) {
-          return this.state
-        } else if (state) {
+        if (state) {
           this.goto(state)
+        } else {
+          return this.state
         }
       }
     }


### PR DESCRIPTION
## Description
When the broker goes down, we can end up with orders/fills in unresolved states. This PR takes care of this by rehydrating those orders/fills on blockOrderWorker initialization and triggering them to run from their current state to completion.

## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
