### PR TITLE
open the channels that are missing when committing

### DIFF
--- a/broker-daemon/broker-rpc/wallet-service/commit.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.js
@@ -91,16 +91,16 @@ async function commit ({ params, relayer, logger, engines, orderbooks }, { Empty
   // we are trying to open. If neither maxOutboundBalance nor maxInboundBalance exist, it means there are no channels open and we can safely
   // attempt to create channels with the balance
   if (maxOutboundBalance || maxInboundBalance) {
-    const insufficientOutboundBalance = maxOutboundBalance && Big(maxOutboundBalance).lt(balance)
-    const insufficientInboundBalance = maxInboundBalance && Big(maxInboundBalance).lt(convertedBalance)
+    const insufficientOutboundBalance = maxOutboundBalance && Big(maxOutboundBalance).plus(engine.feeEstimate).lt(balance)
+    const insufficientInboundBalance = maxInboundBalance && Big(maxInboundBalance).plus(inverseEngine.feeEstimate).lt(convertedBalance)
 
     if (insufficientOutboundBalance) {
-      logger.error('Existing outbound channel of insufficient size', { desiredBalance: balance, existingBalance: maxOutboundBalance })
+      logger.error('Existing outbound channel of insufficient size', { desiredBalance: balance, feeEstimate: engine.feeEstimate, existingBalance: maxOutboundBalance })
       throw new PublicError('You have an existing outbound channel with a balance lower than desired, release that channel and try again.')
     }
 
     if (insufficientInboundBalance) {
-      logger.error('Existing inbound channel of insufficient size', { desiredBalance: convertedBalance, existingBalance: maxInboundBalance })
+      logger.error('Existing inbound channel of insufficient size', { desiredBalance: convertedBalance, feeEstimate: inverseEngine.feeEstimate, existingBalance: maxInboundBalance })
       throw new PublicError('You have an existing inbound channel with a balance lower than desired, release that channel and try again.')
     }
   }

--- a/broker-daemon/broker-rpc/wallet-service/commit.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.js
@@ -132,7 +132,7 @@ async function commit ({ params, relayer, logger, engines, orderbooks }, { Empty
       }, authorization)
     } catch (e) {
       // TODO: Close channel that was open if relayer call has failed
-      throw (e)
+      throw new PublicError(`Error requesting inbound channel from Relayer: ${e.message}`, e)
     }
   } else {
     logger.debug('Inbound channel already exists', { balance: maxInboundBalance })

--- a/broker-daemon/broker-rpc/wallet-service/commit.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.spec.js
@@ -111,6 +111,14 @@ describe('commit', () => {
     ).to.be.rejectedWith(PublicError, 'Funding error')
   })
 
+  it('throws an error if requesting an inbound channel fails', () => {
+    createChannelRelayerStub.rejects(new Error('fake relayer error'))
+
+    expect(
+      commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })
+    ).to.be.rejectedWith(PublicError, 'Error requesting inbound channel')
+  })
+
   describe('committing a balance to the relayer', () => {
     let fakeAuth
     beforeEach(async () => {

--- a/broker-daemon/broker-rpc/wallet-service/commit.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.spec.js
@@ -30,7 +30,7 @@ describe('commit', () => {
     relayerAddress = 'qwerty@localhost'
     getAddressStub = sinon.stub().resolves({ address: paymentNetworkAddress })
     createChannelRelayerStub = sinon.stub().resolves({})
-    convertBalanceStub = sinon.stub().returns('100')
+    convertBalanceStub = sinon.stub().returns('100000')
     createChannelStub = sinon.stub()
     orderbooks = new Map([['BTC/LTC', {}]])
     logger = {
@@ -45,6 +45,7 @@ describe('commit', () => {
       createChannel: createChannelStub,
       getMaxChannel: getMaxOutboundChannelStub,
       symbol: 'BTC',
+      feeEstimate: '20000',
       quantumsPerCommon: '100000000',
       maxChannelBalance: '16777215'
     }
@@ -52,6 +53,7 @@ describe('commit', () => {
       getPaymentChannelNetworkAddress: sinon.stub().resolves(relayerAddress),
       getMaxChannel: getMaxInboundChannelStub,
       symbol: 'LTC',
+      feeEstimate: '20000',
       quantumsPerCommon: '100000000',
       maxChannelBalance: '1006632900'
     }
@@ -142,7 +144,7 @@ describe('commit', () => {
       expect(createChannelRelayerStub).to.have.been.calledOnce()
       expect(createChannelRelayerStub).to.have.been.calledWith({
         address: relayerAddress,
-        balance: '100',
+        balance: '100000',
         symbol: 'LTC'
       }, fakeAuth)
     })
@@ -182,7 +184,7 @@ describe('commit', () => {
   describe('checking channel balances', () => {
     it('does not throw if there are already open inbound and outbound channel', () => {
       getMaxOutboundChannelStub.resolves({maxBalance: '10000001'})
-      getMaxInboundChannelStub.resolves({maxBalance: '300'})
+      getMaxInboundChannelStub.resolves({maxBalance: '100000'})
 
       return expect(
         commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })
@@ -191,7 +193,7 @@ describe('commit', () => {
 
     it('opens an outbound channel if the outbound channel does not exist', async () => {
       getMaxOutboundChannelStub.resolves({})
-      getMaxInboundChannelStub.resolves({maxBalance: '300'})
+      getMaxInboundChannelStub.resolves({maxBalance: '100000'})
 
       await commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })
 
@@ -209,17 +211,17 @@ describe('commit', () => {
       expect(createChannelRelayerStub).to.have.been.calledOnce()
     })
 
-    it('throws an error if the outbound channel does not have the desired amount', () => {
+    it('throws an error if the outbound channel does not have the desired amount excluding the fee estimate', () => {
       getMaxOutboundChannelStub.resolves({maxBalance: '1000'})
-      getMaxInboundChannelStub.resolves({maxBalance: '300'})
+      getMaxInboundChannelStub.resolves({maxBalance: '100000'})
       return expect(
         commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })
       ).to.be.rejectedWith(PublicError, 'You have an existing outbound channel with a balance lower than desired, release that channel and try again.')
     })
 
-    it('throws an error if the inbound channel does not have the desired amount', () => {
+    it('throws an error if the inbound channel does not have the desired amount excluding the fee estimate', () => {
       getMaxOutboundChannelStub.resolves({maxBalance: '100000001'})
-      getMaxInboundChannelStub.resolves({maxBalance: '10'})
+      getMaxInboundChannelStub.resolves({maxBalance: '70000'})
       return expect(
         commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })
       ).to.be.rejectedWith(PublicError, 'You have an existing inbound channel with a balance lower than desired, release that channel and try again.')


### PR DESCRIPTION
## Description
This PR changes the behavior of commit to open a second channel if only one had previously been opened.

It retains the behavior of doing nothing if either of the channels is smaller than the requested size.

## Todos
- [x] Tests
