### PR TITLE
Use engine for max balance

### DIFF
--- a/broker-daemon/broker-rpc/info-service/market-stats.spec.js
+++ b/broker-daemon/broker-rpc/info-service/market-stats.spec.js
@@ -17,13 +17,11 @@ describe('MarketStats', () => {
     currencyConfig = [{
       name: 'Bitcoin',
       symbol: 'BTC',
-      quantumsPerCommon: '100000000',
-      maxChannelBalance: '16777215'
+      quantumsPerCommon: '100000000'
     }, {
       name: 'Ethereum',
       symbol: 'ETH',
-      quantumsPerCommon: '100000000',
-      maxChannelBalance: '16777215'
+      quantumsPerCommon: '100000000'
     }]
 
     MarketStats.__set__('currencyConfig', currencyConfig)

--- a/broker-daemon/broker-rpc/wallet-service/commit.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.js
@@ -1,7 +1,6 @@
 const { PublicError } = require('grpc-methods')
 
 const { convertBalance, Big } = require('../../utils')
-const { currencies: currencyConfig } = require('../../config')
 
 /**
  * Minimum funding amount in common units (e.g. 0.123 BTC)
@@ -25,11 +24,6 @@ const MINIMUM_FUNDING_AMOUNT = Big(0.00400000)
  */
 async function commit ({ params, relayer, logger, engines, orderbooks }, { EmptyResponse }) {
   const { balance: balanceInCommonUnits, symbol, market } = params
-  const currentCurrencyConfig = currencyConfig.find(({ symbol: configSymbol }) => configSymbol === symbol)
-
-  if (!currentCurrencyConfig) {
-    throw new Error(`Currency was not found when trying to commit to market: ${symbol}`)
-  }
 
   const orderbook = orderbooks.get(market)
 
@@ -55,8 +49,8 @@ async function commit ({ params, relayer, logger, engines, orderbooks }, { Empty
     throw new PublicError(`No engine is configured for symbol: ${inverseSymbol}`)
   }
 
-  const maxChannelBalance = Big(currentCurrencyConfig.maxChannelBalance)
-  const balance = Big(balanceInCommonUnits).times(currentCurrencyConfig.quantumsPerCommon).toString()
+  const maxChannelBalance = Big(engine.currencyConfig.maxChannelBalance)
+  const balance = Big(balanceInCommonUnits).times(engine.currencyConfig.quantumsPerCommon).toString()
 
   logger.info(`Attempting to create channel with ${address} on ${symbol} with ${balanceInCommonUnits}`, { balanceInCommonUnits, balance })
 

--- a/broker-daemon/broker-rpc/wallet-service/commit.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.spec.js
@@ -53,7 +53,13 @@ describe('commit', () => {
     }
     ltcEngine = {
       getPaymentChannelNetworkAddress: sinon.stub().resolves(relayerAddress),
-      getMaxChannel: getMaxInboundChannelStub
+      getMaxChannel: getMaxInboundChannelStub,
+      currencyConfig: {
+        name: 'Litecoin',
+        symbol: 'LTC',
+        quantumsPerCommon: '100000000',
+        maxChannelBalance: '1006632900'
+      }
     }
     engines = new Map([
       ['BTC', btcEngine],
@@ -84,6 +90,15 @@ describe('commit', () => {
   it('balance over allowed maximum value throws an error for an incorrect balance', () => {
     const maxBalance = btcEngine.currencyConfig.maxChannelBalance
     params.balance = maxBalance + 1
+    return expect(
+      commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })
+    ).to.be.rejectedWith(PublicError, 'Maximum balance')
+  })
+
+  it('throws an error if the inbound channel exceeds the maximum value', () => {
+    ltcEngine.currencyConfig.maxChannelBalance = btcEngine.currencyConfig.maxChannelBalance
+
+    params.balance = btcEngine.currencyConfig.maxChannelBalance - 1
     return expect(
       commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })
     ).to.be.rejectedWith(PublicError, 'Maximum balance')

--- a/broker-daemon/broker-rpc/wallet-service/commit.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.spec.js
@@ -44,22 +44,16 @@ describe('commit', () => {
     btcEngine = {
       createChannel: createChannelStub,
       getMaxChannel: getMaxOutboundChannelStub,
-      currencyConfig: {
-        name: 'Bitcoin',
-        symbol: 'BTC',
-        quantumsPerCommon: '100000000',
-        maxChannelBalance: '16777215'
-      }
+      symbol: 'BTC',
+      quantumsPerCommon: '100000000',
+      maxChannelBalance: '16777215'
     }
     ltcEngine = {
       getPaymentChannelNetworkAddress: sinon.stub().resolves(relayerAddress),
       getMaxChannel: getMaxInboundChannelStub,
-      currencyConfig: {
-        name: 'Litecoin',
-        symbol: 'LTC',
-        quantumsPerCommon: '100000000',
-        maxChannelBalance: '1006632900'
-      }
+      symbol: 'LTC',
+      quantumsPerCommon: '100000000',
+      maxChannelBalance: '1006632900'
     }
     engines = new Map([
       ['BTC', btcEngine],
@@ -88,7 +82,7 @@ describe('commit', () => {
   })
 
   it('balance over allowed maximum value throws an error for an incorrect balance', () => {
-    const maxBalance = btcEngine.currencyConfig.maxChannelBalance
+    const maxBalance = btcEngine.maxChannelBalance
     params.balance = maxBalance + 1
     return expect(
       commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })
@@ -96,9 +90,9 @@ describe('commit', () => {
   })
 
   it('throws an error if the inbound channel exceeds the maximum value', () => {
-    ltcEngine.currencyConfig.maxChannelBalance = btcEngine.currencyConfig.maxChannelBalance
+    ltcEngine.maxChannelBalance = btcEngine.maxChannelBalance
 
-    params.balance = btcEngine.currencyConfig.maxChannelBalance - 1
+    params.balance = btcEngine.maxChannelBalance - 1
     return expect(
       commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })
     ).to.be.rejectedWith(PublicError, 'Maximum balance')
@@ -114,7 +108,7 @@ describe('commit', () => {
     })
 
     it('creates a channel through an btc engine with base units', () => {
-      const baseUnitsBalance = Big(params.balance).times(btcEngine.currencyConfig.quantumsPerCommon).toString()
+      const baseUnitsBalance = Big(params.balance).times(btcEngine.quantumsPerCommon).toString()
       expect(btcEngine.createChannel).to.have.been.calledWith(paymentNetworkAddress, baseUnitsBalance)
     })
 

--- a/broker-daemon/broker-rpc/wallet-service/commit.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.spec.js
@@ -23,7 +23,6 @@ describe('commit', () => {
   let getMaxOutboundChannelStub
   let getMaxInboundChannelStub
   let orderbooks
-  let currencyConfig
 
   beforeEach(() => {
     EmptyResponse = sinon.stub()
@@ -44,7 +43,13 @@ describe('commit', () => {
 
     btcEngine = {
       createChannel: createChannelStub,
-      getMaxChannel: getMaxOutboundChannelStub
+      getMaxChannel: getMaxOutboundChannelStub,
+      currencyConfig: {
+        name: 'Bitcoin',
+        symbol: 'BTC',
+        quantumsPerCommon: '100000000',
+        maxChannelBalance: '16777215'
+      }
     }
     ltcEngine = {
       getPaymentChannelNetworkAddress: sinon.stub().resolves(relayerAddress),
@@ -65,21 +70,8 @@ describe('commit', () => {
         createChannel: createChannelRelayerStub
       }
     }
-    currencyConfig = [{
-      name: 'Bitcoin',
-      symbol: 'BTC',
-      quantumsPerCommon: '100000000',
-      maxChannelBalance: '16777215'
-    }]
 
     commit.__set__('convertBalance', convertBalanceStub)
-    commit.__set__('currencyConfig', currencyConfig)
-  })
-
-  it('throws an error if engine does not exist for symbol', () => {
-    const badSymbol = 'bad'
-    const errorMessage = `Currency was not found when trying to commit to market: ${badSymbol}`
-    return expect(commit({ params: { symbol: badSymbol }, relayer, logger, engines, orderbooks }, { EmptyResponse })).to.eventually.be.rejectedWith(errorMessage)
   })
 
   it('balance under minimum amount throws an error for an incorrect balance', () => {
@@ -90,7 +82,7 @@ describe('commit', () => {
   })
 
   it('balance over allowed maximum value throws an error for an incorrect balance', () => {
-    const maxBalance = currencyConfig[0].maxChannelBalance
+    const maxBalance = btcEngine.currencyConfig.maxChannelBalance
     params.balance = maxBalance + 1
     return expect(
       commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })
@@ -107,7 +99,7 @@ describe('commit', () => {
     })
 
     it('creates a channel through an btc engine with base units', () => {
-      const baseUnitsBalance = Big(params.balance).times(currencyConfig[0].quantumsPerCommon).toString()
+      const baseUnitsBalance = Big(params.balance).times(btcEngine.currencyConfig.quantumsPerCommon).toString()
       expect(btcEngine.createChannel).to.have.been.calledWith(paymentNetworkAddress, baseUnitsBalance)
     })
 
@@ -146,14 +138,6 @@ describe('commit', () => {
 
   describe('invalid engine types', () => {
     it('throws an error if engine does not exist for symbol', () => {
-      currencyConfig = [{
-        name: 'BadBitcoin',
-        symbol: 'BAD',
-        quantumsPerCommon: '100000000',
-        maxChannelBalance: '16777215'
-      }]
-
-      commit.__set__('currencyConfig', currencyConfig)
       const badParams = {symbol: 'BAD', market: 'BTC/LTC'}
       const errorMessage = `No engine is configured for symbol: ${badParams.symbol}`
       return expect(commit({ params: badParams, relayer, logger, engines, orderbooks }, { EmptyResponse })).to.eventually.be.rejectedWith(errorMessage)

--- a/broker-daemon/broker-rpc/wallet-service/get-balances.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-balances.js
@@ -1,6 +1,3 @@
-const { PublicError } = require('grpc-methods')
-
-const { currencies: currencyConfig } = require('../../config')
 const { Big } = require('../../utils')
 
 /**
@@ -23,12 +20,7 @@ const BALANCE_PRECISION = 16
  * @return {String} res.totalPendingChannelBalance
  */
 async function getEngineBalances (symbol, engine, logger) {
-  const { quantumsPerCommon } = currencyConfig.find(({ symbol: configSymbol }) => configSymbol === symbol) || {}
-
-  if (!quantumsPerCommon) {
-    logger.error(`Currency not supported in ${symbol} configuration`)
-    throw new PublicError(`Currency not supported in ${symbol} configuration`)
-  }
+  const { quantumsPerCommon } = engine
 
   let [uncommittedBalance, totalChannelBalance, totalPendingChannelBalance, uncommittedPendingBalance] = await Promise.all([
     engine.getUncommittedBalance(),

--- a/broker-daemon/broker-rpc/wallet-service/get-balances.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-balances.spec.js
@@ -89,7 +89,6 @@ describe('get-balances', () => {
     let uncommittedPendingBalance
     let uncommittedPendingBalanceStub
     let totalPendingBalanceStub
-    let currencyConfig
 
     beforeEach(() => {
       symbol = 'BTC'
@@ -97,11 +96,6 @@ describe('get-balances', () => {
       totalChannelBalance = 10000
       totalPendingChannelBalance = 1000
       uncommittedPendingBalance = 5000
-      currencyConfig = [{
-        name: 'Bitcoin',
-        symbol: 'BTC',
-        quantumsPerCommon: '100000000'
-      }]
 
       uncommittedBalanceStub = sinon.stub().resolves(uncommittedBalance)
       totalChannelBalanceStub = sinon.stub().resolves(totalChannelBalance)
@@ -111,11 +105,11 @@ describe('get-balances', () => {
         getUncommittedBalance: uncommittedBalanceStub,
         getTotalChannelBalance: totalChannelBalanceStub,
         getTotalPendingChannelBalance: totalPendingBalanceStub,
-        getUncommittedPendingBalance: uncommittedPendingBalanceStub
+        getUncommittedPendingBalance: uncommittedPendingBalanceStub,
+        quantumsPerCommon: '100000000'
       }
 
       getEngineBalances = getBalances.__get__('getEngineBalances')
-      getBalances.__set__('currencyConfig', currencyConfig)
     })
 
     it('gets the total balance of an engine', async () => {
@@ -136,11 +130,6 @@ describe('get-balances', () => {
         totalPendingChannelBalance: '0.0000100000000000',
         uncommittedPendingBalance: '0.0000500000000000'
       })
-    })
-
-    it('returns an error if a currencies config is not found', () => {
-      const badSymbol = 'LTC'
-      return expect(getEngineBalances(badSymbol, engineStub, logger)).to.eventually.be.rejectedWith('Currency not supported')
     })
   })
 })

--- a/broker-daemon/broker-rpc/wallet-service/get-balances.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-balances.spec.js
@@ -100,8 +100,7 @@ describe('get-balances', () => {
       currencyConfig = [{
         name: 'Bitcoin',
         symbol: 'BTC',
-        quantumsPerCommon: '100000000',
-        maxChannelBalance: '16777215'
+        quantumsPerCommon: '100000000'
       }]
 
       uncommittedBalanceStub = sinon.stub().resolves(uncommittedBalance)

--- a/broker-daemon/config.json
+++ b/broker-daemon/config.json
@@ -3,14 +3,12 @@
     {
       "name": "Bitcoin",
       "symbol": "BTC",
-      "quantumsPerCommon": "100000000",
-      "maxChannelBalance": "16777215"
+      "quantumsPerCommon": "100000000"
     },
     {
       "name": "Litecoin",
       "symbol": "LTC",
-      "quantumsPerCommon": "100000000",
-      "maxChannelBalance": "1006632900"
+      "quantumsPerCommon": "100000000"
     }
   ]
 }

--- a/broker-daemon/interchain-router/get-preimage.js
+++ b/broker-daemon/interchain-router/get-preimage.js
@@ -45,7 +45,7 @@ function timeLockDeltaInSeconds (inboundEngine, timeLock, bestHeight) {
     throw new Error(`Current block height (${bestHeight}) is higher than the extended timelock (${timeLock})`)
   }
 
-  return timeLockDelta.times(inboundEngine.currencyConfig.secondsPerBlock).toString()
+  return timeLockDelta.times(inboundEngine.secondsPerBlock).toString()
 }
 
 /**

--- a/broker-daemon/interchain-router/get-preimage.spec.js
+++ b/broker-daemon/interchain-router/get-preimage.spec.js
@@ -59,9 +59,7 @@ describe('getPreimage', () => {
       getPaymentPreimage
     })
     engines.set('BTC', {
-      currencyConfig: {
-        secondsPerBlock: 600
-      }
+      secondsPerBlock: 600
     })
   })
 


### PR DESCRIPTION
## Description
This PR removes `maxChannelBalance` from the broker's configuration and instead relies on the config from the engine.

It also checks that the requested inbound channel does not exceed our own engine's max channel balance as requesting it will lead to channel failure and cause the user to have to release their own channel.

## Related PRs
Relies on https://github.com/sparkswap/lnd-engine/pull/148 and should be updated to depend on the version of LND engine that includes this change.


## Todos
- [x] Tests
