### PR TITLE
update path to rpc cert

### DIFF
--- a/broker-cli/default-config.js
+++ b/broker-cli/default-config.js
@@ -20,7 +20,7 @@ module.exports = {
    * Default path of the Broker Daemons RPC Public Cert
    * @type {String}
    */
-  rpcCertPath: '~/.sparkswap/certs/broker-rpc-tls.cert',
+  rpcCertPath: '~/.sparkswap/secure/broker-rpc-tls.cert',
 
   /**
    * Configuration for SSL between the CLI and Daemon. This setting is only required

--- a/broker-cli/sample-config.js
+++ b/broker-cli/sample-config.js
@@ -20,7 +20,7 @@ module.exports = {
    * Default path of the Broker Daemons RPC Public Cert
    * @type {String}
    */
-  rpcCertPath: '~/.sparkswap/certs/broker-rpc-tls.cert',
+  rpcCertPath: '~/.sparkswap/secure/broker-rpc-tls.cert',
 
   /**
    * Configuration for SSL between the CLI and Daemon. This setting is only required


### PR DESCRIPTION
## Description
When we updated the naming of /certs to /secure in https://github.com/sparkswap/broker/pull/391, I forgot to update the rpc paths to point to the new location of the cert.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
