### PR TITLE
revert pm2 change that prevents watch from working

### DIFF
--- a/docker-compose.regtest.sample.yml
+++ b/docker-compose.regtest.sample.yml
@@ -16,12 +16,9 @@ services:
       - lnd_btc
       - lnd_ltc
     volumes:
-      - './broker-daemon:/home/app/broker-daemon/'
-      # TODO: This can be removed once utils are moved to a shared repo or into
-      # the broker-daemon itself. broker-daemon relies on these utils for ./broker-daemon/bin/sparkswapd
-      - './broker-cli/utils:/home/app/broker-cli/utils/'
-      - './proto:/home/app/proto/'
-      - './scripts:/home/app/scripts/'
+      - './:/home/app/'
+      - '/home/app/node_modules'
+      - '/home/app/broker-cli/node_modules'
     environment:
       # WARNING: only disable Relayer SSL/AUTH during development
       - DISABLE_RELAYER_AUTH=false

--- a/pm2.json
+++ b/pm2.json
@@ -6,15 +6,15 @@
   "exec_interpreter" : "bash",
   "exec_mode"  : "fork_mode",
   "min_uptime": 5000,
+  "watch_options": {
+    "usePolling": true,
+    "interval": 5001
+  },
+  "watch": [
+    "broker-daemon",
+    "proto"
+  ],
   "env": {
-    "NODE_ENV": "development",
-    "watch_options": {
-      "usePolling": true,
-      "interval": 5001
-    },
-    "watch": [
-      "broker-daemon",
-      "proto"
-    ]
+    "NODE_ENV": "development"
   }
 }


### PR DESCRIPTION
## Description
revert pm2 change that prevents `--watch` from working. I had shifted `watch` parameters locations in pm2 directory.

This PR also addresses bind mount issues in the regtest docker-compose.

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
