### PR TITLE
separate bitcoind/litecoind into own docker-compose files

### DIFF
--- a/.env-mainnet-sample
+++ b/.env-mainnet-sample
@@ -48,11 +48,12 @@ BTC_RPC_PASS=sparkswapbtc
 LTC_RPC_USER=sparkswapltc
 LTC_RPC_PASS=sparkswapltc
 
-# Location of nodes
+# Block Broadcast Addresses
 BTC_ZMQPUBRAWBLOCK=tcp://bitcoind:28333
-BTC_ZMQPUBRAWTX=tcp://bitcoind:28334
-
 LTC_ZMQPUBRAWBLOCK=tcp://litecoind:28333
+
+# Transaction Broadcast Addresses
+BTC_ZMQPUBRAWTX=tcp://bitcoind:28334
 LTC_ZMQPUBRAWTX=tcp://litecoind:28334
 
 # External IP Addresses
@@ -69,7 +70,7 @@ EXTERNAL_LTC_ADDRESS=sample.ip.address
 
 # Docker compose files
 # docker-compose by default will look for the docker-compose.yml file and apply the docker-compose.override.yml file if
-# it exists by default. If we specify the COMPOSE_FILE variable, all compose files joined by the COMPOSE_PATH_SEPARATOR will
+# it exists. If we specify the COMPOSE_FILE variable, all compose files joined by the COMPOSE_PATH_SEPARATOR will
 # be applied and used
 #
 COMPOSE_PATH_SEPARATOR=:

--- a/.env-mainnet-sample
+++ b/.env-mainnet-sample
@@ -33,8 +33,8 @@ RELAYER_CERT_HOST=relayer.mainnet.sparkswap.com:8080
 # RPC_HOST. You will be required to also set different RPC_USER/RPC_PASS values
 #
 # Daemon RPC Hosts
-BTC_RPC_HOST=bitcoind
-LTC_RPC_HOST=litecoind
+# BTC_RPC_HOST=your.btc.rpc.host
+# LTC_RPC_HOST=your.ltc.rpc.host
 
 # RPC USER/PASS settings
 #
@@ -49,12 +49,12 @@ LTC_RPC_USER=sparkswapltc
 LTC_RPC_PASS=sparkswapltc
 
 # Block Broadcast Addresses
-BTC_ZMQPUBRAWBLOCK=tcp://bitcoind:28333
-LTC_ZMQPUBRAWBLOCK=tcp://litecoind:28333
+# BTC_ZMQPUBRAWBLOCK=your.bitcoin.node.block.address
+# LTC_ZMQPUBRAWBLOCK=your.litecoin.node.block.address
 
 # Transaction Broadcast Addresses
-BTC_ZMQPUBRAWTX=tcp://bitcoind:28334
-LTC_ZMQPUBRAWTX=tcp://litecoind:28334
+# BTC_ZMQPUBRAWTX=your.bitcoin.node.transaction.address
+# LTC_ZMQPUBRAWTX=your.litecoin.node.transaction.address
 
 # External IP Addresses
 #

--- a/.env-mainnet-sample
+++ b/.env-mainnet-sample
@@ -48,6 +48,13 @@ BTC_RPC_PASS=sparkswapbtc
 LTC_RPC_USER=sparkswapltc
 LTC_RPC_PASS=sparkswapltc
 
+# Location of nodes
+BTC_ZMQPUBRAWBLOCK=tcp://bitcoind:28333
+BTC_ZMQPUBRAWTX=tcp://bitcoind:28334
+
+LTC_ZMQPUBRAWBLOCK=tcp://litecoind:28333
+LTC_ZMQPUBRAWTX=tcp://litecoind:28334
+
 # External IP Addresses
 #
 # In order for your lightning nodes to be found by other users on the network
@@ -59,3 +66,11 @@ LTC_RPC_PASS=sparkswapltc
 #
 EXTERNAL_BTC_ADDRESS=sample.ip.address
 EXTERNAL_LTC_ADDRESS=sample.ip.address
