### PR TITLE
default external address to localhost for local use

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -62,6 +62,7 @@ mkdir -p ./certs
 KEY_PATH="./certs/broker-rpc-tls.key"
 CERT_PATH="./certs/broker-rpc-tls.cert"
 CSR_PATH="./certs/brokr-rpc-csr.csr"
+EXTERNAL_ADDRESS=${EXTERNAL_ADDRESS:-localhost}
 
 openssl ecparam -genkey -name prime256v1 -out $KEY_PATH
 openssl req -new -sha256 -key $KEY_PATH -out $CSR_PATH -subj "/CN=$EXTERNAL_ADDRESS/O=sparkswap"
@@ -69,7 +70,7 @@ openssl req -x509 -sha256 -days 36500 -key $KEY_PATH -in $CSR_PATH -out $CERT_PA
 rm $CSR_PATH
 
 echo "Building broker docker images"
-EXTERNAL_ADDRESS=$EXTERNAL_ADDRESS KEY_PATH=$KEY_PATH CERT_PATH=$CERT_PATH npm run build-images
+KEY_PATH=$KEY_PATH CERT_PATH=$CERT_PATH npm run build-images
 
 # We can skip the copying of certs to a local directory if the current build is
 # a standalone broker


### PR DESCRIPTION
## Description
In https://github.com/sparkswap/broker/pull/336/files we removed the default external address as localhost accidentally, which broke cert generation on simnet. 

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
