### PR TITLE
Persist certs by having them in .sparkswap directory

### DIFF
--- a/.env-mainnet-sample
+++ b/.env-mainnet-sample
@@ -68,5 +68,5 @@ EXTERNAL_LTC_ADDRESS=sample.ip.address
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose.yml:docker-compose.bitcoind.yml:docker-compose.litecoind.yml:docker-compose.override.yml
 
-# Path to rpc and identity certs
-PATH_TO_CERTS=~/.sparkswap/certs
+# Path to rpc certs and identity keys
+SECURE_PATH=~/.sparkswap/secure

--- a/.env-mainnet-sample
+++ b/.env-mainnet-sample
@@ -60,6 +60,9 @@ LTC_RPC_PASS=sparkswapltc
 EXTERNAL_BTC_ADDRESS=sample.ip.address
 EXTERNAL_LTC_ADDRESS=sample.ip.address
 
+# Path to rpc certs and identity keys
+SECURE_PATH=~/.sparkswap/secure
+
 # Docker compose files
 # docker-compose by default will look for the docker-compose.yml file and apply the docker-compose.override.yml file if
 # it exists. If we specify the COMPOSE_FILE variable, all compose files joined by the COMPOSE_PATH_SEPARATOR will
@@ -67,6 +70,3 @@ EXTERNAL_LTC_ADDRESS=sample.ip.address
 #
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose.yml:docker-compose.bitcoind.yml:docker-compose.litecoind.yml:docker-compose.override.yml
-
-# Path to rpc certs and identity keys
-SECURE_PATH=~/.sparkswap/secure

--- a/.env-mainnet-sample
+++ b/.env-mainnet-sample
@@ -67,3 +67,6 @@ EXTERNAL_LTC_ADDRESS=sample.ip.address
 #
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose.yml:docker-compose.bitcoind.yml:docker-compose.litecoind.yml:docker-compose.override.yml
+
+# Path to rpc and identity certs
+PATH_TO_CERTS=~/.sparkswap/certs

--- a/.env-regtest-sample
+++ b/.env-regtest-sample
@@ -68,3 +68,6 @@ EXTERNAL_LTC_ADDRESS=host.docker.internal
 #
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose.yml:docker-compose.bitcoind.yml:docker-compose.litecoind.yml:docker-compose.override.yml
+
+# Path to rpc and identity certs
+PATH_TO_CERTS=~/.sparkswap/certs

--- a/.env-regtest-sample
+++ b/.env-regtest-sample
@@ -69,5 +69,5 @@ EXTERNAL_LTC_ADDRESS=host.docker.internal
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose.yml:docker-compose.bitcoind.yml:docker-compose.litecoind.yml:docker-compose.override.yml
 
-# Path to rpc and identity certs
-PATH_TO_CERTS=~/.sparkswap/certs
+# Path to rpc certs and identity keys
+SECURE_PATH=~/.sparkswap/secure

--- a/.env-regtest-sample
+++ b/.env-regtest-sample
@@ -61,6 +61,9 @@ LTC_RPC_PASS=sparkswapltc
 EXTERNAL_BTC_ADDRESS=host.docker.internal
 EXTERNAL_LTC_ADDRESS=host.docker.internal
 
+# Path to rpc certs and identity keys
+SECURE_PATH=~/.sparkswap/secure
+
 # Docker compose files
 # docker-compose by default will look for the docker-compose.yml file and apply the docker-compose.override.yml file if
 # it exists. If we specify the COMPOSE_FILE variable, all compose files joined by the COMPOSE_PATH_SEPARATOR will
@@ -68,6 +71,3 @@ EXTERNAL_LTC_ADDRESS=host.docker.internal
 #
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose.yml:docker-compose.bitcoind.yml:docker-compose.litecoind.yml:docker-compose.override.yml
-
-# Path to rpc certs and identity keys
-SECURE_PATH=~/.sparkswap/secure

--- a/.env-testnet-sample
+++ b/.env-testnet-sample
@@ -68,3 +68,6 @@ EXTERNAL_LTC_ADDRESS=sample.ip.address
 #
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose.yml:docker-compose.bitcoind.yml:docker-compose.litecoind.yml:docker-compose.override.yml
+
+# Path to rpc and identity certs
+PATH_TO_CERTS=~/.sparkswap/certs

--- a/.env-testnet-sample
+++ b/.env-testnet-sample
@@ -61,6 +61,9 @@ LTC_RPC_PASS=sparkswapltc
 EXTERNAL_BTC_ADDRESS=sample.ip.address
 EXTERNAL_LTC_ADDRESS=sample.ip.address
 