+
+# Docker compose files
+# docker-compose by default will look for the docker-compose.yml file and apply the docker-compose.override.yml file if
+# it exists by default. If we specify the COMPOSE_FILE variable, all compose files joined by the COMPOSE_PATH_SEPARATOR will
+# be applied and used
+#
+COMPOSE_PATH_SEPARATOR=:
+COMPOSE_FILE=docker-compose.yml:docker-compose.bitcoind.yml:docker-compose.litecoind.yml:docker-compose.override.yml

--- a/.env-regtest-sample
+++ b/.env-regtest-sample
@@ -51,11 +51,12 @@ BTC_RPC_PASS=sparkswapbtc
 LTC_RPC_USER=sparkswapltc
 LTC_RPC_PASS=sparkswapltc
 
-# ZMQPUBRAWBLOCK/ZMQPUBRAWTX
+# Block Broadcast Addresses
 BTC_ZMQPUBRAWBLOCK=tcp://bitcoind:28333
-BTC_ZMQPUBRAWTX=tcp://bitcoind:28334
-
 LTC_ZMQPUBRAWBLOCK=tcp://litecoind:28333
+
+# Transaction Broadcast Addresses
+BTC_ZMQPUBRAWTX=tcp://bitcoind:28334
 LTC_ZMQPUBRAWTX=tcp://litecoind:28334
 
 # External IP Addresses
@@ -72,7 +73,7 @@ EXTERNAL_LTC_ADDRESS=host.docker.internal
 
 # Docker compose files
 # docker-compose by default will look for the docker-compose.yml file and apply the docker-compose.override.yml file if
-# it exists by default. If we specify the COMPOSE_FILE variable, all compose files joined by the COMPOSE_PATH_SEPARATOR will
+# it exists. If we specify the COMPOSE_FILE variable, all compose files joined by the COMPOSE_PATH_SEPARATOR will
 # be applied and used
 #
 COMPOSE_PATH_SEPARATOR=:

--- a/.env-regtest-sample
+++ b/.env-regtest-sample
@@ -51,6 +51,13 @@ BTC_RPC_PASS=sparkswapbtc
 LTC_RPC_USER=sparkswapltc
 LTC_RPC_PASS=sparkswapltc
 
+# ZMQPUBRAWBLOCK/ZMQPUBRAWTX
+BTC_ZMQPUBRAWBLOCK=tcp://bitcoind:28333
+BTC_ZMQPUBRAWTX=tcp://bitcoind:28334
+
+LTC_ZMQPUBRAWBLOCK=tcp://litecoind:28333
+LTC_ZMQPUBRAWTX=tcp://litecoind:28334
+
 # External IP Addresses
 #
 # In order for your lightning nodes to be found by other users on the network
@@ -62,3 +69,11 @@ LTC_RPC_PASS=sparkswapltc
 #
 EXTERNAL_BTC_ADDRESS=host.docker.internal
 EXTERNAL_LTC_ADDRESS=host.docker.internal
+
+# Docker compose files
+# docker-compose by default will look for the docker-compose.yml file and apply the docker-compose.override.yml file if
+# it exists by default. If we specify the COMPOSE_FILE variable, all compose files joined by the COMPOSE_PATH_SEPARATOR will
+# be applied and used
+#
+COMPOSE_PATH_SEPARATOR=:
+COMPOSE_FILE=docker-compose.yml:docker-compose.bitcoind.yml:docker-compose.litecoind.yml:docker-compose.override.yml

--- a/.env-regtest-sample
+++ b/.env-regtest-sample
@@ -36,8 +36,8 @@ RELAYER_CERT_HOST=host.docker.internal:8080
 # RPC_HOST. You will be required to also set different RPC_USER/RPC_PASS values
 #
 # Daemon RPC Hosts
-BTC_RPC_HOST=bitcoind
-LTC_RPC_HOST=litecoind
+# BTC_RPC_HOST=your.btc.rpc.host
+# LTC_RPC_HOST=your.ltc.rpc.host
 
 # RPC USER/PASS settings
 #
@@ -52,12 +52,12 @@ LTC_RPC_USER=sparkswapltc
 LTC_RPC_PASS=sparkswapltc
 
 # Block Broadcast Addresses
