### PR TITLE
Fix/regtest local

### DIFF
--- a/.env-regtest-local-sample
+++ b/.env-regtest-local-sample
@@ -32,6 +32,9 @@ BTC_RPC_PASS=sparkswapbtc
 # Transaction Broadcast Address
 # BTC_ZMQPUBRAWTX=your.bitcoin.node.transaction.address
 
+# Regtest Host
+BITCOIND_CONNECT_HOST=host.docker.internal
+
 # Litecoin Settings
 #
 # We have provided default username/passwords for all active engines (ltc, btc)
@@ -47,6 +50,9 @@ LTC_RPC_PASS=sparkswapltc
 
 # Transaction Broadcast Address
 # LTC_ZMQPUBRAWTX=your.litecoin.node.transaction.address
+
+# Regtest Host
+LITECOIND_CONNECT_HOST=host.docker.internal
 
 # External IP Addresses
 #

--- a/.env-regtest-local-sample
+++ b/.env-regtest-local-sample
@@ -69,4 +69,4 @@ SECURE_PATH=~/.sparkswap/secure
 # be applied and used
 #
 COMPOSE_PATH_SEPARATOR=:
-COMPOSE_FILE=docker-compose.yml:docker-compose.bitcoind.yml:docker-compose.litecoind.yml:docker-compose.override.yml
+COMPOSE_FILE=docker-compose.yml:docker-compose.bitcoind.yml:docker-compose.litecoind.yml:docker-compose.regtest.yml:docker-compose.local.yml

--- a/.env-regtest-local-sample
+++ b/.env-regtest-local-sample
@@ -1,5 +1,5 @@
 ###############################################################
-# TestNet Sparkswap Environment File
+# Sparkswap Environment File
 #
 # These settings control the underlying functionality of sparkswapd and the
 # associated lightning implementations (engines).
@@ -7,14 +7,14 @@
 ###############################################################
 
 # Set the network that sparkswap and engines will work on.
-NETWORK=testnet
+NETWORK=regtest
 
 # Set secure credentials for your sparkswap daemon
 RPC_USER=sparkswap
 RPC_PASS=sparkswap
 
-# Relayer Host Addresses for TestNet
-RELAYER_RPC_HOST=relayer.testnet.sparkswap.com:28492
+# Relayer Host Addresses for RegTest
+RELAYER_RPC_HOST=host.docker.internal:28492
 
 # Bitcoin Settings
 #
@@ -57,8 +57,8 @@ LTC_RPC_PASS=sparkswapltc
 # This address can either be a TLD or an IP address. Do NOT include the port number
 # as this is defined in the docker-compose file instead.
 #
-EXTERNAL_BTC_ADDRESS=sample.ip.address
-EXTERNAL_LTC_ADDRESS=sample.ip.address
+EXTERNAL_BTC_ADDRESS=host.docker.internal
+EXTERNAL_LTC_ADDRESS=host.docker.internal
 
 # Path to rpc certs and identity keys
 SECURE_PATH=~/.sparkswap/secure
@@ -69,4 +69,4 @@ SECURE_PATH=~/.sparkswap/secure
 # be applied and used
 #
 COMPOSE_PATH_SEPARATOR=:
-COMPOSE_FILE=docker-compose.yml:docker-compose.bitcoind.yml:docker-compose.litecoind.yml
+COMPOSE_FILE=docker-compose.yml:docker-compose.bitcoind.yml:docker-compose.litecoind.yml:docker-compose.override.yml

--- a/.env-regtest-sample
+++ b/.env-regtest-sample
@@ -14,8 +14,7 @@ RPC_USER=sparkswap
 RPC_PASS=sparkswap
 
 # Relayer Host Addresses for RegTest
-RELAYER_RPC_HOST=host.docker.internal:28492
-RELAYER_CERT_HOST=host.docker.internal:8080
+RELAYER_RPC_HOST=relayer.regtest.sparkswap.com:28492
 
 # Bitcoin Settings
 #

