### PR TITLE
remove broker-proto check

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -79,9 +79,6 @@ echo ""
 echo "It's time to BUILD! All resistance is futile."
 echo ""
 
-echo "Checking broker.proto file for issues"
-npm run broker-proto
-
 echo "Downloading relayer proto files"
 # Blow away proto directory and recreate or git-clone will yell at us
 if [ -d ./proto ]; then


### PR DESCRIPTION
## Description
For the Broker, when we build the application, it is redundant to check `broker-proto` because we should already be checking the validity of the proto files before committing into the repo.

Additionally, this is breaking all builds for the broker because it forces the user to install nodejs dev dependencies

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