-BTC_ZMQPUBRAWBLOCK=tcp://bitcoind:28333
-LTC_ZMQPUBRAWBLOCK=tcp://litecoind:28333
+# BTC_ZMQPUBRAWBLOCK=your.bitcoin.node.block.address
+# LTC_ZMQPUBRAWBLOCK=your.litecoin.node.block.address
 
 # Transaction Broadcast Addresses
-BTC_ZMQPUBRAWTX=tcp://bitcoind:28334
-LTC_ZMQPUBRAWTX=tcp://litecoind:28334
+# BTC_ZMQPUBRAWTX=your.bitcoin.node.transaction.address
+# LTC_ZMQPUBRAWTX=your.litecoin.node.transaction.address
 
 # External IP Addresses
 #

--- a/.env-testnet-sample
+++ b/.env-testnet-sample
@@ -51,11 +51,12 @@ BTC_RPC_PASS=sparkswapbtc
 LTC_RPC_USER=sparkswapltc
 LTC_RPC_PASS=sparkswapltc
 
-# Location of nodes
+# Block Broadcast Addresses
 BTC_ZMQPUBRAWBLOCK=tcp://bitcoind:28333
-BTC_ZMQPUBRAWTX=tcp://bitcoind:28334
-
 LTC_ZMQPUBRAWBLOCK=tcp://litecoind:28333
+
+# Transaction Broadcast Addresses
+BTC_ZMQPUBRAWTX=tcp://bitcoind:28334
 LTC_ZMQPUBRAWTX=tcp://litecoind:28334
 
 # External IP Addresses
@@ -72,7 +73,7 @@ EXTERNAL_LTC_ADDRESS=sample.ip.address
 
 # Docker compose files
 # docker-compose by default will look for the docker-compose.yml file and apply the docker-compose.override.yml file if
-# it exists by default. If we specify the COMPOSE_FILE variable, all compose files joined by the COMPOSE_PATH_SEPARATOR will
+# it exists. If we specify the COMPOSE_FILE variable, all compose files joined by the COMPOSE_PATH_SEPARATOR will
 # be applied and used
 #
 COMPOSE_PATH_SEPARATOR=:

--- a/.env-testnet-sample
+++ b/.env-testnet-sample
@@ -36,8 +36,8 @@ RELAYER_CERT_HOST=relayer.testnet.sparkswap.com:8080
 # RPC_HOST. You will be required to also set different RPC_USER/RPC_PASS values
 #
 # Daemon RPC Hosts
-BTC_RPC_HOST=bitcoind
-LTC_RPC_HOST=litecoind
+# BTC_RPC_HOST=your.btc.rpc.host
+# LTC_RPC_HOST=your.ltc.rpc.host
 
 # RPC USER/PASS settings
 #
@@ -52,12 +52,12 @@ LTC_RPC_USER=sparkswapltc
 LTC_RPC_PASS=sparkswapltc
 
 # Block Broadcast Addresses
-BTC_ZMQPUBRAWBLOCK=tcp://bitcoind:28333
-LTC_ZMQPUBRAWBLOCK=tcp://litecoind:28333
+# BTC_ZMQPUBRAWBLOCK=your.bitcoin.node.block.address
+# LTC_ZMQPUBRAWBLOCK=your.litecoin.node.block.address
 
 # Transaction Broadcast Addresses
-BTC_ZMQPUBRAWTX=tcp://bitcoind:28334
-LTC_ZMQPUBRAWTX=tcp://litecoind:28334
+# BTC_ZMQPUBRAWTX=your.bitcoin.node.transaction.address
+# LTC_ZMQPUBRAWTX=your.litecoin.node.transaction.address
 
 # External IP Addresses
 #

--- a/.env-testnet-sample
+++ b/.env-testnet-sample
@@ -51,6 +51,13 @@ BTC_RPC_PASS=sparkswapbtc
 LTC_RPC_USER=sparkswapltc
 LTC_RPC_PASS=sparkswapltc
 
+# Location of nodes
+BTC_ZMQPUBRAWBLOCK=tcp://bitcoind:28333
+BTC_ZMQPUBRAWTX=tcp://bitcoind:28334
+
+LTC_ZMQPUBRAWBLOCK=tcp://litecoind:28333
+LTC_ZMQPUBRAWTX=tcp://litecoind:28334
+
 # External IP Addresses
 #
 # In order for your lightning nodes to be found by other users on the network
