### PR TITLE
FIX: table nesting for cli-table2

### DIFF
--- a/broker-cli/commands/orderbook.js
+++ b/broker-cli/commands/orderbook.js
@@ -73,8 +73,6 @@ function createUI (market, asks, bids) {
   ui.push(' ' + Array(windowWidth - 1 - rightSubSubHeader.length).join(' ') + rightSubSubHeader.underline.gray)
   ui.push('')
 
-  table.push([askTable, bidTable])
-
   // TODO: collapse orders at the same price point into a single line
 
   asks.forEach((ask) => {
@@ -90,6 +88,8 @@ function createUI (market, asks, bids) {
     let depth = String(` ${bid.amount} `)
     bidTable.push([price.green, depth.white])
   })
+
+  table.push([askTable.toString(), bidTable.toString()])
 
   ui.push(table.toString())
   console.log(ui.join('\n') + '\n')


### PR DESCRIPTION
## Description
The move to cli-table2 broke the orderbook display which uses nested Tables. This change explicitly converts the sub-tables to strings before nesting them.

## Related PRs
#402 introduced the issue.

## Todos
- [ ] Tests
