### PR TITLE
use tags instead of follow tags

### DIFF
--- a/scripts/publish-broker-cli.sh
+++ b/scripts/publish-broker-cli.sh
@@ -34,7 +34,7 @@ echo "Pushing to GitHub"
 git push origin master
 
 echo "Pushing missing/relevant tags to github"
-git push origin master --follow-tags
+git push origin master --tags
 
 echo "Removing working directory"
 


### PR DESCRIPTION
## Description
`--follow-tags` did not push associated tags to the broker-cli repo. We are going to use `--tags` for CI push

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
