### PR TITLE
remove lnd-engine dependency in cli

### DIFF
--- a/broker-cli/commands/health-check.js
+++ b/broker-cli/commands/health-check.js
@@ -15,6 +15,8 @@ const STATUS_CODES = Object.freeze({
 })
 
 /**
+ * Engine status codes we expect to be returned from the engine, defined in:
+ * https://github.com/sparkswap/lnd-engine/blob/master/src/constants/engine-statuses.js
  * @constant
  * @type {Object<key, String>}
  * @default

--- a/broker-cli/commands/health-check.js
+++ b/broker-cli/commands/health-check.js
@@ -1,4 +1,3 @@
-const LndEngine = require('lnd-engine')
 require('colors')
 
 const BrokerDaemonClient = require('../broker-daemon-client')
@@ -13,6 +12,15 @@ const { RPC_ADDRESS_HELP_STRING } = require('../utils/strings')
 const STATUS_CODES = Object.freeze({
   OK: 'OK',
   UNKNOWN: 'UNKNOWN'
+})
+
+/**
+ * @constant
+ * @type {Object<key, String>}
+ * @default
+ */
+const ENGINE_STATUS_CODES = Object.freeze({
+  VALIDATED: 'VALIDATED'
 })
 
 /**
@@ -44,7 +52,7 @@ async function healthCheck (args, opts, logger) {
     }
 
     engineStatus.forEach(({ symbol, status }) => {
-      if (status === LndEngine.STATUSES.VALIDATED) {
+      if (status === ENGINE_STATUS_CODES.VALIDATED) {
         logger.info(`Engine status for ${symbol}: ` + `${STATUS_CODES.OK}`.green)
       } else {
         logger.info(`Engine status for ${symbol}: ` + `${status}`.red)

--- a/broker-cli/commands/health-check.spec.js
+++ b/broker-cli/commands/health-check.spec.js
@@ -29,8 +29,8 @@ describe('healthCheck', () => {
     errorSpy = sinon.spy()
     healthCheckStub = sinon.stub().returns({
       engineStatus: [
-        { symbol: 'BTC', status: 'OK' },
-        { symbol: 'LTC', status: 'OK' }
+        { symbol: 'BTC', status: 'VALIDATED' },
+        { symbol: 'LTC', status: 'NOT VALIDATED' }
       ],
       relayerStatus: 'OK'
     })
@@ -53,5 +53,15 @@ describe('healthCheck', () => {
   it('makes a request to the broker', async () => {
     await healthCheck(args, opts, logger)
     expect(healthCheckStub).to.have.been.called()
+  })
+
+  it('logs ok engine status if engine is validated', async () => {
+    await healthCheck(args, opts, logger)
+    expect(logger.info).to.have.been.calledWith('Engine status for BTC: ' + 'OK'.green)
+  })
+
+  it('logs other engine status if engine is not validated', async () => {
+    await healthCheck(args, opts, logger)
+    expect(logger.info).to.have.been.calledWith('Engine status for LTC: ' + 'NOT VALIDATED'.red)
   })
 })


### PR DESCRIPTION
## Description
broker-cli now has a dependency on lnd-engine and we do not have lnd-engine in the package.json nor do we want to just to use it for a status. 
This PR moves the call to lnd-engine to a constant.
This was not noticed because it is not an issue when you use broker-cli locally from the broker directory, but it is when you are using remote cli

## Related PRs
List related PRs if applicable


## Todos
- [x] Tests
- [x] Documentation
- [ ] Link to Trello
