### PR TITLE
Consistent wording for Broker Registration

### DIFF
--- a/broker-cli/commands/register.js
+++ b/broker-cli/commands/register.js
@@ -6,7 +6,7 @@ require('colors')
 
 /**
  *
- * Register publicKey with the Relayer
+ * Register Broker with the Relayer
  *
  * ex: `sparkswap register`
  *
@@ -30,7 +30,7 @@ async function register (args, opts, logger) {
     })
 
     registerTable.push([''])
-    registerTable.push([{ hAlign: 'center', content: 'Successfully registered public key with the Ϟ Sparkswap Relayer!' }])
+    registerTable.push([{ hAlign: 'center', content: 'Successfully registered Broker with the Ϟ Sparkswap Relayer!' }])
     registerTable.push([''])
     registerTable.push([{ hAlign: 'center', content: `Go to ${url.cyan} to complete registration.` }])
     registerTable.push([''])
@@ -43,7 +43,7 @@ async function register (args, opts, logger) {
 
 module.exports = (program) => {
   program
-    .command('register', 'Registers the public key with the relayer')
+    .command('register', 'Registers the Broker with the relayer')
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING, validations.isHost)
     .action(register)
 }

--- a/broker-cli/commands/register.spec.js
+++ b/broker-cli/commands/register.spec.js
@@ -65,7 +65,7 @@ describe('register', () => {
 
   it('logs a table with registration information', async () => {
     await register(args, opts, logger)
-    expect(instanceTableStub.push).to.have.been.calledWith([{ hAlign: 'center', content: 'Successfully registered public key with the Ϟ Sparkswap Relayer!' }])
+    expect(instanceTableStub.push).to.have.been.calledWith([{ hAlign: 'center', content: 'Successfully registered Broker with the Ϟ Sparkswap Relayer!' }])
     expect(instanceTableStub.push).to.have.been.calledWith([{ hAlign: 'center', content: `Go to ${url.cyan} to complete registration.` }])
   })
 })

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -265,8 +265,9 @@ service AdminService {
   }
 
   /**
-   * Register takes the publicKey of users identity returns the entityId of the entity
-   * created by the Relayer and the url for the user to complete registration
+   * Register provides the Broker's identity (via Public Key) to the Relayer
+   * and returns the Relayer-assigned entityId for the Broker as well as
+   * the URL to use to complete user registration.
    *
    * ```javascript
    * const deadline = new Date().setSeconds(new Date().getSeconds() + 5)
@@ -292,7 +293,7 @@ service AdminService {
    * ```shell
    * ┌─────────────────────────────────────────────────────────────────────────────────────────┐
    * │                                                                                         │
-   * │          Successfully registered public key with the Ϟ Sparkswap Relayer!               │
+   * │          Successfully registered Broker with the Ϟ Sparkswap Relayer!                   │
    * │                                                                                         │
    * │ Go to https://sparkswap.com/register/BAfwIYxkUqHJ3pLLh60AAQj3 to complete registration. │
    * │                                                                                         │

--- a/broker-daemon/broker-rpc/admin-service/register.js
+++ b/broker-daemon/broker-rpc/admin-service/register.js
@@ -1,5 +1,5 @@
 /**
- * Sparkswap url for registering a user
+ * Sparkswap url for completing registration
  * @constant
  * @default
  * @type {String}
@@ -22,7 +22,7 @@ async function register ({ relayer, logger }, { RegisterResponse }) {
   // Currently we don't do anything with this entityId but we will need it in the future
   const { entityId } = await relayer.adminService.register({ publicKey })
 
-  logger.info('Successfully registered public key with relayer', { entityId })
+  logger.info('Successfully registered Broker with relayer', { entityId })
   const url = `${REGISTER_URL}${entityId}`
   return new RegisterResponse({ entityId, url })
 }

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -265,8 +265,9 @@ service AdminService {
   }
 
   /**
-   * Register takes the publicKey of users identity returns the entityId of the entity
-   * created by the Relayer and the url for the user to complete registration
+   * Register provides the Broker's identity (via Public Key) to the Relayer
+   * and returns the Relayer-assigned entityId for the Broker as well as
+   * the URL to use to complete user registration.
    *
    * ```javascript
    * const deadline = new Date().setSeconds(new Date().getSeconds() + 5)
@@ -292,7 +293,7 @@ service AdminService {
    * ```shell
    * ┌─────────────────────────────────────────────────────────────────────────────────────────┐
    * │                                                                                         │
-   * │          Successfully registered public key with the Ϟ Sparkswap Relayer!               │
+   * │          Successfully registered Broker with the Ϟ Sparkswap Relayer!                   │
    * │                                                                                         │
    * │ Go to https://sparkswap.com/register/BAfwIYxkUqHJ3pLLh60AAQj3 to complete registration. │
    * │                                                                                         │


### PR DESCRIPTION
## Description
This change unifies the wording we use for Broker registration, removing references to public keys and identities in favor of more plain language about the Broker.