### PR TITLE
add function for cancelling all active block orders for a given market

### DIFF
--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -359,6 +359,31 @@ class BlockOrderWorker extends EventEmitter {
   }
 
   /**
+   * Cancel all active orders for a given market
+   * @param  {string} market to cancel orders on
+   * @return {object} successfulCancellations and unsuccessfulCancellations as arrays of blockorderids
+   */
+  async cancelActiveOrders (market) {
+    this.logger.info('Cancelling all active orders for market', { market })
+
+    const blockOrders = await this.getBlockOrders(market)
+    const activeBlockOrders = blockOrders.filter(blockOrder => blockOrder.isActive)
+    const successfulCancellations = []
+    const unsuccessfulCancellations = []
+
+    for (let blockOrder of activeBlockOrders) {
+      try {
+        await this.cancelBlockOrder(blockOrder.id)
+        successfulCancellations.push(blockOrder.id)
+      } catch (e) {
+        unsuccessfulCancellations.push(blockOrder.id)
+      }
+    }
+
+    return { successfulCancellations, unsuccessfulCancellations }
+  }
+
+  /**
    * Get existing block orders
    * @param  {String} market to filter by
    * @return {Array<BlockOrder>}

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -377,7 +377,7 @@ class BlockOrderWorker extends EventEmitter {
           await this.cancelBlockOrder(blockOrder.id)
           cancelledOrders.push(blockOrder.id)
         } catch (e) {
-          this.logger.error('Failed to cancel order', e)
+          this.logger.error('Failed to cancel block order', { blockOrderId: blockOrder.id, error: e })
           failedToCancelOrders.push(blockOrder.id)
         }
       })

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -361,7 +361,9 @@ class BlockOrderWorker extends EventEmitter {
   /**
    * Cancel all active orders for a given market
    * @param  {string} market to cancel orders on
-   * @return {object} cancelledOrders and failedToCancelOrders as arrays of blockorderids
+   * @returns {object} result
+   * @returns {Array<string>} result.cancelledOrders ids of block orders that have been cancelled
+   * @returns {Array<string>} result.failedToCancelOrders ids of block orders that failed to be cancelled
    */
   async cancelActiveOrders (market) {
     this.logger.info('Cancelling all active orders for market', { market })

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -385,6 +385,7 @@ class BlockOrderWorker extends EventEmitter {
       })
     )
 
+    this.logger.info(`Succesfully cancelled ${cancelledOrders.length} orders, failed to cancel ${failedToCancelOrders.length}.`)
     return { cancelledOrders, failedToCancelOrders }
   }
 

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -1211,6 +1211,73 @@ describe('BlockOrderWorker', () => {
     })
   })
 
+  describe.only('#cancelActiveOrders', () => {
+    let worker
+    let getBlockOrders
+    let market
+    let cancelBlockOrder
+    let unsuccessfulBlockOrder
+    let successfulBlockOrder
+
+    beforeEach(() => {
+      market = 'BTC/LTC'
+      unsuccessfulBlockOrder = {
+        isActive: true,
+        id: 'unsuccessfulId'
+      }
+      successfulBlockOrder = {
+        isActive: true,
+        id: 'successfulId'
+      }
+      cancelBlockOrder = sinon.stub()
+      cancelBlockOrder.withArgs(unsuccessfulBlockOrder.id).rejects()
+      cancelBlockOrder.withArgs(successfulBlockOrder.id).resolves()
+
+      getBlockOrders = sinon.stub().resolves([successfulBlockOrder, unsuccessfulBlockOrder])
+
+      worker = new BlockOrderWorker({ orderbooks, store, logger, relayer, engines })
+      worker.getBlockOrders = getBlockOrders
+      worker.cancelBlockOrder = cancelBlockOrder
+    })
+
+    it('gets all block orders', async () => {
+      await worker.cancelActiveOrders(market)
+
+      expect(getBlockOrders).to.have.been.called()
+      expect(getBlockOrders).to.have.been.calledWith(market)
+    })
+
+    it('filters out inactive block orders', async () => {
+      const inactiveBlockOrder = {
+        isActive: false,
+        id: 'inactiveBlockOrder'
+      }
+      getBlockOrders.resolves([successfulBlockOrder, unsuccessfulBlockOrder, inactiveBlockOrder])
+      await worker.cancelActiveOrders(market)
+
+      expect(cancelBlockOrder).to.not.have.been.calledWith(inactiveBlockOrder.id)
+    })
+
+    it('attempts to cancel each block order', async () => {
+      await worker.cancelActiveOrders(market)
+
+      expect(cancelBlockOrder).to.have.been.calledWith(successfulBlockOrder.id)
+      expect(cancelBlockOrder).to.have.been.calledWith(unsuccessfulBlockOrder.id)
+    })
+
+    it('returns successfully cancelled block order ids', async () => {
+      const res = await worker.cancelActiveOrders(market)
+
+      expect(res.successfulCancellations).to.eql(['successfulId'])
+    })
+
+    it('returns unsuccessfully cancelled block order ids', async () => {
+      const res = await worker.cancelActiveOrders(market)
+
+      expect(res.unsuccessfulCancellations).to.eql(['unsuccessfulId'])
+    })
+  })
+
   describe('#cancelOutstandingOrders', () => {
     let worker
     let blockOrder

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -1211,7 +1211,7 @@ describe('BlockOrderWorker', () => {
     })
   })
 
