### PR TITLE
Remove submodule error from broker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,7 @@ typings/
 .DS_Store
 
 # Proto build files
-proto/*
+proto
 
 # Override file which we use dynamically in the broker setup
 docker-compose.override.yml


### PR DESCRIPTION
## Description
The proto directory, which we clone from a separate git repository, was getting mistakenly interpreted as a submodule. By ignoring it completely and removing it from the repo we should avoid this issue, which also causes problems when installing the https://github.com/sparkswap/broker-cli.