--- a/.env-regtest-sample
+++ b/.env-regtest-sample
@@ -69,4 +69,4 @@ SECURE_PATH=~/.sparkswap/secure
 # be applied and used
 #
 COMPOSE_PATH_SEPARATOR=:
-COMPOSE_FILE=docker-compose.yml:docker-compose.bitcoind.yml:docker-compose.litecoind.yml:docker-compose.override.yml
+COMPOSE_FILE=docker-compose.yml:docker-compose.bitcoind.yml:docker-compose.litecoind.yml:docker-compose.regtest.yml

--- a/.env-regtest-sample
+++ b/.env-regtest-sample
@@ -32,6 +32,9 @@ BTC_RPC_PASS=sparkswapbtc
 # Transaction Broadcast Address
 # BTC_ZMQPUBRAWTX=your.bitcoin.node.transaction.address
 
+# Regtest Host
+BITCOIND_CONNECT_HOST=relayer.regtest.sparkswap.com
+
 # Litecoin Settings
 #
 # We have provided default username/passwords for all active engines (ltc, btc)
@@ -47,6 +50,9 @@ LTC_RPC_PASS=sparkswapltc
 
 # Transaction Broadcast Address
 # LTC_ZMQPUBRAWTX=your.litecoin.node.transaction.address
+
+# Regtest Host
+LITECOIND_CONNECT_HOST=relayer.regtest.sparkswap.com
 
 # External IP Addresses
 #