-  describe.only('#cancelActiveOrders', () => {
+  describe('#cancelActiveOrders', () => {
     let worker
     let getBlockOrders
     let market
@@ -1268,13 +1268,13 @@ describe('BlockOrderWorker', () => {
     it('returns successfully cancelled block order ids', async () => {
       const res = await worker.cancelActiveOrders(market)
 
-      expect(res.successfulCancellations).to.eql(['successfulId'])
+      expect(res.cancelledOrders).to.eql(['successfulId'])
     })
 
     it('returns unsuccessfully cancelled block order ids', async () => {
       const res = await worker.cancelActiveOrders(market)
 
-      expect(res.unsuccessfulCancellations).to.eql(['unsuccessfulId'])
+      expect(res.failedToCancelOrders).to.eql(['unsuccessfulId'])
     })
   })
 

--- a/broker-daemon/broker-rpc/wallet-service/index.js
+++ b/broker-daemon/broker-rpc/wallet-service/index.js
@@ -56,7 +56,7 @@ class WalletService {
       commit: new GrpcUnaryMethod(commit, this.messageId('commit'), { logger, engines, relayer, orderbooks, auth }, { EmptyResponse }).register(),
       getPaymentChannelNetworkAddress: new GrpcUnaryMethod(getPaymentChannelNetworkAddress, this.messageId('getPaymentChannelNetworkAddress'), { logger, engines, auth }, { GetPaymentChannelNetworkAddressResponse }).register(),
       getTradingCapacities: new GrpcUnaryMethod(getTradingCapacities, this.messageId('getTradingCapacities'), { logger, engines, orderbooks, blockOrderWorker, auth }, { GetTradingCapacitiesResponse }).register(),
-      releaseChannels: new GrpcUnaryMethod(releaseChannels, this.messageId('releaseChannels'), { logger, engines, orderbooks, auth }, { ReleaseChannelsResponse }).register(),
+      releaseChannels: new GrpcUnaryMethod(releaseChannels, this.messageId('releaseChannels'), { logger, engines, orderbooks, blockOrderWorker, auth }, { ReleaseChannelsResponse }).register(),
       withdrawFunds: new GrpcUnaryMethod(withdrawFunds, this.messageId('withdrawFunds'), { logger, engines, auth }, { WithdrawFundsResponse }).register(),
       createWallet: new GrpcUnaryMethod(createWallet, this.messageId('createWallet'), { logger, engines, auth }, { CreateWalletResponse }).register(),
       unlockWallet: new GrpcUnaryMethod(unlockWallet, this.messageId('unlockWallet'), { logger, engines, auth }, { EmptyResponse }).register()

--- a/broker-daemon/broker-rpc/wallet-service/index.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/index.spec.js
@@ -152,7 +152,7 @@ describe('WalletService', () => {
       expect(unaryMethodStub).to.have.been.calledWith(
         releaseChannels,
         expectedMessageId,
-        { logger, engines, orderbooks, auth },
+        { logger, engines, orderbooks, blockOrderWorker, auth },
         { ReleaseChannelsResponse: responseStub }
       )
     })

--- a/broker-daemon/broker-rpc/wallet-service/release-channels.js
+++ b/broker-daemon/broker-rpc/wallet-service/release-channels.js
@@ -68,8 +68,8 @@ async function releaseChannels ({ params, logger, engines, orderbooks, blockOrde
   }
 
   const { cancelledOrders, failedToCancelOrders } = await blockOrderWorker.cancelActiveOrders(market)
-  logger.info('Successfully cancelled orders', { orders: cancelledOrders })
-  logger.info('Failed to cancel orders', { orders: failedToCancelOrders })
+  if (cancelledOrders) logger.info('Successfully cancelled orders', { orders: cancelledOrders })
+  if (failedToCancelOrders) logger.info('Failed to cancel orders', { orders: failedToCancelOrders })
 
   const [baseSymbol, counterSymbol] = market.split('/')
 

--- a/broker-daemon/broker-rpc/wallet-service/release-channels.js
+++ b/broker-daemon/broker-rpc/wallet-service/release-channels.js
@@ -68,8 +68,9 @@ async function releaseChannels ({ params, logger, engines, orderbooks, blockOrde
   }
 
   const { cancelledOrders, failedToCancelOrders } = await blockOrderWorker.cancelActiveOrders(market)
-  if (cancelledOrders) logger.info('Successfully cancelled orders', { orders: cancelledOrders })
-  if (failedToCancelOrders) logger.info('Failed to cancel orders', { orders: failedToCancelOrders })
+
+  if (cancelledOrders.length) logger.info('Successfully cancelled orders', { orders: cancelledOrders })
+  if (failedToCancelOrders.length) logger.info('Failed to cancel orders', { orders: failedToCancelOrders })
 
   const [baseSymbol, counterSymbol] = market.split('/')
 

--- a/broker-daemon/broker-rpc/wallet-service/release-channels.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/release-channels.spec.js
@@ -73,7 +73,7 @@ describe('releaseChannels', () => {
         blockOrderWorker.cancelActiveOrders.resolves({ cancelledOrders: [], failedToCancelOrders })
         await releaseChannels({ params, logger, engines, orderbooks, blockOrderWorker }, { ReleaseChannelsResponse })
 
-        expect(logger.info).to.not.have.been.calledWith('Successfully cancelled orders', { orders: cancelledOrders })
+        expect(logger.info).to.not.have.been.calledWith('Successfully cancelled orders', { orders: [] })
       })
     })
 
@@ -88,7 +88,7 @@ describe('releaseChannels', () => {
         blockOrderWorker.cancelActiveOrders.resolves({ cancelledOrders, failedToCancelOrders: [] })
         await releaseChannels({ params, logger, engines, orderbooks, blockOrderWorker }, { ReleaseChannelsResponse })
 
-        expect(logger.info).to.not.have.been.calledWith('Failed to cancel orders', { orders: failedToCancelOrders })
+        expect(logger.info).to.not.have.been.calledWith('Failed to cancel orders', { orders: [] })
       })
     })
   })

--- a/broker-daemon/broker-rpc/wallet-service/release-channels.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/release-channels.spec.js
@@ -8,9 +8,12 @@ describe('releaseChannels', () => {
   let logger
   let engines
   let orderbooks
+  let blockOrderWorker
   let baseEngineStub
   let counterEngineStub
   let ReleaseChannelsResponse
+  let successfulCancellations
+  let unsuccessfulCancellations
 
   beforeEach(() => {
     ReleaseChannelsResponse = sinon.stub()
@@ -21,6 +24,11 @@ describe('releaseChannels', () => {
 
     params = { market: 'BTC/LTC' }
     orderbooks = new Map([['BTC/LTC', { store: sinon.stub() }]])
+    successfulCancellations = ['asdfasdf', 'asdfwerw']
+    unsuccessfulCancellations = ['gsdgsdgsg']
+    blockOrderWorker = {
+      cancelActiveOrders: sinon.stub().resolves({ successfulCancellations, unsuccessfulCancellations })
+    }
     baseEngineStub = { closeChannels: sinon.stub().resolves([{chan: 'channel'}]) }
     counterEngineStub = { closeChannels: sinon.stub().resolves([{chan: 'counterchannel'}, {chan: 'counterchannel'}]) }
     engines = new Map([['BTC', baseEngineStub], ['LTC', counterEngineStub]])
@@ -28,7 +36,7 @@ describe('releaseChannels', () => {
 
   describe('release channels from a specific market', () => {
     beforeEach(async () => {
-      await releaseChannels({ params, logger, engines, orderbooks }, { ReleaseChannelsResponse })
+      await releaseChannels({ params, logger, engines, orderbooks, blockOrderWorker }, { ReleaseChannelsResponse })
     })
 
     it('attempts to close channels on the base engine', async () => {
@@ -47,12 +55,18 @@ describe('releaseChannels', () => {
       }
       expect(ReleaseChannelsResponse).to.have.been.calledWith(expectedRes)
     })
+
+    it('cancels all orders on the market', async () => {
+      expect(blockOrderWorker.cancelActiveOrders).to.have.been.calledWith(params.market)
+      expect(logger.info).to.have.been.calledWith('Successfully cancelled orders', { orders: successfulCancellations })
+      expect(logger.info).to.have.been.calledWith('Failed to cancel orders', { orders: unsuccessfulCancellations })
+    })
   })
 
   describe('force releasing channels from a specific market', () => {
     beforeEach(async () => {
       params.force = true
-      await releaseChannels({ params, logger, engines, orderbooks }, { ReleaseChannelsResponse })
+      await releaseChannels({ params, logger, engines, orderbooks, blockOrderWorker }, { ReleaseChannelsResponse })
     })
 
     it('force closes channels on the base engine', async () => {
@@ -69,20 +83,20 @@ describe('releaseChannels', () => {
       orderbooks = new Map([['ABC/DXS', { store: sinon.stub() }]])
 
       const errorMessage = `${params.market} is not being tracked as a market.`
-      return expect(releaseChannels({ params, logger, engines, orderbooks }, { ReleaseChannelsResponse })).to.eventually.be.rejectedWith(errorMessage)
+      return expect(releaseChannels({ params, logger, engines, orderbooks, blockOrderWorker }, { ReleaseChannelsResponse })).to.eventually.be.rejectedWith(errorMessage)
     })
 
     it('throws an error if the base engine does not exist for symbol', () => {
       engines = new Map([['LTC', counterEngineStub]])
       return expect(
-        releaseChannels({ params, logger, engines, orderbooks }, { ReleaseChannelsResponse })
+        releaseChannels({ params, logger, engines, orderbooks, blockOrderWorker }, { ReleaseChannelsResponse })
       ).to.eventually.be.rejectedWith(PublicError, `No engine available for BTC`)
     })
 
     it('throws an error if the counter engine does not exist for symbol', () => {
       engines = new Map([['BTC', baseEngineStub]])
       return expect(
-        releaseChannels({ params, logger, engines, orderbooks }, { ReleaseChannelsResponse })
+        releaseChannels({ params, logger, engines, orderbooks, blockOrderWorker }, { ReleaseChannelsResponse })
       ).to.be.rejectedWith(PublicError, `No engine available for LTC`)
     })
   })
@@ -92,13 +106,20 @@ describe('releaseChannels', () => {
       const { RELEASED, FAILED } = releaseChannels.__get__('RELEASE_STATE')
       const error = new Error('BTC engine is locked')
       baseEngineStub.closeChannels.rejects(error)
-      await releaseChannels({ params, logger, engines, orderbooks }, { ReleaseChannelsResponse })
+      await releaseChannels({ params, logger, engines, orderbooks, blockOrderWorker }, { ReleaseChannelsResponse })
 
       const expectedResponse = {
         base: { symbol: 'BTC', error: error.message, status: FAILED },
         counter: { symbol: 'LTC', status: RELEASED }
       }
       expect(ReleaseChannelsResponse).to.have.been.calledWith(expectedResponse)
+    })
+
+    it('does not cancel orders on the market', async () => {
+      const error = new Error('BTC engine is locked')
+      baseEngineStub.closeChannels.rejects(error)
+      await releaseChannels({ params, logger, engines, orderbooks, blockOrderWorker }, { ReleaseChannelsResponse })
+      expect(blockOrderWorker.cancelActiveOrders).to.not.have.been.called()
     })
   })
 })

--- a/broker-daemon/broker-rpc/wallet-service/release-channels.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/release-channels.spec.js
@@ -55,11 +55,41 @@ describe('releaseChannels', () => {
       }
       expect(ReleaseChannelsResponse).to.have.been.calledWith(expectedRes)
     })
+  })
 
+  describe('cancelling orders on the market', () => {
     it('cancels all orders on the market', async () => {
+      await releaseChannels({ params, logger, engines, orderbooks, blockOrderWorker }, { ReleaseChannelsResponse })
       expect(blockOrderWorker.cancelActiveOrders).to.have.been.calledWith(params.market)
-      expect(logger.info).to.have.been.calledWith('Successfully cancelled orders', { orders: cancelledOrders })
-      expect(logger.info).to.have.been.calledWith('Failed to cancel orders', { orders: failedToCancelOrders })
+    })
+
+    context('logging cancelled orders', async () => {
+      it('logs successfully cancelled orders', async () => {
+        await releaseChannels({ params, logger, engines, orderbooks, blockOrderWorker }, { ReleaseChannelsResponse })
+        expect(logger.info).to.have.been.calledWith('Successfully cancelled orders', { orders: cancelledOrders })
+      })
+
+      it('does not log success if none were successfully cancelled', async () => {
+        blockOrderWorker.cancelActiveOrders.resolves({ cancelledOrders: [], failedToCancelOrders })
+        await releaseChannels({ params, logger, engines, orderbooks, blockOrderWorker }, { ReleaseChannelsResponse })
+
+        expect(logger.info).to.not.have.been.calledWith('Successfully cancelled orders', { orders: cancelledOrders })
+      })
+    })
+
+    context('logging failed to cancel orders', async () => {
+      it('logs orders that could not be cancelled', async () => {
+        await releaseChannels({ params, logger, engines, orderbooks, blockOrderWorker }, { ReleaseChannelsResponse })
+
+        expect(logger.info).to.have.been.calledWith('Failed to cancel orders', { orders: failedToCancelOrders })
+      })
+
+      it('does not log failure if no orders failed to cancel', async () => {
+        blockOrderWorker.cancelActiveOrders.resolves({ cancelledOrders, failedToCancelOrders: [] })
+        await releaseChannels({ params, logger, engines, orderbooks, blockOrderWorker }, { ReleaseChannelsResponse })
+
+        expect(logger.info).to.not.have.been.calledWith('Failed to cancel orders', { orders: failedToCancelOrders })
+      })
     })
   })
 

--- a/broker-daemon/models/block-order.js
+++ b/broker-daemon/models/block-order.js
@@ -239,11 +239,19 @@ class BlockOrder {
   }
 
   /**
+   * get boolean for if the blockOrder is in an active
+   * @return {Boolean}
+   */
+  get isActive () {
+    return this.status === BlockOrder.STATUSES.ACTIVE
+  }
+
+  /**
    * get boolean for if the blockOrder is an a state to be worked
    * @return {Boolean}
    */
   get isInWorkableState () {
-    return this.status === BlockOrder.STATUSES.ACTIVE
+    return this.isActive
   }
 
   /**

--- a/broker-daemon/models/block-order.spec.js
+++ b/broker-daemon/models/block-order.spec.js
@@ -717,6 +717,17 @@ describe('BlockOrder', () => {
       })
     })
 
+    describe('get isActive', () => {
+      it('returns true if blockOrder is active', () => {
+        expect(blockOrder).to.have.property('isActive', true)
+      })
+
+      it('returns false if order is not active', () => {
+        blockOrder.status = 'CANCELLED'
+        expect(blockOrder).to.have.property('isActive', false)
+      })
+    })
+
     describe('get isInWorkableState', () => {
       it('returns true if blockOrder is active', () => {
         expect(blockOrder).to.have.property('isInWorkableState', true)


### PR DESCRIPTION
## Description
When a user releases their channels, we should cancel all their orders on that market because the user will no longer have the funds to fulfill those orders.

## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
