### PR TITLE
Fix: return funding errors to the user

### DIFF
--- a/broker-daemon/broker-rpc/wallet-service/commit.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.js
@@ -114,7 +114,7 @@ async function commit ({ params, relayer, logger, engines, orderbooks }, { Empty
     await engine.createChannel(address, balance)
   } catch (e) {
     logger.error('Received error when creating outbound channel', { error: e.stack })
-    throw new PublicError(`Funding error: Check that you have sufficient balance`)
+    throw new PublicError(`Funding error: ${e.message}`)
   }
 
   const paymentChannelNetworkAddress = await inverseEngine.getPaymentChannelNetworkAddress()

--- a/broker-daemon/broker-rpc/wallet-service/commit.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.spec.js
@@ -98,6 +98,14 @@ describe('commit', () => {
     ).to.be.rejectedWith(PublicError, 'Maximum balance')
   })
 
+  it('throws an error if creating a channel fails', () => {
+    createChannelStub.rejects(new Error('channels cannot be created before the wallet is fully synced'))
+
+    expect(
+      commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })
+    ).to.be.rejectedWith(PublicError, 'Funding error')
+  })
+
   describe('committing a balance to the exchange', () => {
     beforeEach(async () => {
       res = await commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })


### PR DESCRIPTION
## Description
Our existing error message when encountering issues opening channels was generic, and referred the user to look at their balance as this is a common cause of issues.

However, in cases where it's not the balance it was quite misleading.

This change displays the underlying error message to the user, which although not perfect, at least leads the user in the right direction.

In the future, we may want to do a more specific mapping between LND/Engine errors and user-facing ones.

## Todos
- [x] Tests