@@ -62,3 +69,11 @@ LTC_RPC_PASS=sparkswapltc
 #
 EXTERNAL_BTC_ADDRESS=sample.ip.address
 EXTERNAL_LTC_ADDRESS=sample.ip.address
+
+# Docker compose files
+# docker-compose by default will look for the docker-compose.yml file and apply the docker-compose.override.yml file if
+# it exists by default. If we specify the COMPOSE_FILE variable, all compose files joined by the COMPOSE_PATH_SEPARATOR will
+# be applied and used
+#
+COMPOSE_PATH_SEPARATOR=:
+COMPOSE_FILE=docker-compose.yml:docker-compose.bitcoind.yml:docker-compose.litecoind.yml:docker-compose.override.yml

--- a/docker-compose.bitcoind.yml
+++ b/docker-compose.bitcoind.yml
@@ -18,6 +18,10 @@ services:
   lnd_btc:
     depends_on:
       - bitcoind
+    environment:
+      - RPC_HOST=bitcoind
+      - ZMQPUBRAWBLOCK=tcp://bitcoind:28333
+      - ZMQPUBRAWTX=tcp://bitcoind:28334
 
   bitcoind:
     image: sparkswap_bitcoind:latest

--- a/docker-compose.bitcoind.yml
+++ b/docker-compose.bitcoind.yml
@@ -1,0 +1,45 @@
+##########################################
+#
+# sparkswap Broker-CLI and Broker-Daemon
+# https://sparkswap.com
+#
+# The broker and engines currently default to TestNet. To adjust settings, please
+# look at the associated `.env` files
+#
+# Troubleshooting GRPC:
+# - GRPC_VERBOSITY=INFO
+# - GRPC_TRACE=all
+#
+##########################################
+
+version: '2.4'
+
+services:
+  lnd_btc:
+    depends_on:
+      - bitcoind
+
+  bitcoind:
+    image: sparkswap_bitcoind:latest
+    volumes:
+      - shared:/shared
+      - bitcoin:/data
+    environment:
+      - RPC_USER=${BTC_RPC_USER}
+      - RPC_PASS=${BTC_RPC_PASS}
+      - NETWORK=${NETWORK}
+      - DEBUG=info
+      - DATA_DIR=/data
+      - RPC_LISTEN=0.0.0.0
+    networks:
+      - broker
+    logging:
+      options:
+        max-size: 50m
+
+volumes:
+  shared:
+  bitcoin:
+
+networks:
+  broker:

--- a/docker-compose.litecoind.yml
+++ b/docker-compose.litecoind.yml
@@ -18,6 +18,10 @@ services:
   lnd_ltc:
     depends_on:
       - litecoind
+    environment:
+      - RPC_HOST=litecoind
+      - ZMQPUBRAWBLOCK=tcp://litecoind:28333
+      - ZMQPUBRAWTX=tcp://litecoind:28334
 
   litecoind:
     image: sparkswap_litecoind:latest

--- a/docker-compose.litecoind.yml
+++ b/docker-compose.litecoind.yml
@@ -1,0 +1,45 @@
+##########################################
+#
+# sparkswap Broker-CLI and Broker-Daemon
+# https://sparkswap.com
+#
+# The broker and engines currently default to TestNet. To adjust settings, please
+# look at the associated `.env` files
+#
+# Troubleshooting GRPC:
+# - GRPC_VERBOSITY=INFO
+# - GRPC_TRACE=all
+#
+##########################################
+
+version: '2.4'
+
+services:
+  lnd_ltc:
+    depends_on:
+      - litecoind
+
+  litecoind:
+    image: sparkswap_litecoind:latest
+    volumes:
+      - shared:/shared
+      - litecoin:/data
+    environment:
+      - RPC_USER=${LTC_RPC_USER}
+      - RPC_PASS=${LTC_RPC_PASS}
+      - NETWORK=${NETWORK}
+      - DEBUG=info
+      - DATA_DIR=/data
+      - RPC_LISTEN=0.0.0.0
+    networks:
+      - broker
+    logging:
+      options:
+        max-size: 50m
+
+volumes:
+  shared:
+  litecoin:
+
+networks:
+  broker:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,8 +62,6 @@ services:
 
   lnd_btc:
     image: sparkswap_lnd_btc:latest
