### PR TITLE
rewrite tags for broker-cli

### DIFF
--- a/scripts/publish-broker-cli.sh
+++ b/scripts/publish-broker-cli.sh
@@ -23,7 +23,7 @@ git clone -b master git@github.com:sparkswap/broker.git .
 echo "Latest commit: $(git log --oneline -n 1)"
 
 echo "Pruning git repo to only broker-cli"
-git filter-branch --prune-empty --subdirectory-filter broker-cli master
+git filter-branch --tag-name-filter cat --prune-empty --subdirectory-filter broker-cli master
 
 echo "Updating remote origin"
 


### PR DESCRIPTION
## Description
Fixes our tags before we push to the tracking repo, otherwise the tags point to the full broker repo.


See https://stackoverflow.com/questions/21009947/when-do-you-need-tag-name-filter-cat-for-git-filter-branch and https://linux.die.net/man/1/git-filter-branch

> When passed, it will be called for every tag ref that points to a rewritten object (or to a tag object which points to a rewritten object). ... use "--tag-name-filter cat" to simply update the tags.