--- a/broker-cli/package-lock.json
+++ b/broker-cli/package-lock.json
@@ -2391,6 +2391,7 @@
           "resolved": false,
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -3724,7 +3725,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/broker-daemon/config.json
+++ b/broker-daemon/config.json
@@ -9,7 +9,7 @@
   "supportedEngineTypes": ["LND"],
   "relayer": {
     "rpcHost": "host.docker.internal:28492",
-    "certPath": "/secure/relayer-root.pem"
+    "certPath": "/secure/relayer-root-regtest-local.pem"
   },
   "rpc": {
     "address": "0.0.0.0:27492",

--- a/broker-daemon/relayer/relayer-client.js
+++ b/broker-daemon/relayer/relayer-client.js
@@ -54,6 +54,7 @@ class RelayerClient {
     let channelCredentials = credentials.createSsl()
 
     if (!PRODUCTION) {
+      logger.info('Using local certs for relayer client', { production: PRODUCTION })
       channelCredentials = credentials.createSsl(readFileSync(certPath))
     }
 

--- a/broker-daemon/relayer/relayer-client.js
+++ b/broker-daemon/relayer/relayer-client.js
@@ -13,10 +13,17 @@ consoleLogger.debug = console.log.bind(console)
 
 /**
  * @constant
- * @type {String}
+ * @type {string}
  * @default
  */
 const RELAYER_PROTO_PATH = './proto/relayer.proto'
+
+/**
+ * @constant
+ * @type {string}
+ * @default
+ */
+const PRODUCTION = process.env.NODE_ENV === 'production'
 
 /**
  * Interface for daemon to interact with a SparkSwap Relayer
@@ -46,7 +53,7 @@ class RelayerClient {
 
     let channelCredentials = credentials.createSsl()
 
-    if (process.env.NODE_ENV === 'development') {
+    if (!PRODUCTION) {
       channelCredentials = credentials.createSsl(readFileSync(certPath))
     }
 

--- a/broker-daemon/relayer/relayer-client.js
+++ b/broker-daemon/relayer/relayer-client.js
@@ -43,11 +43,10 @@ class RelayerClient {
     this.proto = loadProto(path.resolve(RELAYER_PROTO_PATH))
 
     this.identity = Identity.load(privKeyPath, pubKeyPath)
-    let channelCredentials
-    // TODO figure out a way for this check to not be in the application code
-    if (process.env.NETWORK === 'mainnet') {
-      channelCredentials = credentials.createSsl()
-    } else {
+
+    let channelCredentials = credentials.createSsl()
+
+    if (process.env.NODE_ENV === 'development') {
       channelCredentials = credentials.createSsl(readFileSync(certPath))
     }
 

--- a/broker-daemon/relayer/relayer-client.spec.js
+++ b/broker-daemon/relayer/relayer-client.spec.js
@@ -131,18 +131,28 @@ describe('RelayerClient', () => {
       expect(relayer).to.have.property('identity', fakeId)
     })
 
-    it('creates ssl credentials', () => {
+    it('creates ssl credentials with local file if in development', () => {
       const fakePath = '/path/to/root.pem'
       const fakeCert = 'fakeydo'
       readFileSync.returns(fakeCert)
+
+      RelayerClient.__set__('PRODUCTION', false)
 
       // eslint-disable-next-line
       new RelayerClient(idKeyPath, { host: relayerHost, certPath: fakePath }, logger)
 
       expect(readFileSync).to.have.been.calledOnce()
       expect(readFileSync).to.have.been.calledWith(fakePath)
-      expect(createSslStub).to.have.been.calledOnce()
       expect(createSslStub).to.have.been.calledWith(fakeCert)
+    })
+
+    it('creates ssl credentials', () => {
+      RelayerClient.__set__('PRODUCTION', true)
+
+      // eslint-disable-next-line
+      new RelayerClient(idKeyPath, { host: relayerHost }, logger)
+
+      expect(createSslStub).to.have.been.calledOnce()
     })
 
     it('sets ssl credentials for the services', () => {

--- a/broker-daemon/utils/logger.js
+++ b/broker-daemon/utils/logger.js
@@ -61,16 +61,14 @@ function createLogger () {
     handleExceptions: true
   })
 
-  if (process.env.NODE_ENV !== 'production') {
-    logger.add(new winston.transports.Console({
-      format: winston.format.combine(
-        filterSensitive(),
-        winston.format.timestamp(),
-        winston.format.colorize(),
-        winston.format.simple()
-      )
-    }))
-  }
+  logger.add(new winston.transports.Console({
+    format: winston.format.combine(
+      filterSensitive(),
+      winston.format.timestamp(),
+      winston.format.colorize(),
+      winston.format.simple()
+    )
+  }))
 
   return logger
 }

--- a/docker-compose.bitcoind.yml
+++ b/docker-compose.bitcoind.yml
@@ -3,9 +3,6 @@
 # sparkswap Broker-CLI and Broker-Daemon
 # https://sparkswap.com
 #
-# The broker and engines currently default to TestNet. To adjust settings, please
-# look at the associated `.env` files
-#
 # Troubleshooting GRPC:
 # - GRPC_VERBOSITY=INFO
 # - GRPC_TRACE=all
@@ -24,7 +21,7 @@ services:
       - ZMQPUBRAWTX=tcp://bitcoind:28334
 
   bitcoind:
-    image: sparkswap/bitcoind:0.3.5-beta
+    image: sparkswap/bitcoind:0.3.6-beta
     volumes:
       - shared:/shared
       - bitcoin:/data

--- a/docker-compose.litecoind.yml
+++ b/docker-compose.litecoind.yml
@@ -1,10 +1,7 @@
 ##########################################
 #
-# sparkswap Broker-CLI and Broker-Daemon
+# Sparkswap Broker-CLI and Broker-Daemon
 # https://sparkswap.com
-#
-# The broker and engines currently default to TestNet. To adjust settings, please
-# look at the associated `.env` files
 #
 # Troubleshooting GRPC:
 # - GRPC_VERBOSITY=INFO
@@ -24,7 +21,7 @@ services:
       - ZMQPUBRAWTX=tcp://litecoind:28334
 
   litecoind:
-    image: sparkswap/litecoind:0.3.5-beta
+    image: sparkswap/litecoind:0.3.6-beta
     volumes:
       - shared:/shared
       - litecoin:/data

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -15,15 +15,7 @@ services:
       - './:/home/app/'
       - '/home/app/node_modules'
       - '/home/app/broker-cli/node_modules'
+    # environment:
+    #   - NODE_ENV=development
     # We use this to be able to have "hot reloading" with our application
     entrypoint: bash -c 'npm run start-sparkswapd-watch'
-
-  bitcoind:
-    environment:
-      - CONNECT_HOST=host.docker.internal
-      - CONNECT_PORT=18666
-
-  litecoind:
-    environment:
-      - CONNECT_HOST=host.docker.internal
-      - CONNECT_PORT=19666

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,10 +1,6 @@
 ##########################################
-# Sparkswap Broker Daemon Regtest development sample file
+# Sparkswap Broker Daemon Local RegTest Development
 # https://sparkswap.com
-#
-# Usage:
-# 1. copy file to `docker-compose.override.yml`
-# 2. restart all containers with `docker-compose up -d`
 ##########################################
 
 version: '2.4'
@@ -15,7 +11,7 @@ services:
       - './:/home/app/'
       - '/home/app/node_modules'
       - '/home/app/broker-cli/node_modules'
-    # environment:
-    #   - NODE_ENV=development
+    environment:
+      - NODE_ENV=development
     # We use this to be able to have "hot reloading" with our application
     entrypoint: bash -c 'npm run start-sparkswapd-watch'

--- a/docker-compose.regtest.yml
+++ b/docker-compose.regtest.yml
@@ -1,0 +1,21 @@
+##########################################
+# Sparkswap Broker Daemon Regtest development sample file
+# https://sparkswap.com
+#
+# Usage:
+# 1. copy file to `docker-compose.override.yml`
+# 2. restart all containers with `docker-compose up -d`
+##########################################
+
+version: '2.4'
+
+services:
+  bitcoind:
+    environment:
+      - CONNECT_HOST=host.docker.internal
+      - CONNECT_PORT=18666
+
+  litecoind:
+    environment:
+      - CONNECT_HOST=host.docker.internal
+      - CONNECT_PORT=19666

--- a/docker-compose.regtest.yml
+++ b/docker-compose.regtest.yml
@@ -1,10 +1,6 @@
 ##########################################
-# Sparkswap Broker Daemon Regtest development sample file
+# Sparkswap Broker Daemon Regtest
 # https://sparkswap.com
-#
-# Usage:
-# 1. copy file to `docker-compose.override.yml`
-# 2. restart all containers with `docker-compose up -d`
 ##########################################
 
 version: '2.4'
@@ -12,10 +8,10 @@ version: '2.4'
 services:
   bitcoind:
     environment:
-      - CONNECT_HOST=host.docker.internal
+      - CONNECT_HOST=${BITCOIND_CONNECT_HOST}
       - CONNECT_PORT=18666
 
   litecoind:
     environment:
-      - CONNECT_HOST=host.docker.internal
+      - CONNECT_HOST=${LITECOIND_CONNECT_HOST}
       - CONNECT_PORT=19666

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,6 @@ services:
       - ID_PRIV_KEY=${ID_PRIV_KEY:-}
       - ID_PUB_KEY=${ID_PUB_KEY:-}
       - RELAYER_RPC_HOST=${RELAYER_RPC_HOST}
-      - RELAYER_CERT_HOST=${RELAYER_CERT_HOST:-}
       - RELAYER_CERT_PATH=${RELAYER_CERT_PATH:-}
     ports:
       - '27492:27492'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,7 @@
 ##########################################
 #
-# sparkswap Broker-CLI and Broker-Daemon
+# Sparkswap Broker-CLI and Broker-Daemon
 # https://sparkswap.com
-#
-# The broker and engines currently default to TestNet. To adjust settings, please
-# look at the associated `.env` files
 #
 # Troubleshooting GRPC:
 # - GRPC_VERBOSITY=INFO
@@ -27,7 +24,6 @@ services:
       - 'shared:/shared'
       # Persistent certs/keys for broker
       - '${SECURE_PATH}:/secure'
-
     environment:
       - NODE_ENV=production
       - DATA_DIR=${DATA_DIR:-}
@@ -50,7 +46,7 @@ services:
     working_dir: '/home/app'
 
   lnd_btc:
-    image: sparkswap/lnd_btc:0.3.5-beta
+    image: sparkswap/lnd_btc:0.3.6-beta
     ports:
       - '10113:9735'
     environment:
@@ -73,7 +69,7 @@ services:
         max-size: 50m
 
   lnd_ltc:
-    image: sparkswap/lnd_ltc:0.3.5-beta
+    image: sparkswap/lnd_ltc:0.3.6-beta
     ports:
       - '10114:9735'
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - '${SECURE_PATH}:/secure'
 
     environment:
+      - NODE_ENV=production
       - DATA_DIR=${DATA_DIR:-}
       - NETWORK=${NETWORK}
       - RPC_ADDRESS=${RPC_ADDRESS:-}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "bash ./scripts/build.sh",
+    "build-local": "npm run build -- --local",
     "destroy": "bash ./scripts/destroy.sh",
     "dist-cli": "npm run broker-proto && bash ./scripts/publish-broker-cli.sh",
     "format": "npm run lint -- --fix",

--- a/pm2.json
+++ b/pm2.json
@@ -13,8 +13,5 @@
   "watch": [
     "broker-daemon",
     "proto"
-  ],
-  "env": {
-    "NODE_ENV": "development"
-  }
+  ]
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -177,7 +177,7 @@ if [ "$LOCAL" == "true" ]; then
   echo "Downloading Local Relayer Cert..."
   # the path of this output is directly related to the SECURE_PATH that is set
   # in the .env file
-  curl --silent -S --output ~/.sparkswap/secure/relayer-root.pem http://localhost:8080/cert
+  curl --silent -S --output ~/.sparkswap/secure/relayer-root-regtest-local.pem http://localhost:8080/cert
   echo "Relayer cert downloaded successfully"
 fi
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -41,6 +41,7 @@ NO_DOCKER="false"
 NO_CERTS="false"
 NO_IDENTITY="false"
 EXTERNAL_ADDRESS="localhost"
+LOCAL="false"
 for i in "$@"
 do
 case $i in
@@ -62,6 +63,10 @@ case $i in
     ;;
     -n|--no-certs)
     NO_CERTS="true"
+
+    ;;
+    -l|--local)
+    LOCAL="true"
 
     ;;
     *)
@@ -167,3 +172,12 @@ if [ -f docker-compose.override.yml ]; then
   echo "WARNING: This may add unwanted settings to the broker that could affect how your daemon runs."
   echo ""
 fi
+
+if [ "$LOCAL" == "true" ]; then
+  echo "Downloading Local Relayer Cert..."
+  # the path of this output is directly related to the SECURE_PATH that is set
+  # in the .env file
+  curl --silent -S --output ~/.sparkswap/secure/relayer-root.pem http://localhost:8080/cert
+  echo "Relayer cert downloaded successfully"
+fi
+

--- a/scripts/start-sparkswapd.sh
+++ b/scripts/start-sparkswapd.sh
@@ -22,14 +22,6 @@ ID_PUB_KEY=${ID_PUB_KEY:-""}
 RELAYER_RPC_HOST=${RELAYER_RPC_HOST:-""}
 RELAYER_CERT_PATH=${RELAYER_CERT_PATH:-""}
 
-if [ "$NETWORK" == "mainnet" ]; then
-  echo "Using GRPC default certs"
-else
-  echo "Downloading Relayer cert..."
-  curl --silent -S --output /secure/relayer-root.pem "${RELAYER_CERT_HOST}/cert" || exit 1
-  echo "Relayer cert downloaded successfully"
-fi
-
 # For each parameter, we must check if the string is blank, because docker-compose
 # will automatically assign a blank string to the value and CLI validations will fail
 PARAMS=""


### PR DESCRIPTION
## Description
This PR refactors some of the regtest work on the broker to allow for an `npm run build-local` command for local dev only.

TLS certificates from the Relayer now use Lets Encrypt (supported by grpc) instead of a dedicated cert server. This dedicated cert server is only available on local setups.

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