-    depends_on:
-      - bitcoind
     ports:
       - '10113:9735'
     environment:
@@ -74,29 +72,11 @@ services:
       - DEBUG=info
       - EXTERNAL_ADDRESS="${EXTERNAL_BTC_ADDRESS}:10113"
       - EXTPREIMAGE_HOST=sparkswapd:40369
-      - ZMQPUBRAWBLOCK=tcp://bitcoind:28333
-      - ZMQPUBRAWTX=tcp://bitcoind:28334
+      - ZMQPUBRAWBLOCK=${BTC_ZMQPUBRAWBLOCK}
+      - ZMQPUBRAWTX=${BTC_ZMQPUBRAWTX}
     volumes:
       - 'shared:/shared'
       - 'lnd_btc:/data'
-    networks:
-      - broker
-    logging:
-      options:
-        max-size: 50m
-
-  bitcoind:
-    image: sparkswap_bitcoind:latest
-    volumes:
-      - shared:/shared
-      - bitcoin:/data
-    environment:
-      - RPC_USER=${BTC_RPC_USER}
-      - RPC_PASS=${BTC_RPC_PASS}
-      - NETWORK=${NETWORK}
-      - DEBUG=info
-      - DATA_DIR=/data
-      - RPC_LISTEN=0.0.0.0
     networks:
       - broker
     logging:
@@ -107,8 +87,6 @@ services:
     image: sparkswap_lnd_ltc:latest
     ports:
       - '10114:9735'
-    depends_on:
-      - litecoind
     environment:
       - RPC_USER=${LTC_RPC_USER}
       - RPC_PASS=${LTC_RPC_PASS}
@@ -117,8 +95,8 @@ services:
       - DEBUG=info
       - EXTERNAL_ADDRESS="${EXTERNAL_LTC_ADDRESS}:10114"
       - EXTPREIMAGE_HOST=sparkswapd:40369
-      - ZMQPUBRAWBLOCK=tcp://litecoind:28333
-      - ZMQPUBRAWTX=tcp://litecoind:28334
+      - ZMQPUBRAWBLOCK=${LTC_ZMQPUBRAWBLOCK}
+      - ZMQPUBRAWTX=${LTC_ZMQPUBRAWTX}
     volumes:
       - 'shared:/shared'
       - 'lnd_ltc:/data'
@@ -128,31 +106,10 @@ services:
       options:
         max-size: 50m
 
-  litecoind:
-    image: sparkswap_litecoind:latest
-    volumes:
-      - shared:/shared
-      - litecoin:/data
-    environment:
-      - RPC_USER=${LTC_RPC_USER}
-      - RPC_PASS=${LTC_RPC_PASS}
-      - NETWORK=${NETWORK}
-      - DEBUG=info
-      - DATA_DIR=/data
-      - RPC_LISTEN=0.0.0.0
-    networks:
-      - broker
-    logging:
-      options:
-        max-size: 50m
-
-
 volumes:
   shared:
   lnd_btc:
   lnd_ltc:
-  bitcoin:
-  litecoin:
   sparkswapd:
 
 networks:


### PR DESCRIPTION
## Description
We need to have an easy configuration setup if a user wants to use their own bitcoind/litecoind nodes. To do this, they need to supply the address of their nodes as env variables for:
```
BTC_ZMQPUBRAWBLOCK
BTC_ZMQPUBRAWTX
LTC_ZMQPUBRAWBLOCK
LTC_ZMQPUBRAWTX
```

Which have been defaulted in the env sample files.

We also do not want to build our own litecoind/bitcoind containers if the user is supplying their own, in which case bitcoind/litecoind containers should be added to docker-compose only if necessary. So I added  the COMPOSE_FILE env variable which specifies multiple docker-compose files that get composed together when calling docker-compose up. The user can remove the docker-compose.bitcoind.yml or docker-compose.litecoind.yml files from the path if they are supplying their own.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