+# Path to rpc certs and identity keys
+SECURE_PATH=~/.sparkswap/secure
+
 # Docker compose files
 # docker-compose by default will look for the docker-compose.yml file and apply the docker-compose.override.yml file if
 # it exists. If we specify the COMPOSE_FILE variable, all compose files joined by the COMPOSE_PATH_SEPARATOR will
@@ -68,6 +71,3 @@ EXTERNAL_LTC_ADDRESS=sample.ip.address
 #
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose.yml:docker-compose.bitcoind.yml:docker-compose.litecoind.yml:docker-compose.override.yml
-
-# Path to rpc certs and identity keys
-SECURE_PATH=~/.sparkswap/secure

--- a/.env-testnet-sample
+++ b/.env-testnet-sample
@@ -69,5 +69,5 @@ EXTERNAL_LTC_ADDRESS=sample.ip.address
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose.yml:docker-compose.bitcoind.yml:docker-compose.litecoind.yml:docker-compose.override.yml
 
-# Path to rpc and identity certs
-PATH_TO_CERTS=~/.sparkswap/certs
+# Path to rpc certs and identity keys
+SECURE_PATH=~/.sparkswap/secure

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,3 @@ proto
 
 # Override file which we use dynamically in the broker setup
 docker-compose.override.yml
-
-# local cert generation
-certs/

--- a/broker-cli/certs/.gitignore
+++ b/broker-cli/certs/.gitignore
@@ -1,5 +1,0 @@
-# Ignore everything in this directory except this file
-# We never want to inadvertantly check-in files to the certs/ directory
-*
-!.gitignore
-!README.md

--- a/broker-cli/certs/README.md
+++ b/broker-cli/certs/README.md
@@ -1,3 +1,0 @@
-## Certs Directory
-
-This directory should contain certs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       # This is populated externally w/ an engine
       - 'shared:/shared'
       # Persistent certs for broker
-      - ${CERT_PATH}:/secure
+      - ${PATH_TO_CERTS}:/secure
     environment:
       - DATA_DIR=${DATA_DIR:-}
       - NETWORK=${NETWORK}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       # This is populated externally w/ an engine
       - 'shared:/shared'
       # Persistent certs for broker
-      - './certs:/secure'
+      - ${CERT_PATH}:/secure
     environment:
       - DATA_DIR=${DATA_DIR:-}
       - NETWORK=${NETWORK}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,9 @@ services:
       - 'sparkswapd:/data'
       # This is populated externally w/ an engine
       - 'shared:/shared'
-      # Persistent certs for broker
-      - ${PATH_TO_CERTS}:/secure
+      # Persistent certs/keys for broker
+      - ${SECURE_PATH}:/secure
+
     environment:
       - DATA_DIR=${DATA_DIR:-}
       - NETWORK=${NETWORK}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       # This is populated externally w/ an engine
       - 'shared:/shared'
       # Persistent certs/keys for broker
-      - ${SECURE_PATH}:/secure
+      - '${SECURE_PATH}:/secure'
 
     environment:
       - DATA_DIR=${DATA_DIR:-}

--- a/docker/sparkswapd/Dockerfile
+++ b/docker/sparkswapd/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /home/app
 RUN git clone -b ${BROKER_VERSION} https://github.com/sparkswap/broker.git .
 
 RUN npm install --quiet --production
-RUN npm run build -- --no-docker
+RUN npm run build -- --no-docker --no-identity --no-certs
 
 # Create a final image as this will be < 50% the size of the build image
 FROM node:8.11-alpine as final
@@ -31,9 +31,6 @@ COPY --from=builder /home/app/broker-cli /home/app/broker-cli
 COPY --from=builder /home/app/scripts/start-sparkswapd.sh /home/app/scripts/start-sparkswapd.sh
 COPY --from=builder /home/app/package.json /home/app/package.json
 COPY --from=builder /home/app/pm2.json /home/app/pm2.json
-
-# Copy certs
-COPY --from=builder /home/app/certs /secure
 
 # Copy relayer-proto files
 COPY --from=builder /home/app/proto /home/app/proto

--- a/docker/sparkswapd/Dockerfile
+++ b/docker/sparkswapd/Dockerfile
@@ -15,6 +15,9 @@ WORKDIR /home/app
 RUN git clone -b ${BROKER_VERSION} https://github.com/sparkswap/broker.git .
 
 RUN npm install --quiet --production
+# --no-docker is set so we don't get into an infinite loop
+# --no-identity makes it so we do not generate keys for the daemons identity because we do this externally
+# --no-certs  makes it so we do not re-generate tls certs for the daemon because we do this externally
 RUN npm run build -- --no-docker --no-identity --no-certs
 
 # Create a final image as this will be < 50% the size of the build image

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -32,6 +32,9 @@ echo "                                                                          
 # correctly for a hosted (remote) broker daemon.
 RELAYER_PROTO_VERSION='master'
 
