### PR TITLE
Fix: remove listeners when an order is cancelled

### DIFF
--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -289,30 +289,31 @@ const OrderStateMachine = StateMachine.factory({
       }
       const dataHandler = ({ orderStatus, fill }) => {
         try {
-          // the Relayer will send a single data message containing the order's state as cancelled and close
-          // the stream if the order has been cancelled. We should handle that and cancel the order locally.
           if (OrderStateMachine.STATES[orderStatus] === OrderStateMachine.STATES.CANCELLED) {
+            // the Relayer will send a single data message containing the order's state as cancelled and close
+            // the stream if the order has been cancelled. We should handle that and cancel the order locally.
             this.logger.info(`Order ${orderId} was cancelled on the relayer, cancelling locally.`, { orderId })
-            return this.tryTo('cancel')
+            this.tryTo('cancel')
+          } else {
+            this.logger.info(`Order ${this.order.orderId} is being filled`, { orderId })
+
+            const { swapHash, fillAmount, takerAddress } = fill
+            this.order.setFilledParams({ swapHash, fillAmount, takerAddress })
+            this.tryTo('execute')
           }
-
-          this.logger.info(`Placed order ${orderId} on the relayer`, { orderId })
-          const { swapHash, fillAmount, takerAddress } = fill
-
-          this.order.setFilledParams({ swapHash, fillAmount, takerAddress })
-
-          this.logger.info(`Order ${this.order.orderId} is being filled`, { orderId })
-          this.tryTo('execute')
         } catch (e) {
           this.reject(e)
+        } finally {
+          finish()
         }
-        finish()
       }
 
       // Set listeners on the call
       call.on('error', errHandler)
       call.on('end', endHandler)
       call.on('data', dataHandler)
+
+      this.logger.info(`Placed order ${orderId} on the relayer`, { orderId })
     },
 
     /**

--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -292,16 +292,16 @@ const OrderStateMachine = StateMachine.factory({
           // the Relayer will send a single data message containing the order's state as cancelled and close
           // the stream if the order has been cancelled. We should handle that and cancel the order locally.
           if (OrderStateMachine.STATES[orderStatus] === OrderStateMachine.STATES.CANCELLED) {
-            this.logger.info(`Order ${orderId} was cancelled on the relayer, cancelling locally.`)
+            this.logger.info(`Order ${orderId} was cancelled on the relayer, cancelling locally.`, { orderId })
             return this.tryTo('cancel')
           }
 
-          this.logger.info(`Placed order ${this.order.orderId} on the relayer`)
+          this.logger.info(`Placed order ${orderId} on the relayer`, { orderId })
           const { swapHash, fillAmount, takerAddress } = fill
 
           this.order.setFilledParams({ swapHash, fillAmount, takerAddress })
 
-          this.logger.info(`Order ${this.order.orderId} is being filled`)
+          this.logger.info(`Order ${this.order.orderId} is being filled`, { orderId })
           this.tryTo('execute')
         } catch (e) {
           this.reject(e)

--- a/broker-daemon/state-machines/order-state-machine.spec.js
+++ b/broker-daemon/state-machines/order-state-machine.spec.js
@@ -544,6 +544,20 @@ describe('OrderStateMachine', () => {
       expect(placeOrderStreamStub.removeListener).to.have.been.calledWith('end')
       expect(placeOrderStreamStub.removeListener).to.have.been.calledWith('data')
     })
+
+    it.only('tears down listeners on cancel', async () => {
+      osm.reject = sinon.stub()
+      placeOrderStreamStub.on.withArgs('data').callsArgWithAsync(1, { orderStatus: 'CANCELLED' })
+
+      await osm.place()
+
+      await delay(10)
+
+      expect(placeOrderStreamStub.removeListener).to.have.been.calledThrice()
+      expect(placeOrderStreamStub.removeListener).to.have.been.calledWith('error')
+      expect(placeOrderStreamStub.removeListener).to.have.been.calledWith('end')
+      expect(placeOrderStreamStub.removeListener).to.have.been.calledWith('data')
+    })
   })
 
   describe('#execute', () => {


### PR DESCRIPTION
## Description
The broker has a bug wherein if an order is cancelled, the Broker will cancel it, but will continue listening for updates from the Relayer.

Beyond creating a memory leak, this creates an issue where the Relayer closing the stream (which it will do after cancelling an order) causes the Broker to move the order to an errored state. This is particularly problematic if the order has not yet been fully transitioned to a cancelled state, as it will cause an invalid transition (moving to rejected while still in the cancel transition), crashing the broker.


## Todos
- [x] Tests
