### PR TITLE
Add authorization into metadata

### DIFF
--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -324,10 +324,8 @@ class BlockOrderWorker extends EventEmitter {
 
     await Promise.all(openOrders.map(({ order }) => {
       const orderId = order.orderId
-      const params = { orderId }
-      const authorization = this.relayer.identity.authorize('CancelOrder', params)
-      this.logger.debug(`Generated authorization for ${orderId}`, authorization)
-      return this.relayer.makerService.cancelOrder(params, authorization)
+      const authorization = this.relayer.identity.authorize()
+      return this.relayer.makerService.cancelOrder({ orderId }, authorization)
     }))
 
     this.logger.info(`Cancelled ${openOrders.length} underlying orders for ${blockOrder.id}`)

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -324,9 +324,10 @@ class BlockOrderWorker extends EventEmitter {
 
     await Promise.all(openOrders.map(({ order }) => {
       const orderId = order.orderId
-      const authorization = this.relayer.identity.authorize(orderId)
+      const params = { orderId }
+      const authorization = this.relayer.identity.authorize('CancelOrder', params)
       this.logger.debug(`Generated authorization for ${orderId}`, authorization)
-      return this.relayer.makerService.cancelOrder({ orderId, authorization })
+      return this.relayer.makerService.cancelOrder(params, authorization)
     }))
 
     this.logger.info(`Cancelled ${openOrders.length} underlying orders for ${blockOrder.id}`)

--- a/broker-daemon/broker-rpc/wallet-service/commit.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.js
@@ -121,9 +121,6 @@ async function commit ({ params, relayer, logger, engines, orderbooks }, { Empty
 
   try {
     const authorization = relayer.identity.authorize()
-    console.log('calling', {
-      address: paymentChannelNetworkAddress
-    })
     await relayer.paymentChannelNetworkService.createChannel({
       address: paymentChannelNetworkAddress,
       balance: convertedBalance,

--- a/broker-daemon/broker-rpc/wallet-service/commit.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.js
@@ -120,10 +120,12 @@ async function commit ({ params, relayer, logger, engines, orderbooks }, { Empty
   const paymentChannelNetworkAddress = await inverseEngine.getPaymentChannelNetworkAddress()
 
   try {
-    const params = { address: paymentChannelNetworkAddress, balance: convertedBalance, symbol: inverseSymbol }
-    const authorization = relayer.identity.authorize('CreateChannel', params)
-    logger.debug('Requesting inbound channel from relayer', params)
-    await relayer.paymentChannelNetworkService.createChannel(params, authorization)
+    const authorization = relayer.identity.authorize()
+    await relayer.paymentChannelNetworkService.createChannel({
+      address: paymentChannelNetworkAddress,
+      balance: convertedBalance,
+      symbol: inverseSymbol
+    }, authorization)
   } catch (e) {
     // TODO: Close channel that was open if relayer call has failed
     throw (e)

--- a/broker-daemon/broker-rpc/wallet-service/commit.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.js
@@ -120,8 +120,10 @@ async function commit ({ params, relayer, logger, engines, orderbooks }, { Empty
   const paymentChannelNetworkAddress = await inverseEngine.getPaymentChannelNetworkAddress()
 
   try {
-    logger.debug('Requesting inbound channel from relayer', { address: paymentChannelNetworkAddress, balance: convertBalance, symbol: inverseSymbol })
-    await relayer.paymentChannelNetworkService.createChannel({address: paymentChannelNetworkAddress, balance: convertedBalance, symbol: inverseSymbol})
+    const params = { address: paymentChannelNetworkAddress, balance: convertedBalance, symbol: inverseSymbol }
+    const authorization = relayer.identity.authorize('CreateChannel', params)
+    logger.debug('Requesting inbound channel from relayer', params)
+    await relayer.paymentChannelNetworkService.createChannel(params, authorization)
   } catch (e) {
     // TODO: Close channel that was open if relayer call has failed
     throw (e)

--- a/broker-daemon/broker-rpc/wallet-service/commit.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.js
@@ -121,6 +121,9 @@ async function commit ({ params, relayer, logger, engines, orderbooks }, { Empty
 
   try {
     const authorization = relayer.identity.authorize()
+    console.log('calling', {
+      address: paymentChannelNetworkAddress
+    })
     await relayer.paymentChannelNetworkService.createChannel({
       address: paymentChannelNetworkAddress,
       balance: convertedBalance,

--- a/broker-daemon/relayer/identity.js
+++ b/broker-daemon/relayer/identity.js
@@ -53,33 +53,21 @@ class Identity {
   }
 
   /**
-   * @typedef {Object} Authorization
-   * @property {String} timestamp Int64 string of the current unix timestamp in seconds
-   * @property {String} nonce base64 string of 32 random bytes
-   * @property {String} signature base64 string of the signature that authorizes it
-   */
-
-  /**
    * Authorize a gRPC Request by adding metadata to it.
    *
    * Specifically, the signature is of the following payload:
-   *  - a string name of the request [ what format? ]
    *  - timestamp of the request, in seconds. A timestamp within +/- 60 seconds of the Relayer's time should be accepted.
    *  - A random nonce of 32 bytes, represented in base64. This nonce should not be repeated, but the Relayer may not reject duplicate nonces older than 24 hours.
-   *  - Contents of the request, JSON stringified
    *
    * This payload is joined by commas (','), and signed using the public key of the broker.
    *
    * The request can then be validated by the Relayer as being genuine from the owner of the public key.
-   * @param  {string} action action to authorize the request for
-   * @param  {object} params Parameters of the request to authorize
    * @return {grpc.Metadata} Metadata object with necessary items to verify it
    */
-  authorize (action, params) {
-    const request = `${action}:${JSON.stringify(params)}`
+  authorize () {
     const timestamp = nowInSeconds().toString()
     const nonce = randomBytes(32).toString('base64')
-    const payload = [ timestamp, nonce, request ].join(',')
+    const payload = [ timestamp, nonce ].join(',')
     const signature = this.sign(payload)
     const pubKey = this.pubKeyBase64
 

--- a/broker-daemon/relayer/identity.js
+++ b/broker-daemon/relayer/identity.js
@@ -67,12 +67,13 @@ class Identity {
   authorize () {
     const timestamp = nowInSeconds().toString()
     const nonce = randomBytes(32).toString('base64')
-    const payload = [ timestamp, nonce ].join(',')
-    const signature = this.sign(payload)
-    const pubKey = this.pubKeyBase64
+    const signature = this.sign(`${timestamp},${nonce}`)
 
     const metadata = new Metadata()
-    metadata.set('authorization', `${pubKey},${timestamp},${nonce},${signature}`)
+    metadata.set('pubkey', this.pubKeyBase64)
+    metadata.set('timestamp', timestamp)
+    metadata.set('nonce', nonce)
+    metadata.set('signature', signature)
 
     return metadata
   }

--- a/broker-daemon/relayer/identity.spec.js
+++ b/broker-daemon/relayer/identity.spec.js
@@ -120,22 +120,6 @@ describe('Identity', () => {
       })
     })
 
-    describe('#identify', () => {
-      let metadata
-
-      beforeEach(() => {
-        metadata = identity.identify()
-      })
-
-      it('creates metadata', () => {
-        expect(metadata).to.be.instanceOf(Metadata)
-      })
-
-      it('adds the pub key to the metadata', () => {
-        expect(Metadata.prototype.set).to.have.been.calledWith('pubkey', 'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWOrLBCKQBQkiMJaIV5A05HqWFmR2GR5j8B19bxx7Th3/zmm7mZ8lNyseTr1YO7BwN7jKEbMe8Agx5LLCd/IP/A==')
-      })
-    })
-
     describe('#authorize', () => {
       let id
       let auth
@@ -151,6 +135,14 @@ describe('Identity', () => {
         nowInSeconds.returns(timeInSeconds)
 
         auth = identity.authorize(id)
+      })
+
+      it('creates metadata', () => {
+        expect(metadata).to.be.instanceOf(Metadata)
+      })
+
+      it('adds the pub key to the metadata', () => {
+        expect(Metadata.prototype.set).to.have.been.calledWith('pubkey', 'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWOrLBCKQBQkiMJaIV5A05HqWFmR2GR5j8B19bxx7Th3/zmm7mZ8lNyseTr1YO7BwN7jKEbMe8Agx5LLCd/IP/A==')
       })
 
       it('adds a random nonce to the auth', () => {

--- a/broker-daemon/relayer/identity.spec.js
+++ b/broker-daemon/relayer/identity.spec.js
@@ -121,47 +121,45 @@ describe('Identity', () => {
     })
 
     describe('#authorize', () => {
-      let id
       let auth
       let fakeRandom = Buffer.from('fake')
       let fakeSign = 'signature'
       let timeInSeconds
 
       beforeEach(() => {
-        id = 'someid'
         randomBytes.returns(fakeRandom)
         identity.sign = sinon.stub().returns(fakeSign)
         timeInSeconds = 1532045655
         nowInSeconds.returns(timeInSeconds)
 
-        auth = identity.authorize(id)
+        auth = identity.authorize()
       })
 
       it('creates metadata', () => {
-        expect(metadata).to.be.instanceOf(Metadata)
+        expect(auth).to.be.instanceOf(Metadata)
       })
 
-      it('adds the pub key to the metadata', () => {
-        expect(Metadata.prototype.set).to.have.been.calledWith('pubkey', 'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWOrLBCKQBQkiMJaIV5A05HqWFmR2GR5j8B19bxx7Th3/zmm7mZ8lNyseTr1YO7BwN7jKEbMe8Agx5LLCd/IP/A==')
+      it('adds the pubkey to the metadata', () => {
+        expect(Metadata.prototype.set).to.have.been.calledWith('pubkey', identity.pubKeyBase64)
       })
 
-      it('adds a random nonce to the auth', () => {
+      it('adds a random nonce to the metadata', () => {
         expect(randomBytes).to.have.been.calledOnce()
         expect(randomBytes).to.have.been.calledWith(32)
-        expect(auth).to.have.property('nonce', fakeRandom.toString('base64'))
+        expect(Metadata.prototype.set).to.have.been.calledWith('nonce', fakeRandom.toString('base64'))
       })
 
-      it('adds a timestamp to the auth', () => {
-        expect(auth).to.have.property('timestamp', timeInSeconds.toString())
+      it('adds a timestamp to the metadata', () => {
+        expect(Metadata.prototype.set).to.have.been.calledWith('timestamp', timeInSeconds.toString())
       })
 
       it('signs the payload', () => {
         expect(identity.sign).to.have.been.calledOnce()
-        expect(identity.sign).to.have.been.calledWith(`${timeInSeconds.toString()},${fakeRandom.toString('base64')},${id}`)
+        expect(identity.sign).to.have.been.calledWith(`${timeInSeconds.toString()},${fakeRandom.toString('base64')}`)
       })
 
-      it('adds the signature to the auth', () => {
-        expect(auth).to.have.property('signature', fakeSign)
+      it('adds the signature to the metadata', () => {
+        expect(Metadata.prototype.set).to.have.been.calledWith('signature', fakeSign)
       })
     })
   })

--- a/broker-daemon/relayer/relayer-client.js
+++ b/broker-daemon/relayer/relayer-client.js
@@ -50,12 +50,8 @@ class RelayerClient {
     } else {
       channelCredentials = credentials.createSsl(readFileSync(certPath))
     }
-    // `service_url` in the line below is defined by the grpc lib, so we need to tell eslint to ignore snake case
-    // eslint-disable-next-line
-    const callCredentials = credentials.createFromMetadataGenerator(({ service_url }, callback) => {
-      callback(null, this.identity.identify())
-    })
-    this.credentials = credentials.combineChannelCredentials(channelCredentials, callCredentials)
+
+    this.credentials = channelCredentials
 
     this.makerService = caller(this.address, this.proto.MakerService, this.credentials)
     this.takerService = caller(this.address, this.proto.TakerService, this.credentials)

--- a/broker-daemon/relayer/relayer-client.spec.js
+++ b/broker-daemon/relayer/relayer-client.spec.js
@@ -6,8 +6,6 @@ const RelayerClient = rewire(path.resolve('broker-daemon', 'relayer', 'relayer-c
 describe('RelayerClient', () => {
   let logger
   let createSslStub
-  let createFromMetadataGeneratorStub
-  let combineChannelCredentialsStub
   let readFileSync
   let pathResolve
   let Identity
@@ -99,13 +97,9 @@ describe('RelayerClient', () => {
     RelayerClient.__set__('caller', callerStub)
 
     createSslStub = sinon.stub()
-    createFromMetadataGeneratorStub = sinon.stub()
-    combineChannelCredentialsStub = sinon.stub()
 
     RelayerClient.__set__('credentials', {
-      createSsl: createSslStub,
-      createFromMetadataGenerator: createFromMetadataGeneratorStub,
-      combineChannelCredentials: combineChannelCredentialsStub
+      createSsl: createSslStub
     })
 
     RelayerClient.__set__('ENABLE_SSL', ENABLE_SSL)
@@ -157,38 +151,12 @@ describe('RelayerClient', () => {
       expect(createSslStub).to.have.been.calledWith(fakeCert)
     })
 
-    it('creates call credentials using the custom signer', () => {
-      // eslint-disable-next-line
-      new RelayerClient(idKeyPath, { host: relayerHost }, logger)
-
-      const generator = createFromMetadataGeneratorStub.args[0][0]
-
-      const fakeMeta = 'fakemetadata'
-      const fakeUrl = 'someurl'
-      const fakeCallback = sinon.stub()
-      identityIdentify.returns(fakeMeta)
-
-      generator({ service_url: fakeUrl }, fakeCallback)
-
-      expect(identityIdentify).to.have.been.calledOnce()
-      expect(identityIdentify).to.have.been.calledWithExactly()
-      expect(fakeCallback).to.have.been.calledOnce()
-      expect(fakeCallback).to.have.been.calledWith(null, fakeMeta)
-    })
-
-    it('combines ssl and custom call credentials', () => {
-      const fakeCallCreds = 'myfake'
+    it('sets ssl credentials for the services', () => {
       const fakeSslCreds = 'yourfake'
-      const fakeCombined = 'ourfake'
       createSslStub.returns(fakeSslCreds)
-      createFromMetadataGeneratorStub.returns(fakeCallCreds)
-      combineChannelCredentialsStub.returns(fakeCombined)
 
       const relayer = new RelayerClient(idKeyPath, { host: relayerHost }, logger)
-
-      expect(combineChannelCredentialsStub).to.have.been.calledOnce()
-      expect(combineChannelCredentialsStub).to.have.been.calledWith(fakeSslCreds, fakeCallCreds)
-      expect(relayer).to.have.property('credentials', fakeCombined)
+      expect(relayer).to.have.property('credentials', fakeSslCreds)
     })
 
     describe('services', () => {
@@ -197,7 +165,7 @@ describe('RelayerClient', () => {
 
       beforeEach(() => {
         fakeCreds = 'somecreds'
-        combineChannelCredentialsStub.returns(fakeCreds)
+        createSslStub.returns(fakeCreds)
         relayer = new RelayerClient(idKeyPath, { host: relayerHost }, logger)
       })
 

--- a/broker-daemon/state-machines/fill-state-machine.js
+++ b/broker-daemon/state-machines/fill-state-machine.js
@@ -185,6 +185,8 @@ const FillStateMachine = StateMachine.factory({
       const swapHash = await inboundEngine.createSwapHash(this.fill.order.orderId, inboundAmount)
       this.fill.setSwapHash(swapHash)
 
+      const authorization = this.relayer.identity.authorize('CreateFill', this.fill.paramsForCreate)
+
       const {
         fillId,
         feePaymentRequest,
@@ -192,7 +194,7 @@ const FillStateMachine = StateMachine.factory({
         feeRequired,
         depositRequired,
         fillError
-      } = await this.relayer.takerService.createFill(this.fill.paramsForCreate)
+      } = await this.relayer.takerService.createFill(this.fill.paramsForCreate, authorization)
 
       if (fillError) {
         this.logger.error(`Encountered error with fill: ${fillError.message}`)
@@ -278,9 +280,10 @@ const FillStateMachine = StateMachine.factory({
         payDepositInvoice
       ])
 
-      const authorization = this.relayer.identity.authorize(fillId)
+      const fillOrderParams = { fillId, feeRefundPaymentRequest, depositRefundPaymentRequest }
+      const authorization = this.relayer.identity.authorize('FillOrder', fillOrderParams)
       this.logger.debug(`Generated authorization for ${fillId}`, authorization)
-      const { fillError } = await this.relayer.takerService.fillOrder({ fillId, feeRefundPaymentRequest, depositRefundPaymentRequest, authorization })
+      const { fillError } = await this.relayer.takerService.fillOrder(fillOrderParams, authorization)
 
       if (fillError) {
         this.logger.error(`Encountered error with fill: ${fillError.message}`)
@@ -308,10 +311,11 @@ const FillStateMachine = StateMachine.factory({
       const { fillId } = this.fill
       this.logger.info(`In filled state, attempting to listen for executions on fill ${fillId}`)
 
-      const authorization = this.relayer.identity.authorize(fillId)
+      const subscribeExecuteParams = { fillId }
+      const authorization = this.relayer.identity.authorize('SubscribeExecute', subscribeExecuteParams)
       this.logger.debug(`Generated authorization for ${fillId}`, authorization)
       // NOTE: this method should NOT reject a promise, as that may prevent the state of the fill from saving
-      const call = this.relayer.takerService.subscribeExecute({ fillId, authorization })
+      const call = this.relayer.takerService.subscribeExecute(subscribeExecuteParams, authorization)
 
       // Stop listening to further events from the stream
       const finish = () => {

--- a/broker-daemon/state-machines/fill-state-machine.js
+++ b/broker-daemon/state-machines/fill-state-machine.js
@@ -185,7 +185,7 @@ const FillStateMachine = StateMachine.factory({
       const swapHash = await inboundEngine.createSwapHash(this.fill.order.orderId, inboundAmount)
       this.fill.setSwapHash(swapHash)
 
-      const authorization = this.relayer.identity.authorize('CreateFill', this.fill.paramsForCreate)
+      const authorization = this.relayer.identity.authorize()
 
       const {
         fillId,
@@ -280,10 +280,12 @@ const FillStateMachine = StateMachine.factory({
         payDepositInvoice
       ])
 
-      const fillOrderParams = { fillId, feeRefundPaymentRequest, depositRefundPaymentRequest }
-      const authorization = this.relayer.identity.authorize('FillOrder', fillOrderParams)
-      this.logger.debug(`Generated authorization for ${fillId}`, authorization)
-      const { fillError } = await this.relayer.takerService.fillOrder(fillOrderParams, authorization)
+      const authorization = this.relayer.identity.authorize()
+      const { fillError } = await this.relayer.takerService.fillOrder({
+        fillId,
+        feeRefundPaymentRequest,
+        depositRefundPaymentRequest
+      }, authorization)
 
       if (fillError) {
         this.logger.error(`Encountered error with fill: ${fillError.message}`)
@@ -311,11 +313,9 @@ const FillStateMachine = StateMachine.factory({
       const { fillId } = this.fill
       this.logger.info(`In filled state, attempting to listen for executions on fill ${fillId}`)
 
-      const subscribeExecuteParams = { fillId }
-      const authorization = this.relayer.identity.authorize('SubscribeExecute', subscribeExecuteParams)
-      this.logger.debug(`Generated authorization for ${fillId}`, authorization)
+      const authorization = this.relayer.identity.authorize()
       // NOTE: this method should NOT reject a promise, as that may prevent the state of the fill from saving
-      const call = this.relayer.takerService.subscribeExecute(subscribeExecuteParams, authorization)
+      const call = this.relayer.takerService.subscribeExecute({ fillId }, authorization)
 
       // Stop listening to further events from the stream
       const finish = () => {

--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -172,7 +172,7 @@ const OrderStateMachine = StateMachine.factory({
       this.order.makerBaseAddress = await baseEngine.getPaymentChannelNetworkAddress()
       this.order.makerCounterAddress = await counterEngine.getPaymentChannelNetworkAddress()
 
-      const authorization = this.relayer.identity.authorize('CreateOrder', this.order.paramsForCreate)
+      const authorization = this.relayer.identity.authorize()
 
       const {
         orderId,
@@ -263,13 +263,7 @@ const OrderStateMachine = StateMachine.factory({
         payDepositInvoice
       ])
 
-      const placeOrderParams = {
-        orderId,
-        feeRefundPaymentRequest,
-        depositRefundPaymentRequest
-      }
-      const authorization = this.relayer.identity.authorize('PlaceOrder', placeOrderParams)
-      this.logger.debug(`Generated authorization for ${orderId}`, authorization)
+      const authorization = this.relayer.identity.authorize()
       // NOTE: this method should NOT reject a promise, as that may prevent the state of the order from saving
       const call = this.relayer.makerService.placeOrder({
         orderId,
@@ -338,8 +332,7 @@ const OrderStateMachine = StateMachine.factory({
       }
       await engine.prepareSwap(orderId, swapHash, amount)
 
-      const authorization = this.relayer.identity.authorize('ExecuteOrder', { orderId })
-      this.logger.debug(`Generated authorization for ${orderId}`, authorization)
+      const authorization = this.relayer.identity.authorize()
       await this.relayer.makerService.executeOrder({ orderId }, authorization)
     },
 

--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -394,9 +394,7 @@ const OrderStateMachine = StateMachine.factory({
       this.order.setSettledParams({ swapPreimage })
 
       const { orderId } = this.order.paramsForComplete
-      const completeOrderParams = { orderId, swapPreimage }
-      const authorization = this.relayer.identity.authorize('CompleteOrder', completeOrderParams)
-      this.logger.debug(`Generated authorization for ${orderId}`, authorization)
+      const authorization = this.relayer.identity.authorize()
       return this.relayer.makerService.completeOrder({ orderId, swapPreimage }, authorization)
     },
 


### PR DESCRIPTION
## Description
This change moves our authorization data into the metadata of a request rather than its body.

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
