### PR TITLE
Protofile standard changes

### DIFF
--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -147,7 +147,7 @@ service AdminService {
    * ```
    */
   rpc HealthCheck (google.protobuf.Empty) returns (HealthCheckResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       get: "/v1/admin/healthcheck"
     };
   }
@@ -183,7 +183,7 @@ service AdminService {
    * ```
    */
   rpc GetIdentity (google.protobuf.Empty) returns (GetIdentityResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       get: "/v1/admin/identity"
     };
   }
@@ -498,7 +498,7 @@ service OrderService {
    *
    */
   rpc CreateBlockOrder (CreateBlockOrderRequest) returns (CreateBlockOrderResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       post: "/v1/orders"
       body: "*"
     };
@@ -552,7 +552,7 @@ service OrderService {
    * ```
    */
   rpc GetBlockOrder (GetBlockOrderRequest) returns (GetBlockOrderResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       get: "/v1/orders/{block_order_id}"
     };
   }
@@ -575,7 +575,7 @@ service OrderService {
    * > The above command will cancel the block order, but has no output.
    */
   rpc CancelBlockOrder (CancelBlockOrderRequest) returns (google.protobuf.Empty) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       delete: "/v1/orders/{block_order_id}"
       body: "*"
     };
@@ -630,7 +630,7 @@ service OrderService {
    * ```
    */
   rpc GetBlockOrders (GetBlockOrdersRequest) returns (GetBlockOrdersResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       get: "/v1/orders"
     };
   }
@@ -809,7 +809,7 @@ service OrderBookService {
    * ```
    */
   rpc GetOrderbook (GetOrderbookRequest) returns (GetOrderbookResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       get: "/v1/orderbook"
     };
   }
@@ -1059,7 +1059,7 @@ service WalletService {
    * ```
    */
   rpc NewDepositAddress (NewDepositAddressRequest) returns (NewDepositAddressResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       post: "/v1/wallet/address"
       body: "*"
     };
@@ -1118,7 +1118,7 @@ service WalletService {
    * ```
    */
   rpc GetBalances (google.protobuf.Empty) returns (GetBalancesResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       get: "/v1/wallet/balances"
     };
   }
@@ -1157,7 +1157,7 @@ service WalletService {
    * ```
    */
   rpc Commit (CommitRequest) returns (google.protobuf.Empty) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       post: "/v1/wallet/commit"
       body: "*"
     };
@@ -1193,7 +1193,7 @@ service WalletService {
    *
    */
   rpc ReleaseChannels (ReleaseChannelsRequest) returns (ReleaseChannelsResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       post: "/v1/wallet/release"
       body: "*"
     };
@@ -1318,7 +1318,7 @@ service WalletService {
    * ```
    */
   rpc WithdrawFunds (WithdrawFundsRequest) returns (WithdrawFundsResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       post: "/v1/wallet/withdraw"
       body: "*"
     };
@@ -1363,7 +1363,7 @@ service WalletService {
    * ```
    */
   rpc CreateWallet (CreateWalletRequest) returns (CreateWalletResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       post: "/v1/wallet/create"
       body: "*"
     };
@@ -1395,7 +1395,7 @@ service WalletService {
    * ```
    */
   rpc UnlockWallet (UnlockWalletRequest) returns (google.protobuf.Empty) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       post: "/v1/wallet/unlock"
       body: "*"
     };
@@ -1566,7 +1566,7 @@ service InfoService {
    * ```
    */
   rpc getSupportedMarkets (google.protobuf.Empty) returns (GetSupportedMarketsResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       get: "/v1/markets"
     };
   }
@@ -1621,7 +1621,7 @@ service InfoService {
    * ```
    */
   rpc getMarketStats (GetMarketStatsRequest) returns (GetMarketStatsResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       get: "/v1/market_stats"
     };
   }
@@ -1696,7 +1696,7 @@ service InfoService {
    * ```
    */
   rpc GetTrades (GetTradesRequest) returns (GetTradesResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       get: "/v1/trades"
     };
   }

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -147,7 +147,7 @@ service AdminService {
    * ```
    */
   rpc HealthCheck (google.protobuf.Empty) returns (HealthCheckResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       get: "/v1/admin/healthcheck"
     };
   }
@@ -183,7 +183,7 @@ service AdminService {
    * ```
    */
   rpc GetIdentity (google.protobuf.Empty) returns (GetIdentityResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       get: "/v1/admin/identity"
     };
   }
@@ -498,7 +498,7 @@ service OrderService {
    *
    */
   rpc CreateBlockOrder (CreateBlockOrderRequest) returns (CreateBlockOrderResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       post: "/v1/orders"
       body: "*"
     };
@@ -552,7 +552,7 @@ service OrderService {
    * ```
    */
   rpc GetBlockOrder (GetBlockOrderRequest) returns (GetBlockOrderResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       get: "/v1/orders/{block_order_id}"
     };
   }
@@ -575,7 +575,7 @@ service OrderService {
    * > The above command will cancel the block order, but has no output.
    */
   rpc CancelBlockOrder (CancelBlockOrderRequest) returns (google.protobuf.Empty) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       delete: "/v1/orders/{block_order_id}"
       body: "*"
     };
@@ -630,7 +630,7 @@ service OrderService {
    * ```
    */
   rpc GetBlockOrders (GetBlockOrdersRequest) returns (GetBlockOrdersResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       get: "/v1/orders"
     };
   }
@@ -809,7 +809,7 @@ service OrderBookService {
    * ```
    */
   rpc GetOrderbook (GetOrderbookRequest) returns (GetOrderbookResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       get: "/v1/orderbook"
     };
   }
@@ -1059,7 +1059,7 @@ service WalletService {
    * ```
    */
   rpc NewDepositAddress (NewDepositAddressRequest) returns (NewDepositAddressResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       post: "/v1/wallet/address"
       body: "*"
     };
@@ -1118,7 +1118,7 @@ service WalletService {
    * ```
    */
   rpc GetBalances (google.protobuf.Empty) returns (GetBalancesResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       get: "/v1/wallet/balances"
     };
   }
@@ -1157,7 +1157,7 @@ service WalletService {
    * ```
    */
   rpc Commit (CommitRequest) returns (google.protobuf.Empty) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       post: "/v1/wallet/commit"
       body: "*"
     };
@@ -1193,7 +1193,7 @@ service WalletService {
    *
    */
   rpc ReleaseChannels (ReleaseChannelsRequest) returns (ReleaseChannelsResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       post: "/v1/wallet/release"
       body: "*"
     };
@@ -1318,7 +1318,7 @@ service WalletService {
    * ```
    */
   rpc WithdrawFunds (WithdrawFundsRequest) returns (WithdrawFundsResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       post: "/v1/wallet/withdraw"
       body: "*"
     };
@@ -1363,7 +1363,7 @@ service WalletService {
    * ```
    */
   rpc CreateWallet (CreateWalletRequest) returns (CreateWalletResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       post: "/v1/wallet/create"
       body: "*"
     };
@@ -1395,7 +1395,7 @@ service WalletService {
    * ```
    */
   rpc UnlockWallet (UnlockWalletRequest) returns (google.protobuf.Empty) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       post: "/v1/wallet/unlock"
       body: "*"
     };
@@ -1566,7 +1566,7 @@ service InfoService {
    * ```
    */
   rpc getSupportedMarkets (google.protobuf.Empty) returns (GetSupportedMarketsResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       get: "/v1/markets"
     };
   }
@@ -1621,7 +1621,7 @@ service InfoService {
    * ```
    */
   rpc getMarketStats (GetMarketStatsRequest) returns (GetMarketStatsResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       get: "/v1/market_stats"
     };
   }
@@ -1696,7 +1696,7 @@ service InfoService {
    * ```
    */
   rpc GetTrades (GetTradesRequest) returns (GetTradesResponse) {
-    option (google.api.http) = {
+    option (.google.api.http) = {
       get: "/v1/trades"
     };
   }

--- a/broker-daemon/utils/create-http-server.js
+++ b/broker-daemon/utils/create-http-server.js
@@ -32,7 +32,6 @@ function createHttpServer (protoPath, rpcAddress, { disableAuth = false, enableC
 
   if (disableAuth) {
     app.use('/', grpcGateway([`/${protoPath}`], rpcAddress))
-    return app
   } else {
     const key = fs.readFileSync(privKeyPath)
     const cert = fs.readFileSync(pubKeyPath)
@@ -52,6 +51,15 @@ function createHttpServer (protoPath, rpcAddress, { disableAuth = false, enableC
 
     return https.createServer({ key, cert }, app)
   }
+
+  // Handle 404s correctly for the server
+  app.get('*', (req, res) => {
+    logger.debug('Received request but had no route', { url: req.url })
+    res.status(404)
+    res.json({ error: '404' })
+  })
+
+  return app
 }
 
 module.exports = createHttpServer

--- a/broker-daemon/utils/create-http-server.js
+++ b/broker-daemon/utils/create-http-server.js
@@ -53,10 +53,9 @@ function createHttpServer (protoPath, rpcAddress, { disableAuth = false, enableC
   }
 
   // Handle 404s correctly for the server
-  app.get('*', (req, res) => {
+  app.use((req, res, _next) => {
     logger.debug('Received request but had no route', { url: req.url })
-    res.status(404)
-    res.json({ error: '404' })
+    res.status(404).send('404')
   })
 
   return app

--- a/broker-daemon/utils/grpc-gateway.js
+++ b/broker-daemon/utils/grpc-gateway.js
@@ -59,24 +59,15 @@ function lowerFirstChar (str) {
  * @param  {string[]} protoFiles Filenames of protobuf-file
  * @param  {string} grpcLocation HOST:PORT of gRPC server
  * @param  {ChannelCredentials}  gRPC credential context (default: grpc.credentials.createInsecure())
- * @param  {string} include      Path to find all includes
  * @return {Function}            Middleware
  */
-const middleware = (protoFiles, grpcLocation, credentials = grpc.credentials.createInsecure(), debug = true, include = '') => {
+const middleware = (protoFiles, grpcLocation, credentials = grpc.credentials.createInsecure(), debug = true) => {
   const router = express.Router()
   const clients = {}
-  if (include.endsWith('/')) {
-    include = include.substring(0, include.length - 1) // remove"/"
-  }
-  protoFiles = protoFiles.map(function (value, index, array) {
-    if (value.startsWith(include)) {
-      value = value.substring(include.length + 1)
-    }
-    return value
-  })
-  const protos = protoFiles.map(p => include ? grpc.load({ file: p, root: include }) : grpc.load(p))
+  const protos = protoFiles.map(p => grpc.load(p))
+
   protoFiles
-    .map(p => `${include}/${p}`)
+    .map(p => `/${p}`)
     .map(p => schema.parse(fs.readFileSync(p)))
     .forEach((sch, si) => {
       const pkg = sch.package


### PR DESCRIPTION
## Description
This PR fixes an issue with our grpc proto file that prevents `protoc` from compiling in other languages.

We receive a warning stating that `google.api.http` is being resolved on additional tries and that `google.api.http` is not available at the parent level. This is fixed by adding a `.` at the begin of the import.

There were additional changes that needed to be made, specifically that protoc will yell at us that the import in `annotations.proto` for `http.proto` is incorrect. However, until we upgrade gRPC on the broker, we are not able to change this path (protobufjs upgrade which includes a `root` flag)

Additional Changes:
1. added 404 handling to grpc gateway
2. removed unused flags on grpc gateway (`grpc.load` does not take an object)
3. added jsdoc

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
