### PR TITLE
Use shorter ids for block orders

### DIFF
--- a/broker-daemon/utils/generate-id.js
+++ b/broker-daemon/utils/generate-id.js
@@ -1,11 +1,14 @@
 const crypto = require('crypto')
 
 /**
- * Generate a random ID string
- * @return {String} 43 random characters in [base64url encoding]{@link https://tools.ietf.org/html/rfc4648}
+ * Generate a unique ID string
+ * We use 9 bytes of randonmness since this is for a single broker.
+ * It can be increased for particularly high-frequency brokers as nothing should depend on the length
+ * of this ID.
+ * @return {String} 12 characters in [base64url encoding]{@link https://tools.ietf.org/html/rfc4648}
  */
 function generateId () {
-  const data = crypto.randomBytes(20).toString('hex')
+  const data = crypto.randomBytes(9).toString('hex')
   return urlEncode(crypto.createHash('sha256').update(data).digest('base64'))
 }
 

--- a/broker-daemon/utils/generate-id.js
+++ b/broker-daemon/utils/generate-id.js
@@ -2,14 +2,25 @@ const crypto = require('crypto')
 
 /**
  * Generate a unique ID string
- * We use 9 bytes of randonmness since this is for a single broker.
- * It can be increased for particularly high-frequency brokers as nothing should depend on the length
- * of this ID.
- * @return {String} 12 characters in [base64url encoding]{@link https://tools.ietf.org/html/rfc4648}
+ * We use 12 bytes of randonmness since this is for a single broker.
+ * We start with the current timestamp so that they are automatically time ordered.
+ * The randomness can be increased for particularly high-frequency brokers as nothing
+ * should depend on the length of this ID.
+ * @return {String} 16 characters in [base64url encoding]{@link https://tools.ietf.org/html/rfc4648}
  */
 function generateId () {
-  const data = crypto.randomBytes(9).toString('hex')
-  return urlEncode(crypto.createHash('sha256').update(data).digest('base64'))
+  // initialize the buffer to hold our 12 byte  ID
+  const id = Buffer.alloc(12)
+
+  // prepend 32 bits of the timestamp in seconds so that IDs are ordered by creation date
+  const timestamp = Math.floor(Date.now() / 1000)
+  id.writeUInt32BE(timestamp)
+
+  // add 8 bytes of random data to make the ID unique
+  const rand = crypto.randomBytes(8)
+  rand.copy(id, 4)
+
+  return urlEncode(id.toString('base64'))
 }
 
 /**

--- a/broker-daemon/utils/generate-id.spec.js
+++ b/broker-daemon/utils/generate-id.spec.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const { sinon, rewire, expect } = require('test/test-helper')
+const { sinon, rewire, expect, timekeeper } = require('test/test-helper')
 
 const generateId = rewire(path.resolve(__dirname, 'generate-id'))
 
@@ -7,33 +7,32 @@ describe('generateId', () => {
   describe('generateId', () => {
     let urlEncode
     let crypto
-    let hash
-    let bytes
     let resetUrlEncode
     let resetCrypto
-    let randomString
+    let randomData
+    let randomHex
     let randomBase64
     let randomUrlEncoded
+    let timestamp
+    let timeInSeconds
 
     beforeEach(() => {
-      randomString = 'aoisjdfoasijfd9sdfu0a9sdf09'
-      randomBase64 = 'asfdjJF09809ASDFasdf+asdf/asdf='
+      timestamp = 1532045654371
+      timeInSeconds = 1532045654
+      timekeeper.freeze(new Date(timestamp))
+      randomData = Buffer.from('deadbeefdeadbeef', 'hex')
+
+      randomHex = timeInSeconds.toString(16) + 'deadbeefdeadbeef'
+
+      // the data should be the timestamp on the front, followed by
+      // our random data at the end
+      randomBase64 = Buffer.from(randomHex, 'hex').toString('base64')
       randomUrlEncoded = 'asfdjJF09809ASDFasdf-asdf_asdf'
 
       urlEncode = sinon.stub().returns(randomUrlEncoded)
-      hash = {
-        update: sinon.stub(),
-        digest: sinon.stub().returns(randomBase64)
-      }
-      hash.update.returns(hash)
-
-      bytes = {
-        toString: sinon.stub().returns(randomString)
-      }
 
       crypto = {
-        randomBytes: sinon.stub().returns(bytes),
-        createHash: sinon.stub().returns(hash)
+        randomBytes: sinon.stub().returns(randomData)
       }
 
       resetUrlEncode = generateId.__set__('urlEncode', urlEncode)
@@ -43,29 +42,17 @@ describe('generateId', () => {
     afterEach(() => {
       resetUrlEncode()
       resetCrypto()
+      timekeeper.reset()
     })
 
     it('creates random hex data', () => {
       generateId()
 
       expect(crypto.randomBytes).to.have.been.calledOnce()
-      expect(crypto.randomBytes).to.have.been.calledWith(9)
-      expect(bytes.toString).to.have.been.calledOnce()
-      expect(bytes.toString).to.have.been.calledWith('hex')
+      expect(crypto.randomBytes).to.have.been.calledWith(8)
     })
 
-    it('hashes the random data', () => {
-      generateId()
-
-      expect(crypto.createHash).to.have.been.calledOnce()
-      expect(crypto.createHash).to.have.been.calledWith('sha256')
-      expect(hash.update).to.have.been.calledOnce()
-      expect(hash.update).to.have.been.calledWith(randomString)
-      expect(hash.digest).to.have.been.calledOnce()
-      expect(hash.digest).to.have.been.calledWith('base64')
-    })
-
-    it('url encodes the hash', () => {
+    it('url encodes the data', () => {
       expect(generateId()).to.be.eql(randomUrlEncoded)
 
       expect(urlEncode).to.have.been.calledOnce()

--- a/broker-daemon/utils/generate-id.spec.js
+++ b/broker-daemon/utils/generate-id.spec.js
@@ -49,7 +49,7 @@ describe('generateId', () => {
       generateId()
 
       expect(crypto.randomBytes).to.have.been.calledOnce()
-      expect(crypto.randomBytes).to.have.been.calledWith(20)
+      expect(crypto.randomBytes).to.have.been.calledWith(9)
       expect(bytes.toString).to.have.been.calledOnce()
       expect(bytes.toString).to.have.been.calledWith('hex')
     })


### PR DESCRIPTION
## Description
Brokers generate block order IDs locally, for their own purposes. However, we currently use a ton of bits for this ID even though a collision is incredibly unlikely.

In this change I reduce the number of bits of overall randomness, and I prepend with a timestamp to make order IDs automatically sort by date of creation.

If a user needs much higher collision resistance, the size of the ID can be easily extended with more randomness (although it requires a code change).

IDs used to look like this:
```
aaaYG_Fq5o0eGOtbElyvFQyOiWlLe5kMNWqJ_VRs5MM
```

With this change they look like this:
```
XDPzhsN0IRyDqgbj
```

This allows for much easier identification, copy and pasting, etc.

## Todos
- [x] Tests
