### PR TITLE
remove unbound variable strict mode to avoid crashes on some systems

### DIFF
--- a/setup-scripts/install.sh
+++ b/setup-scripts/install.sh
@@ -10,7 +10,8 @@
 # 
 #################################
 
-set -e -u
+# Note: we don't set -u because we're sourcing from scripts (e.g. .bashrc) that may not be as strict.
+set -e
 
 TAG='[⚡ Sparkswap Installer]'
 WHITE='\033[1;37m'


### PR DESCRIPTION
## Description
The sparkswap install script uses variable strict mode: `set -u`, which causes the script to fail on unbound variables.

Unfortunately, since we source a bunch of random files in that script in an attempt to load `nvm`, we are exposed to tons of potentially poorly written bash, which will trip that strict variable.

In particular the default Amazon Linux images on AWS contain a script in `/etc/bashrc` that attempts to determine if it's an interactive shell using `$PS1`, which is not declared. So our script fails on that image.

This change removes the strict mode, which makes the script more error prone, but actually makes it work in more locations. Which is a *little* important.
