### PR TITLE
add orderbook sync status to healthcheck and output table for healthcheck

### DIFF
--- a/broker-cli/commands/health-check.js
+++ b/broker-cli/commands/health-check.js
@@ -4,7 +4,6 @@ const BrokerDaemonClient = require('../broker-daemon-client')
 const { validations, handleError } = require('../utils')
 const { RPC_ADDRESS_HELP_STRING } = require('../utils/strings')
 const Table = require('cli-table')
-const size = require('window-size')
 
 /**
  * @constant

--- a/broker-cli/commands/health-check.js
+++ b/broker-cli/commands/health-check.js
@@ -3,6 +3,8 @@ require('colors')
 const BrokerDaemonClient = require('../broker-daemon-client')
 const { validations, handleError } = require('../utils')
 const { RPC_ADDRESS_HELP_STRING } = require('../utils/strings')
+const Table = require('cli-table')
+const size = require('window-size')
 
 /**
  * @constant
@@ -26,6 +28,15 @@ const ENGINE_STATUS_CODES = Object.freeze({
 })
 
 /**
+ * Statuses for whether or not the orderbook is synced
+ * @constant
+ * @type {Object}
+ */
+const SYNCED_STATUS = Object.freeze({
+  NOT_SYNCED: 'NOT_SYNCED'
+})
+
+/**
  * sparkswap healthcheck
  *
  * Tests the broker and engine connection for the cli
@@ -46,28 +57,46 @@ async function healthCheck (args, opts, logger) {
 
     const {
       engineStatus = [],
+      orderbookStatus = [],
       relayerStatus = STATUS_CODES.UNKNOWN
     } = await client.adminService.healthCheck({})
 
-    if (!engineStatus.length) {
-      logger.info(`No Engine Statuses Returned`.red)
-    }
+    const windowWidth = size.get().width
+    const unitWidth = Math.floor(windowWidth / 16)
 
-    engineStatus.forEach(({ symbol, status }) => {
-      if (status === ENGINE_STATUS_CODES.VALIDATED) {
-        logger.info(`Engine status for ${symbol}: ` + `${STATUS_CODES.OK}`.green)
-      } else {
-        logger.info(`Engine status for ${symbol}: ` + `${status}`.red)
-      }
+    const healthcheckTable = new Table({
+      head: ['Component', 'Status'],
+      colWidths: [unitWidth, unitWidth],
+      style: { head: ['gray'] }
     })
 
-    if (relayerStatus === STATUS_CODES.OK) {
-      logger.info('Relayer Status: ' + `${relayerStatus}`.green)
+    const ui = []
+
+    ui.push('')
+    ui.push('Sparkswap Healthcheck'.bold.white)
+    ui.push('')
+
+    if (engineStatus.length > 0) {
+      engineStatus.forEach(({ symbol, status }) => {
+        const statusString = status === ENGINE_STATUS_CODES.VALIDATED ? `${STATUS_CODES.OK}`.green : `${status}`.red
+        healthcheckTable.push([`${symbol} Engine`, statusString])
+      })
     } else {
-      logger.info('Relayer Status: ' + `${relayerStatus}`.red)
+      healthcheckTable.push(['Engines', 'No Statuses Returned'.red])
     }
 
-    logger.info('Daemon Status: ' + `${STATUS_CODES.OK}`.green)
+    const relayerStatusString = relayerStatus === STATUS_CODES.OK ? `${relayerStatus}`.green : `${relayerStatus}`.red
+    healthcheckTable.push(['Relayer', relayerStatusString])
+
+    orderbookStatus.forEach(({ market, synced }) => {
+      const orderbookStatusString = synced ? STATUS_CODES.OK.green : SYNCED_STATUS.NOT_SYNCED.red
+      healthcheckTable.push([`${market} Orderbook`, orderbookStatusString])
+    })
+
+    healthcheckTable.push(['Daemon', `${STATUS_CODES.OK}`.green])
+
+    ui.push(healthcheckTable.toString())
+    console.log(ui.join('\n') + '\n')
   } catch (e) {
     logger.error(handleError(e))
   }

--- a/broker-cli/commands/health-check.js
+++ b/broker-cli/commands/health-check.js
@@ -52,12 +52,8 @@ async function healthCheck (args, opts, logger) {
       relayerStatus = STATUS_CODES.UNKNOWN
     } = await client.adminService.healthCheck({})
 
-    const windowWidth = size.get().width
-    const unitWidth = Math.floor(windowWidth / 16)
-
     const healthcheckTable = new Table({
       head: ['Component', 'Status'],
-      colWidths: [unitWidth, unitWidth],
       style: { head: ['gray'] }
     })
 
@@ -69,20 +65,24 @@ async function healthCheck (args, opts, logger) {
 
     if (engineStatus.length > 0) {
       engineStatus.forEach(({ symbol, status }) => {
-        const statusString = status === ENGINE_STATUS_CODES.VALIDATED ? `${STATUS_CODES.OK}`.green : status.red
+        const statusString = (status === ENGINE_STATUS_CODES.VALIDATED) ? `${STATUS_CODES.OK}`.green : status.red
         healthcheckTable.push([`${symbol} Engine`, statusString])
       })
     } else {
       healthcheckTable.push(['Engines', 'No Statuses Returned'.red])
     }
 
-    const relayerStatusString = relayerStatus === STATUS_CODES.OK ? relayerStatus.green : relayerStatus.red
+    const relayerStatusString = (relayerStatus === STATUS_CODES.OK) ? relayerStatus.green : relayerStatus.red
     healthcheckTable.push(['Relayer', relayerStatusString])
 
-    orderbookStatus.forEach(({ market, status }) => {
-      const orderbookStatusString = status === STATUS_CODES.OK ? status.green : status.red
-      healthcheckTable.push([`${market} Orderbook`, orderbookStatusString])
-    })
+    if (orderbookStatus.length > 0) {
+      orderbookStatus.forEach(({ market, status }) => {
+        const orderbookStatusString = (status === STATUS_CODES.OK) ? status.green : status.red
+        healthcheckTable.push([`${market} Orderbook`, orderbookStatusString])
+      })
+    } else {
+      healthcheckTable.push(['Orderbooks', 'No Statuses Returned'.red])
+    }
 
     healthcheckTable.push(['Daemon', `${STATUS_CODES.OK}`.green])
 

--- a/broker-cli/commands/health-check.js
+++ b/broker-cli/commands/health-check.js
@@ -28,15 +28,6 @@ const ENGINE_STATUS_CODES = Object.freeze({
 })
 
 /**
- * Statuses for whether or not the orderbook is synced
- * @constant
- * @type {Object}
- */
-const SYNCED_STATUS = Object.freeze({
-  NOT_SYNCED: 'NOT_SYNCED'
-})
-
-/**
  * sparkswap healthcheck
  *
  * Tests the broker and engine connection for the cli
@@ -78,18 +69,18 @@ async function healthCheck (args, opts, logger) {
 
     if (engineStatus.length > 0) {
       engineStatus.forEach(({ symbol, status }) => {
-        const statusString = status === ENGINE_STATUS_CODES.VALIDATED ? `${STATUS_CODES.OK}`.green : `${status}`.red
+        const statusString = status === ENGINE_STATUS_CODES.VALIDATED ? `${STATUS_CODES.OK}`.green : status.red
         healthcheckTable.push([`${symbol} Engine`, statusString])
       })
     } else {
       healthcheckTable.push(['Engines', 'No Statuses Returned'.red])
     }
 
-    const relayerStatusString = relayerStatus === STATUS_CODES.OK ? `${relayerStatus}`.green : `${relayerStatus}`.red
+    const relayerStatusString = relayerStatus === STATUS_CODES.OK ? relayerStatus.green : relayerStatus.red
     healthcheckTable.push(['Relayer', relayerStatusString])
 
-    orderbookStatus.forEach(({ market, synced }) => {
-      const orderbookStatusString = synced ? STATUS_CODES.OK.green : SYNCED_STATUS.NOT_SYNCED.red
+    orderbookStatus.forEach(({ market, status }) => {
+      const orderbookStatusString = status === STATUS_CODES.OK ? status.green : status.red
       healthcheckTable.push([`${market} Orderbook`, orderbookStatusString])
     })
 

--- a/broker-cli/commands/health-check.spec.js
+++ b/broker-cli/commands/health-check.spec.js
@@ -37,8 +37,8 @@ describe('healthCheck', () => {
       ],
       relayerStatus: 'OK',
       orderbookStatus: [
-        { market: 'BTC/LTC', synced: true },
-        { market: 'ABC/XYZ', synced: false }
+        { market: 'BTC/LTC', status: 'OK' },
+        { market: 'ABC/XYZ', status: 'NOT_SYNCED' }
       ]
     })
     instanceTableStub = {push: sinon.stub()}
@@ -76,8 +76,8 @@ describe('healthCheck', () => {
     healthCheckStub = sinon.stub().returns({
       relayerStatus: 'OK',
       orderbookStatus: [
-        { market: 'BTC/LTC', synced: true },
-        { market: 'ABC/XYZ', synced: false }
+        { market: 'BTC/LTC', status: 'OK' },
+        { market: 'ABC/XYZ', status: 'NOT_SYNCED' }
       ]
     })
     brokerStub.prototype.adminService = { healthCheck: healthCheckStub }

--- a/broker-cli/commands/health-check.spec.js
+++ b/broker-cli/commands/health-check.spec.js
@@ -18,6 +18,9 @@ describe('healthCheck', () => {
   let healthCheckStub
   let brokerStub
   let rpcAddress
+  let instanceTableStub
+  let tableStub
+  let revertTable
 
   const healthCheck = program.__get__('healthCheck')
 
@@ -32,8 +35,15 @@ describe('healthCheck', () => {
         { symbol: 'BTC', status: 'VALIDATED' },
         { symbol: 'LTC', status: 'NOT VALIDATED' }
       ],
-      relayerStatus: 'OK'
+      relayerStatus: 'OK',
+      orderbookStatus: [
+        { market: 'BTC/LTC', synced: true },
+        { market: 'ABC/XYZ', synced: false }
+      ]
     })
+    instanceTableStub = {push: sinon.stub()}
+    tableStub = sinon.stub().returns(instanceTableStub)
+    revertTable = program.__set__('Table', tableStub)
 
     brokerStub = sinon.stub()
     brokerStub.prototype.adminService = { healthCheck: healthCheckStub }
@@ -48,6 +58,7 @@ describe('healthCheck', () => {
 
   afterEach(() => {
     revert()
+    revertTable()
   })
 
   it('makes a request to the broker', async () => {
@@ -55,13 +66,38 @@ describe('healthCheck', () => {
     expect(healthCheckStub).to.have.been.called()
   })
 
-  it('logs ok engine status if engine is validated', async () => {
+  it('adds engine statuses to the healthcheck table', async () => {
     await healthCheck(args, opts, logger)
-    expect(logger.info).to.have.been.calledWith('Engine status for BTC: ' + 'OK'.green)
+    expect(instanceTableStub.push).to.have.been.calledWith(['BTC Engine', 'OK'.green])
+    expect(instanceTableStub.push).to.have.been.calledWith(['LTC Engine', 'NOT VALIDATED'.red])
   })
 
-  it('logs other engine status if engine is not validated', async () => {
+  it('adds engine error status if no engines are returned', async () => {
+    healthCheckStub = sinon.stub().returns({
+      relayerStatus: 'OK',
+      orderbookStatus: [
+        { market: 'BTC/LTC', synced: true },
+        { market: 'ABC/XYZ', synced: false }
+      ]
+    })
+    brokerStub.prototype.adminService = { healthCheck: healthCheckStub }
     await healthCheck(args, opts, logger)
-    expect(logger.info).to.have.been.calledWith('Engine status for LTC: ' + 'NOT VALIDATED'.red)
+    expect(instanceTableStub.push).to.have.been.calledWith(['Engines', 'No Statuses Returned'.red])
+  })
+
+  it('adds relayer status to the healthcheck table', async () => {
+    await healthCheck(args, opts, logger)
+    expect(instanceTableStub.push).to.have.been.calledWith(['Relayer', 'OK'.green])
+  })
+
+  it('adds daemon status to the healthcheck table', async () => {
+    await healthCheck(args, opts, logger)
+    expect(instanceTableStub.push).to.have.been.calledWith(['Daemon', 'OK'.green])
+  })
+
+  it('adds orderbook status to the healthcheck table', async () => {
+    await healthCheck(args, opts, logger)
+    expect(instanceTableStub.push).to.have.been.calledWith(['BTC/LTC Orderbook', 'OK'.green])
+    expect(instanceTableStub.push).to.have.been.calledWith(['ABC/XYZ Orderbook', 'NOT_SYNCED'.red])
   })
 })

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -75,17 +75,17 @@ enum Side {
 enum EngineStatuses {
   // Default state of the engine
   UNKNOWN = 0;
-  // LightningRpc (lnrpc) is unavailable, WalletUnlocker rpc is unavailable
+  // Engine is unavailable
   UNAVAILABLE = 1;
-  // Wallet does not exist, LightningRpc is UNIMPLEMENTED, genSeeds does not throw
+  // Wallet does not exist
   NEEDS_WALLET = 2;
-  // LightningRpc (lnrpc) is UNIMPLEMENTED, genSeeds throws "wallet already exists"
+  // Wallet exists but is not locked
   LOCKED = 3;
-  // LightningRpc (lnrpc) getInfo does not throw an error
+  // Wallet is unlocked but the configuration of the node and chain sync status are not known
   UNLOCKED = 4;
-  // LightningRpc (lnrpc) getInfo synced_to_chain boolean is false
+  // Wallet is not yet synced to chain
   NOT_SYNCED = 5;
-  // LightningRpc (lnrpc) getInfo matches the engines configuration
+  // Engine is validated and ready for use
   VALIDATED = 6;
 }
 

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -174,13 +174,6 @@ service AdminService {
    * │ Daemon            │ OK                │
    * └───────────────────┴───────────────────┘
    * ```
-   *
-   * ```shell
-   * Engine status for BTC: OK
-   * Engine status for LTC: OK
-   * Relayer Status: OK
-   * Daemon Status: OK
-   * ```
    */
   rpc HealthCheck (google.protobuf.Empty) returns (HealthCheckResponse) {
     option (.google.api.http) = {

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -70,13 +70,53 @@ enum Side {
 }
 
 /**
+ * Statuses of an engine
+ */
+enum EngineStatuses {
+  // Default state of the engine
+  UNKNOWN = 0;
+  // LightningRpc (lnrpc) is unavailable, WalletUnlocker rpc is unavailable
+  UNAVAILABLE = 1;
+  // Wallet does not exist, LightningRpc is UNIMPLEMENTED, genSeeds does not throw
+  NEEDS_WALLET = 2;
+  // LightningRpc (lnrpc) is UNIMPLEMENTED, genSeeds throws "wallet already exists"
+  LOCKED = 3;
+  // LightningRpc (lnrpc) getInfo does not throw an error
+  UNLOCKED = 4;
+  // LightningRpc (lnrpc) getInfo synced_to_chain boolean is false
+  NOT_SYNCED = 5;
+  // LightningRpc (lnrpc) getInfo matches the engines configuration
+  VALIDATED = 6;
+}
+
+/**
+ * Statuses of the relayer
+ */
+enum RelayerStatuses {
+  // Relayer is available
+  OK = 0;
+  // Relayer is not available
+  UNAVAILABLE = 1;
+}
+
+/**
+ * Statuses of an orderbook
+ */
+enum OrderbookStatuses {
+  // Orderbook is synced
+  OK = 0;
+  // Orderbook is not synced
+  NOT_SYNCED = 1;
+}
+
+/**
  * HealthCheckResponse provides information on the health of a BrokerDaemon.
  */
 message HealthCheckResponse {
   // The status of every engine available on the BrokerDaemon.
   repeated EngineStatus engine_status = 1;
   // The status of the relayer this BrokerDaemon is connected to, either `'OK'` or the error message returned when connecting to it.
-  string relayer_status = 2;
+  RelayerStatuses relayer_status = 2;
   // The status of every orderbook available on the BrokerDaemon.
   repeated OrderbookStatus orderbook_status = 3;
 
@@ -86,8 +126,8 @@ message HealthCheckResponse {
   message EngineStatus {
     // The common symbol that the engine is responsible for, e.g. `BTC` or `LTC`
     string symbol = 1;
-    // The status of the engine, either `'OK'` or the error message returned when accessing it.
-    string status = 2;
+    // The status of the engine
+    EngineStatuses status = 2;
   }
 
   /**
@@ -96,8 +136,8 @@ message HealthCheckResponse {
   message OrderbookStatus {
     // The market for the orderbook, e.g. `BTC/LTC`
     string market = 1;
-    // The status of the market, either `'OK'` or `'NOT_SYNCED'`.
-    string status = 2;
+    // The status of the market
+    OrderbookStatuses status = 2;
   }
 }
 

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -96,8 +96,8 @@ message HealthCheckResponse {
   message OrderbookStatus {
     // The market for the orderbook, e.g. `BTC/LTC`
     string market = 1;
-    // The status of the market, either `true` or `false`.
-    bool synced = 2;
+    // The status of the market, either `'OK'` or `'NOT_SYNCED'`.
+    string status = 2;
   }
 }
 
@@ -150,7 +150,7 @@ service AdminService {
    *   "orderbookStatus": [
    *     {
    *       "market": "BTC/LTC",
-   *       "synced": "true"
+   *       "status": "OK"
    *     }
    *   ],
    *   "relayerStatus": "OK"

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -77,7 +77,7 @@ message HealthCheckResponse {
   repeated EngineStatus engine_status = 1;
   // The status of the relayer this BrokerDaemon is connected to, either `'OK'` or the error message returned when connecting to it.
   string relayer_status = 2;
-  // The status of every engine available on the BrokerDaemon.
+  // The status of every orderbook available on the BrokerDaemon.
   repeated OrderbookStatus orderbook_status = 3;
 
   /**
@@ -96,7 +96,7 @@ message HealthCheckResponse {
   message OrderbookStatus {
     // The market for the orderbook, e.g. `BTC/LTC`
     string market = 1;
-    // The status of the market, either `'synced'` or `'not synced'`.
+    // The status of the market, either `true` or `false`.
     bool synced = 2;
   }
 }
@@ -147,8 +147,32 @@ service AdminService {
    *       "status": "OK"
    *     },
    *   ],
+   *   "orderbookStatus": [
+   *     {
+   *       "market": "BTC/LTC",
+   *       "synced": "true"
+   *     }
+   *   ],
    *   "relayerStatus": "OK"
    * }
+   * ```
+   *
+   * ```shell
+   * Sparkswap Healthcheck
+   *
+   * ┌───────────────────┬───────────────────┐
+   * │ Component         │ Status            │
+   * ├───────────────────┼───────────────────┤
+   * │ BTC Engine        │ OK                │
+   * ├───────────────────┼───────────────────┤
+   * │ LTC Engine        │ OK                │
+   * ├───────────────────┼───────────────────┤
+   * │ Relayer           │ OK                │
+   * ├───────────────────┼───────────────────┤
+   * │ BTC/LTC Orderbook │ OK                │
+   * ├───────────────────┼───────────────────┤
+   * │ Daemon            │ OK                │
+   * └───────────────────┴───────────────────┘
    * ```
    *
    * ```shell

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -77,6 +77,8 @@ message HealthCheckResponse {
   repeated EngineStatus engine_status = 1;
   // The status of the relayer this BrokerDaemon is connected to, either `'OK'` or the error message returned when connecting to it.
   string relayer_status = 2;
+  // The status of every engine available on the BrokerDaemon.
+  repeated OrderbookStatus orderbook_status = 3;
 
   /**
    * EngineStatus provides the status of an engine for a currency.
@@ -86,6 +88,16 @@ message HealthCheckResponse {
     string symbol = 1;
     // The status of the engine, either `'OK'` or the error message returned when accessing it.
     string status = 2;
+  }
+
+  /**
+   * OrderbookStatus provides the status of an orderbook for a market.
+   */
+  message OrderbookStatus {
+    // The market for the orderbook, e.g. `BTC/LTC`
+    string market = 1;
+    // The status of the market, either `'synced'` or `'not synced'`.
+    bool synced = 2;
   }
 }
 

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -83,7 +83,7 @@ enum EngineStatuses {
   LOCKED = 3;
   // Wallet is unlocked but the configuration of the node and chain sync status are not known
   UNLOCKED = 4;
-  // Wallet is not yet synced to chain
+  // Engine is not yet synced to chain
   NOT_SYNCED = 5;
   // Engine is validated and ready for use
   VALIDATED = 6;

--- a/broker-daemon/broker-rpc/admin-service/health-check.js
+++ b/broker-daemon/broker-rpc/admin-service/health-check.js
@@ -5,7 +5,8 @@
  */
 const STATUS_CODES = Object.freeze({
   UNAVAILABLE: 'UNAVAILABLE',
-  OK: 'OK'
+  OK: 'OK',
+  NOT_SYNCED: 'NOT_SYNCED'
 })
 
 /**
@@ -47,7 +48,8 @@ async function healthCheck ({ relayer, logger, engines, orderbooks }, { HealthCh
   logger.debug(`Received status from relayer`, { relayerStatus })
 
   const orderbookStatus = Array.from(orderbooks).map(([ market, orderbook ]) => {
-    return { market, synced: orderbook.synced }
+    const status = orderbook.synced ? STATUS_CODES.OK : STATUS_CODES.NOT_SYNCED
+    return { market, status }
   })
 
   logger.debug(`Received status from orderbooks`, { orderbookStatus })

--- a/broker-daemon/broker-rpc/admin-service/health-check.js
+++ b/broker-daemon/broker-rpc/admin-service/health-check.js
@@ -35,7 +35,7 @@ async function getRelayerStatus (relayer, { logger }) {
  * @param {function} responses.HealthCheckResponse - constructor for HealthCheckResponse messages
  * @return {responses.HealthCheckResponse}
  */
-async function healthCheck ({ relayer, logger, engines }, { HealthCheckResponse }) {
+async function healthCheck ({ relayer, logger, engines, orderbooks }, { HealthCheckResponse }) {
   const engineStatus = Array.from(engines).map(([ symbol, engine ]) => {
     return { symbol, status: engine.status }
   })
@@ -46,7 +46,13 @@ async function healthCheck ({ relayer, logger, engines }, { HealthCheckResponse 
 
   logger.debug(`Received status from relayer`, { relayerStatus })
 
-  return new HealthCheckResponse({ engineStatus, relayerStatus })
+  const orderbookStatus = Array.from(orderbooks).map(([ market, orderbook ]) => {
+    return { market, synced: orderbook.synced }
+  })
+
+  logger.debug(`Received status from orderbooks`, { orderbookStatus })
+
+  return new HealthCheckResponse({ engineStatus, relayerStatus, orderbookStatus })
 }
 
 module.exports = healthCheck

--- a/broker-daemon/broker-rpc/admin-service/health-check.spec.js
+++ b/broker-daemon/broker-rpc/admin-service/health-check.spec.js
@@ -18,6 +18,8 @@ describe('health-check', () => {
     let engineStub
     let engines
     let reverts = []
+    let orderbooks
+    let orderbookStub
 
     beforeEach(() => {
       relayerStub = sinon.stub()
@@ -27,6 +29,12 @@ describe('health-check', () => {
       }
       engines.set('BTC', engineStub)
       engines.set('LTC', engineStub)
+
+      orderbooks = new Map()
+      orderbookStub = {
+        synced: true
+      }
+      orderbooks.set('BTC/LTC', orderbookStub)
       loggerStub = {
         info: sinon.stub(),
         debug: sinon.stub()
@@ -39,7 +47,7 @@ describe('health-check', () => {
     })
 
     beforeEach(async () => {
-      result = await healthCheck({ relayer: relayerStub, logger: loggerStub, engines: engines }, { HealthCheckResponse })
+      result = await healthCheck({ relayer: relayerStub, logger: loggerStub, engines, orderbooks }, { HealthCheckResponse })
     })
 
     afterEach(() => {
@@ -54,7 +62,17 @@ describe('health-check', () => {
     it('returns status values', async () => {
       expect(result).to.be.an.instanceOf(HealthCheckResponse)
       expect(HealthCheckResponse).to.have.been.calledOnce()
-      expect(HealthCheckResponse).to.have.been.calledWith(sinon.match({ engineStatus: [ { symbol: 'BTC', status: statusOK }, { symbol: 'LTC', status: statusOK } ], relayerStatus: statusOK }))
+      expect(HealthCheckResponse).to.have.been.calledWith(sinon.match(
+        {
+          engineStatus: [
+            { symbol: 'BTC', status: statusOK },
+            { symbol: 'LTC', status: statusOK }
+          ],
+          relayerStatus: statusOK,
+          orderbookStatus: [
+            { market: 'BTC/LTC', synced: true }
+          ]
+        }))
     })
   })
 

--- a/broker-daemon/broker-rpc/admin-service/health-check.spec.js
+++ b/broker-daemon/broker-rpc/admin-service/health-check.spec.js
@@ -70,7 +70,7 @@ describe('health-check', () => {
           ],
           relayerStatus: statusOK,
           orderbookStatus: [
-            { market: 'BTC/LTC', synced: true }
+            { market: 'BTC/LTC', status: 'OK' }
           ]
         }))
     })

--- a/broker-daemon/broker-rpc/admin-service/health-check.spec.js
+++ b/broker-daemon/broker-rpc/admin-service/health-check.spec.js
@@ -70,7 +70,7 @@ describe('health-check', () => {
           ],
           relayerStatus: statusOK,
           orderbookStatus: [
-            { market: 'BTC/LTC', status: 'OK' }
+            { market: 'BTC/LTC', status: statusOK }
           ]
         }))
     })

--- a/broker-daemon/broker-rpc/admin-service/index.js
+++ b/broker-daemon/broker-rpc/admin-service/index.js
@@ -11,9 +11,10 @@ class AdminService {
    * @param {Object} opts.logger
    * @param {Object} opts.relayer
    * @param {Map} opts.engines
+   * @param {Map} opts.orderbooks
    * @param {Function} opts.auth
    */
-  constructor (protoPath, { logger, relayer, engines, auth }) {
+  constructor (protoPath, { logger, relayer, engines, orderbooks, auth }) {
     this.protoPath = protoPath
     this.proto = loadProto(this.protoPath)
     this.logger = logger
@@ -27,7 +28,7 @@ class AdminService {
     } = this.proto.broker.rpc
 
     this.implementation = {
-      healthCheck: new GrpcUnaryMethod(healthCheck, this.messageId('healthCheck'), { logger, relayer, engines, auth }, { HealthCheckResponse }).register(),
+      healthCheck: new GrpcUnaryMethod(healthCheck, this.messageId('healthCheck'), { logger, relayer, engines, orderbooks, auth }, { HealthCheckResponse }).register(),
       getIdentity: new GrpcUnaryMethod(getIdentity, this.messageId('getIdentity'), { logger, relayer, auth }, { GetIdentityResponse }).register()
     }
   }

--- a/broker-daemon/broker-rpc/admin-service/index.spec.js
+++ b/broker-daemon/broker-rpc/admin-service/index.spec.js
@@ -18,6 +18,7 @@ describe('AdminService', () => {
 
   let relayer
   let engines
+  let orderbooks
   let auth
 
   let server
@@ -43,6 +44,7 @@ describe('AdminService', () => {
 
     relayer = sinon.stub()
     engines = new Map()
+    orderbooks = new Map()
 
     GrpcMethod = sinon.stub()
     fakeRegistered = sinon.stub()
@@ -59,7 +61,7 @@ describe('AdminService', () => {
   })
 
   beforeEach(() => {
-    server = new AdminService(protoPath, { logger, relayer, engines, auth })
+    server = new AdminService(protoPath, { logger, relayer, engines, orderbooks, auth })
   })
 
   it('assigns a proto path', () => {
@@ -136,6 +138,10 @@ describe('AdminService', () => {
 
       it('passes in the engines', () => {
         expect(callArgs[2]).to.have.property('engines', engines)
+      })
+
+      it('passes in the orderbooks', () => {
+        expect(callArgs[2]).to.have.property('orderbooks', orderbooks)
       })
 
       it('passes in auth', () => {

--- a/broker-daemon/broker-rpc/broker-rpc-server.js
+++ b/broker-daemon/broker-rpc/broker-rpc-server.js
@@ -77,7 +77,7 @@ class BrokerRPCServer {
     this.server = new grpc.Server()
     this.httpServer = createHttpServer(this.protoPath, DEFAULT_RPC_ADDRESS, { disableAuth, enableCors, privKeyPath, pubKeyPath, logger })
 
-    this.adminService = new AdminService(this.protoPath, { logger, relayer, engines, auth: this.auth })
+    this.adminService = new AdminService(this.protoPath, { logger, relayer, engines, orderbooks, auth: this.auth })
     this.server.addService(this.adminService.definition, this.adminService.implementation)
 
     this.orderService = new OrderService(this.protoPath, { logger, blockOrderWorker, auth: this.auth })

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -75,17 +75,17 @@ enum Side {
 enum EngineStatuses {
   // Default state of the engine
   UNKNOWN = 0;
-  // LightningRpc (lnrpc) is unavailable, WalletUnlocker rpc is unavailable
+  // Engine is unavailable
   UNAVAILABLE = 1;
-  // Wallet does not exist, LightningRpc is UNIMPLEMENTED, genSeeds does not throw
+  // Wallet does not exist
   NEEDS_WALLET = 2;
-  // LightningRpc (lnrpc) is UNIMPLEMENTED, genSeeds throws "wallet already exists"
+  // Wallet exists but is not locked
   LOCKED = 3;
-  // LightningRpc (lnrpc) getInfo does not throw an error
+  // Wallet is unlocked but the configuration of the node and chain sync status are not known
   UNLOCKED = 4;
-  // LightningRpc (lnrpc) getInfo synced_to_chain boolean is false
+  // Wallet is not yet synced to chain
   NOT_SYNCED = 5;
-  // LightningRpc (lnrpc) getInfo matches the engines configuration
+  // Engine is validated and ready for use
   VALIDATED = 6;
 }
 

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -174,13 +174,6 @@ service AdminService {
    * │ Daemon            │ OK                │
    * └───────────────────┴───────────────────┘
    * ```
-   *
-   * ```shell
-   * Engine status for BTC: OK
-   * Engine status for LTC: OK
-   * Relayer Status: OK
-   * Daemon Status: OK
-   * ```
    */
   rpc HealthCheck (google.protobuf.Empty) returns (HealthCheckResponse) {
     option (.google.api.http) = {

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -70,13 +70,53 @@ enum Side {
 }
 
 /**
+ * Statuses of an engine
+ */
+enum EngineStatuses {
+  // Default state of the engine
+  UNKNOWN = 0;
+  // LightningRpc (lnrpc) is unavailable, WalletUnlocker rpc is unavailable
+  UNAVAILABLE = 1;
+  // Wallet does not exist, LightningRpc is UNIMPLEMENTED, genSeeds does not throw
+  NEEDS_WALLET = 2;
+  // LightningRpc (lnrpc) is UNIMPLEMENTED, genSeeds throws "wallet already exists"
+  LOCKED = 3;
+  // LightningRpc (lnrpc) getInfo does not throw an error
+  UNLOCKED = 4;
+  // LightningRpc (lnrpc) getInfo synced_to_chain boolean is false
+  NOT_SYNCED = 5;
+  // LightningRpc (lnrpc) getInfo matches the engines configuration
+  VALIDATED = 6;
+}
+
+/**
+ * Statuses of the relayer
+ */
+enum RelayerStatuses {
+  // Relayer is available
+  OK = 0;
+  // Relayer is not available
+  UNAVAILABLE = 1;
+}
+
+/**
+ * Statuses of an orderbook
+ */
+enum OrderbookStatuses {
+  // Orderbook is synced
+  OK = 0;
+  // Orderbook is not synced
+  NOT_SYNCED = 1;
+}
+
+/**
  * HealthCheckResponse provides information on the health of a BrokerDaemon.
  */
 message HealthCheckResponse {
   // The status of every engine available on the BrokerDaemon.
   repeated EngineStatus engine_status = 1;
   // The status of the relayer this BrokerDaemon is connected to, either `'OK'` or the error message returned when connecting to it.
-  string relayer_status = 2;
+  RelayerStatuses relayer_status = 2;
   // The status of every orderbook available on the BrokerDaemon.
   repeated OrderbookStatus orderbook_status = 3;
 
@@ -86,8 +126,8 @@ message HealthCheckResponse {
   message EngineStatus {
     // The common symbol that the engine is responsible for, e.g. `BTC` or `LTC`
     string symbol = 1;
-    // The status of the engine, either `'OK'` or the error message returned when accessing it.
-    string status = 2;
+    // The status of the engine
+    EngineStatuses status = 2;
   }
 
   /**
@@ -96,8 +136,8 @@ message HealthCheckResponse {
   message OrderbookStatus {
     // The market for the orderbook, e.g. `BTC/LTC`
     string market = 1;
-    // The status of the market, either `'OK'` or `'NOT_SYNCED'`.
-    string status = 2;
+    // The status of the market
+    OrderbookStatuses status = 2;
   }
 }
 

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -96,8 +96,8 @@ message HealthCheckResponse {
   message OrderbookStatus {
     // The market for the orderbook, e.g. `BTC/LTC`
     string market = 1;
-    // The status of the market, either `true` or `false`.
-    bool synced = 2;
+    // The status of the market, either `'OK'` or `'NOT_SYNCED'`.
+    string status = 2;
   }
 }
 
@@ -150,7 +150,7 @@ service AdminService {
    *   "orderbookStatus": [
    *     {
    *       "market": "BTC/LTC",
-   *       "synced": "true"
+   *       "status": "OK"
    *     }
    *   ],
    *   "relayerStatus": "OK"

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -77,7 +77,7 @@ message HealthCheckResponse {
   repeated EngineStatus engine_status = 1;
   // The status of the relayer this BrokerDaemon is connected to, either `'OK'` or the error message returned when connecting to it.
   string relayer_status = 2;
-  // The status of every engine available on the BrokerDaemon.
+  // The status of every orderbook available on the BrokerDaemon.
   repeated OrderbookStatus orderbook_status = 3;
 
   /**
@@ -96,7 +96,7 @@ message HealthCheckResponse {
   message OrderbookStatus {
     // The market for the orderbook, e.g. `BTC/LTC`
     string market = 1;
-    // The status of the market, either `'synced'` or `'not synced'`.
+    // The status of the market, either `true` or `false`.
     bool synced = 2;
   }
 }
@@ -147,8 +147,32 @@ service AdminService {
    *       "status": "OK"
    *     },
    *   ],
+   *   "orderbookStatus": [
+   *     {
+   *       "market": "BTC/LTC",
+   *       "synced": "true"
+   *     }
+   *   ],
    *   "relayerStatus": "OK"
    * }
+   * ```
+   *
+   * ```shell
+   * Sparkswap Healthcheck
+   *
+   * ┌───────────────────┬───────────────────┐
+   * │ Component         │ Status            │
+   * ├───────────────────┼───────────────────┤
+   * │ BTC Engine        │ OK                │
+   * ├───────────────────┼───────────────────┤
+   * │ LTC Engine        │ OK                │
+   * ├───────────────────┼───────────────────┤
+   * │ Relayer           │ OK                │
+   * ├───────────────────┼───────────────────┤
+   * │ BTC/LTC Orderbook │ OK                │
+   * ├───────────────────┼───────────────────┤
+   * │ Daemon            │ OK                │
+   * └───────────────────┴───────────────────┘
    * ```
    *
    * ```shell

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -77,6 +77,8 @@ message HealthCheckResponse {
   repeated EngineStatus engine_status = 1;
   // The status of the relayer this BrokerDaemon is connected to, either `'OK'` or the error message returned when connecting to it.
   string relayer_status = 2;
+  // The status of every engine available on the BrokerDaemon.
+  repeated OrderbookStatus orderbook_status = 3;
 
   /**
    * EngineStatus provides the status of an engine for a currency.
@@ -86,6 +88,16 @@ message HealthCheckResponse {
     string symbol = 1;
     // The status of the engine, either `'OK'` or the error message returned when accessing it.
     string status = 2;
+  }
+
+  /**
+   * OrderbookStatus provides the status of an orderbook for a market.
+   */
+  message OrderbookStatus {
+    // The market for the orderbook, e.g. `BTC/LTC`
+    string market = 1;
+    // The status of the market, either `'synced'` or `'not synced'`.
+    bool synced = 2;
   }
 }
 

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -83,7 +83,7 @@ enum EngineStatuses {
   LOCKED = 3;
   // Wallet is unlocked but the configuration of the node and chain sync status are not known
   UNLOCKED = 4;
-  // Wallet is not yet synced to chain
+  // Engine is not yet synced to chain
   NOT_SYNCED = 5;
   // Engine is validated and ready for use
   VALIDATED = 6;


### PR DESCRIPTION

![screen shot 2019-01-15 at 1 51 03 pm](https://user-images.githubusercontent.com/10237992/51212188-a446a900-18cc-11e9-8898-0842d5f70e9a.png)


## Description
We have the orderbook synced status, its false if not all the order updates have come over from the relayer, true if they have. We want to add to the healthcheck. Also made the healthcheck in a table format for readability. 

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
