### PR TITLE
update license to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2018 Kinesis Inc DBA Sparkswap
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ This repo contains source for the following products:
     - Daemon that handles interactions between the user's lightning nodes and the SparkSwap Relayer
 
 Documentation regarding installation and usage can be found in the [sparkswap docs](https://sparkswap.com/docs/getting-started).
+
+### License
+
+The Sparkswap Broker Daemon and Broker CLI are licensed under the [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 [![CircleCI](https://circleci.com/gh/sparkswap/broker.svg?style=svg&circle-token=11fe800209ce8a6839b3c071f8f61ee8a345b026)](https://circleci.com/gh/sparkswap/broker)
 
-SparkSwap Broker CLI + Daemon
+Sparkswap Broker CLI + Daemon
 ===========================
 
 This repo contains source for the following products:
 
-- [`sparkswap` (CLI for SparkSwap Broker Daemon)](./broker-cli)
+- [`sparkswap` (CLI for Sparkswap Broker Daemon)](./broker-cli)
     - User interface for sparkswapd
-- [`sparkswapd` (SparkSwap Broker Daemon)](./broker-daemon)
-    - Daemon that handles interactions between the user's lightning nodes and the SparkSwap Relayer
+- [`sparkswapd` (Sparkswap Broker Daemon)](./broker-daemon)
+    - Daemon that handles interactions between the user's lightning nodes and the Sparkswap Relayer
 
-Documentation regarding installation and usage can be found in the [sparkswap docs](https://sparkswap.com/docs/getting-started).
+Documentation regarding installation and usage can be found in the [Sparkswap docs](https://sparkswap.com/docs/getting-started).
 
 ### License
 

--- a/broker-cli/LICENSE
+++ b/broker-cli/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2018 Kinesis Inc DBA Sparkswap
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/broker-cli/README.md
+++ b/broker-cli/README.md
@@ -1,7 +1,7 @@
-SparkSwap Broker Command Line Interface
+Sparkswap Broker Command Line Interface
 =======================================
 
-`sparkswap` is the standalone command line interface for the SparkSwap Broker Daemon, and is a simple client for its gRPC-based API.
+`sparkswap` is the standalone command line interface for the Sparkswap Broker Daemon, and is a simple client for its gRPC-based API.
 
 1. [Install the `sparkswap` cli](https://sparkswap.com/docs/getting-started/installation#install-the-cli)
 2. [Try it out](https://sparkswap.com/docs/getting-started/first-use)

--- a/broker-cli/README.md
+++ b/broker-cli/README.md
@@ -5,3 +5,7 @@ SparkSwap Broker Command Line Interface
 
 1. [Install the `sparkswap` cli](https://sparkswap.com/docs/getting-started/installation#install-the-cli)
 2. [Try it out](https://sparkswap.com/docs/getting-started/first-use)
+
+### License
+
+The Sparkswap Broker CLI is licensed under the [MIT License](./LICENSE).

--- a/broker-cli/package.json
+++ b/broker-cli/package.json
@@ -24,7 +24,7 @@
     "type": "git",
     "url": "git+https://github.com/sparkswap/broker-cli.git"
   },
-  "author": "",
+  "author": "sparkswap",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/sparkswap/broker-cli/issues"

--- a/broker-cli/package.json
+++ b/broker-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "broker-cli",
   "version": "0.2.0-alpha-preview",
-  "description": "Broker CLI utility to interact with the SparkSwap Broker Daemon",
+  "description": "Broker CLI utility to interact with the Sparkswap Broker Daemon",
   "main": "./bin/sparkswap",
   "scripts": {
     "format": "standard --fix",
@@ -24,7 +24,7 @@
     "type": "git",
     "url": "git+https://github.com/sparkswap/broker-cli.git"
   },
-  "author": "sparkswap",
+  "author": "Sparkswap <dev@sparkswap.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/sparkswap/broker-cli/issues"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "type": "git",
     "url": "git+https://github.com/sparkswap/broker.git"
   },
-  "author": "sparkswap",
+  "author": "Sparkswap <dev@sparkswap.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/sparkswap/broker/issues"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "url": "git+https://github.com/sparkswap/broker.git"
   },
   "author": "sparkswap",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/sparkswap/broker/issues"
   },


### PR DESCRIPTION
## Description
This change adds the MIT license to the Repo and unifies the license choice between the Broker Daemon and Broker CLI.