+# The directory where we store the sparkswap configuration, certs, and keys.
+SPARKSWAP_DIRECTORY=~/.sparkswap
+
 # parse options
 NO_CLI="false"
 NO_DOCKER="false"
@@ -98,21 +101,12 @@ rm -rf ./proto/.git
 #
 #############################################
 
-DIRECTORY=~/.sparkswap
-if [ ! -d "$DIRECTORY" ]; then
-  echo "Creating directory $DIRECTORY"
-  mkdir -p $DIRECTORY
-fi
+echo "Creating directories $SPARKSWAP_DIRECTORY and $SPARKSWAP_DIRECTORY/secure"
+mkdir -p $SPARKSWAP_DIRECTORY/secure
 
-if [[ ! -d "$DIRECTORY/secure" ]]; then
-  echo "Creating directory $DIRECTORY/secure"
-
-  mkdir -p $DIRECTORY/secure
-fi
-
-KEY_PATH=$DIRECTORY/secure/broker-rpc-tls.key
-CERT_PATH=$DIRECTORY/secure/broker-rpc-tls.cert
-CSR_PATH=$DIRECTORY/secure/broker-rpc-csr.csr
+KEY_PATH=$SPARKSWAP_DIRECTORY/secure/broker-rpc-tls.key
+CERT_PATH=$SPARKSWAP_DIRECTORY/secure/broker-rpc-tls.cert
+CSR_PATH=$SPARKSWAP_DIRECTORY/secure/broker-rpc-csr.csr
 
 if [[ -f "$KEY_PATH" ]]; then
   echo "WARNING: TLS Private Key already exists at $KEY_PATH for Broker Daemon. Skipping cert generation"
@@ -148,8 +142,8 @@ fi
 #
 #############################################
 
-ID_PRIV_KEY=$DIRECTORY/secure/broker-identity.private.pem
-ID_PUB_KEY=$DIRECTORY/secure/broker-identity.public.pem
+ID_PRIV_KEY=$SPARKSWAP_DIRECTORY/secure/broker-identity.private.pem
+ID_PUB_KEY=$SPARKSWAP_DIRECTORY/secure/broker-identity.public.pem
 
 if [[ -f "$ID_PRIV_KEY" ]]; then
   echo "WARNING: ID already exists for Broker Daemon. Skipping ID generation"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -104,15 +104,15 @@ if [ ! -d "$DIRECTORY" ]; then
   mkdir -p $DIRECTORY
 fi
 
-if [[ ! -d "$DIRECTORY/certs" ]]; then
-  echo "Creating directory $DIRECTORY/certs"
+if [[ ! -d "$DIRECTORY/secure" ]]; then
+  echo "Creating directory $DIRECTORY/secure"
 
-  mkdir -p $DIRECTORY/certs
+  mkdir -p $DIRECTORY/secure
 fi
 
-KEY_PATH=~/.sparkswap/certs/broker-rpc-tls.key
-CERT_PATH=~/.sparkswap/certs/broker-rpc-tls.cert
-CSR_PATH=~/.sparkswap/certs/broker-rpc-csr.csr
+KEY_PATH=$DIRECTORY/secure/broker-rpc-tls.key
+CERT_PATH=$DIRECTORY/secure/broker-rpc-tls.cert
+CSR_PATH=$DIRECTORY/secure/broker-rpc-csr.csr
 
 if [[ -f "$KEY_PATH" ]]; then
   echo "WARNING: TLS Private Key already exists at $KEY_PATH for Broker Daemon. Skipping cert generation"
@@ -147,8 +147,9 @@ fi
 # via a non secure channel.
 #
 #############################################
-ID_PRIV_KEY=~/.sparkswap/certs/broker-identity.private.pem
-ID_PUB_KEY=~/.sparkswap/certs/broker-identity.public.pem
+
+ID_PRIV_KEY=$DIRECTORY/secure/broker-identity.private.pem
+ID_PUB_KEY=$DIRECTORY/secure/broker-identity.public.pem
 
 if [[ -f "$ID_PRIV_KEY" ]]; then
   echo "WARNING: ID already exists for Broker Daemon. Skipping ID generation"


### PR DESCRIPTION
## Description
We want the rpc and identity certs to be in a persistent location (so we don't regenerate them every time we build)

This PR:
- Puts the generated certs in the `.sparkswap/certs` directory if they don't exist
- Binds the /secure folder in the container to the cert path specified in the .env file (default is `.sparkswap/certs`)

## Related PRs

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
