### PR TITLE
Remove public errors

### DIFF
--- a/broker-daemon/broker-rpc/order-service/cancel-block-order.js
+++ b/broker-daemon/broker-rpc/order-service/cancel-block-order.js
@@ -1,7 +1,3 @@
-const { PublicError } = require('grpc-methods')
-
-const { BlockOrderNotFoundError } = require('../../models/errors')
-
 /**
  * Cancels a block order in progress
  *
@@ -16,17 +12,9 @@ async function cancelBlockOrder ({ params, logger, blockOrderWorker }) {
     blockOrderId
   } = params
 
-  try {
-    await blockOrderWorker.cancelBlockOrder(blockOrderId)
+  await blockOrderWorker.cancelBlockOrder(blockOrderId)
 
-    return {}
-  } catch (err) {
-    if (err instanceof BlockOrderNotFoundError) {
-      throw new PublicError(err.message, err)
-    }
-
-    throw err
-  }
+  return {}
 }
 
 module.exports = cancelBlockOrder

--- a/broker-daemon/broker-rpc/order-service/cancel-block-order.spec.js
+++ b/broker-daemon/broker-rpc/order-service/cancel-block-order.spec.js
@@ -6,13 +6,10 @@ const { BlockOrderNotFoundError } = require('../../models/errors')
 const cancelBlockOrder = rewire(path.resolve(__dirname, 'cancel-block-order'))
 
 describe('cancelBlockOrder', () => {
-  let PublicError
   let blockOrderWorker
   let blockOrder
 
   beforeEach(() => {
-    PublicError = cancelBlockOrder.__get__('PublicError')
-
     blockOrder = {
       serialize: sinon.stub()
     }
@@ -21,18 +18,8 @@ describe('cancelBlockOrder', () => {
     }
   })
 
-  it('throws a Public Error if the block order is not found', () => {
+  it('throws an error if the block order is not found', () => {
     blockOrderWorker.cancelBlockOrder.rejects(new BlockOrderNotFoundError('fakeID', new Error('fake error')))
-
-    const params = {
-      blockOrderId: 'fakeID'
-    }
-
-    return expect(cancelBlockOrder({ params, blockOrderWorker })).to.eventually.be.rejectedWith(PublicError)
-  })
-
-  it('throws a non-public error if another error is encountered', () => {
-    blockOrderWorker.cancelBlockOrder.rejects()
 
     const params = {
       blockOrderId: 'fakeID'

--- a/broker-daemon/broker-rpc/order-service/create-block-order.js
+++ b/broker-daemon/broker-rpc/order-service/create-block-order.js
@@ -1,5 +1,3 @@
-const { PublicError } = require('grpc-methods')
-
 /**
  * Creates an order with the relayer
  *
@@ -22,7 +20,7 @@ async function createBlockOrder ({ params, blockOrderWorker }, { CreateBlockOrde
   } = params
 
   if (TimeInForce[timeInForce] !== TimeInForce.GTC) {
-    throw new PublicError('Only Good-til-cancelled orders are currently supported')
+    throw new Error('Only Good-til-cancelled orders are currently supported')
   }
 
   const blockOrderId = await blockOrderWorker.createBlockOrder({

--- a/broker-daemon/broker-rpc/order-service/create-block-order.spec.js
+++ b/broker-daemon/broker-rpc/order-service/create-block-order.spec.js
@@ -4,7 +4,6 @@ const { expect, rewire, sinon } = require('test/test-helper')
 const createBlockOrder = rewire(path.resolve(__dirname, 'create-block-order'))
 
 describe('createBlockOrder', () => {
-  let PublicError
   let CreateBlockOrderResponse
   let blockOrderWorker
   let TimeInForce
@@ -12,8 +11,6 @@ describe('createBlockOrder', () => {
   let revert
 
   beforeEach(() => {
-    PublicError = createBlockOrder.__get__('PublicError')
-
     CreateBlockOrderResponse = sinon.stub()
     TimeInForce = {
       GTC: 1
@@ -47,7 +44,7 @@ describe('createBlockOrder', () => {
       limitPrice: '1000.678',
       timeInForce: 'FOK'
     }
-    return expect(createBlockOrder({ params, blockOrderWorker }, { CreateBlockOrderResponse, TimeInForce })).to.be.rejectedWith(PublicError)
+    return expect(createBlockOrder({ params, blockOrderWorker }, { CreateBlockOrderResponse, TimeInForce })).to.be.rejectedWith('Only Good-til-cancelled orders are currently supported')
   })
 
   it('creates a block order on the BlockOrderWorker', async () => {

--- a/broker-daemon/broker-rpc/order-service/get-block-order.js
+++ b/broker-daemon/broker-rpc/order-service/get-block-order.js
@@ -1,7 +1,3 @@
-const { PublicError } = require('grpc-methods')
-
-const { BlockOrderNotFoundError } = require('../../models/errors')
-
 /**
  * Check on the status of a block order
  *
@@ -18,20 +14,12 @@ async function getBlockOrder ({ params, logger, blockOrderWorker }, { GetBlockOr
     blockOrderId
   } = params
 
-  try {
-    const blockOrder = await blockOrderWorker.getBlockOrder(blockOrderId)
+  const blockOrder = await blockOrderWorker.getBlockOrder(blockOrderId)
 
-    // the grpc response constructor does not properly serialize oneof fields, and tries to send both
-    // when sending the limitPrice, it sends it as an object to encode the in64, which fails on the wire
-    // so instead, we use a plain object
-    return blockOrder.serialize()
-  } catch (err) {
-    if (err instanceof BlockOrderNotFoundError) {
-      throw new PublicError(err.message, err)
-    }
-
-    throw err
-  }
+  // the grpc response constructor does not properly serialize oneof fields, and tries to send both
+  // when sending the limitPrice, it sends it as an object to encode the in64, which fails on the wire
+  // so instead, we use a plain object
+  return blockOrder.serialize()
 }
 
 module.exports = getBlockOrder

--- a/broker-daemon/broker-rpc/order-service/get-block-order.spec.js
+++ b/broker-daemon/broker-rpc/order-service/get-block-order.spec.js
@@ -6,14 +6,11 @@ const { BlockOrderNotFoundError } = require('../../models/errors')
 const getBlockOrder = rewire(path.resolve(__dirname, 'get-block-order'))
 
 describe('getBlockOrder', () => {
-  let PublicError
   let GetBlockOrderResponse
   let blockOrderWorker
   let blockOrder
 
   beforeEach(() => {
-    PublicError = getBlockOrder.__get__('PublicError')
-
     GetBlockOrderResponse = sinon.stub()
 
     blockOrder = {
@@ -24,24 +21,14 @@ describe('getBlockOrder', () => {
     }
   })
 
-  it('throws a Public Error if the block order is not found', () => {
+  it('throws an Error if the block order is not found', () => {
     blockOrderWorker.getBlockOrder.rejects(new BlockOrderNotFoundError('fakeID', new Error('fake error')))
 
     const params = {
       blockOrderId: 'fakeID'
     }
 
-    return expect(getBlockOrder({ params, blockOrderWorker }, { GetBlockOrderResponse })).to.eventually.be.rejectedWith(PublicError)
-  })
-
-  it('throws a non-public error if another error is encountered', () => {
-    blockOrderWorker.getBlockOrder.rejects()
-
-    const params = {
-      blockOrderId: 'fakeID'
-    }
-
-    return expect(getBlockOrder({ params, blockOrderWorker }, { GetBlockOrderResponse })).to.eventually.be.rejectedWith(Error)
+    return expect(getBlockOrder({ params, blockOrderWorker }, { GetBlockOrderResponse })).to.eventually.be.rejectedWith(Error, 'Block Order with ID fakeID was not found.')
   })
 
   it('retrieves the block order by id', async () => {

--- a/broker-daemon/broker-rpc/orderbook-service/get-market-stats.js
+++ b/broker-daemon/broker-rpc/orderbook-service/get-market-stats.js
@@ -1,5 +1,4 @@
 const nano = require('nano-seconds')
-const { PublicError } = require('grpc-methods')
 
 const { BlockOrder, MarketEvent } = require('../../models')
 const { Big } = require('../../utils')
@@ -27,7 +26,7 @@ async function getMarketStats ({ params, logger, orderbooks }, { GetMarketStatsR
   const { market } = params
   const orderbook = orderbooks.get(market)
 
-  if (!orderbook) throw new PublicError(`${market} is not being tracked as a market.`)
+  if (!orderbook) throw new Error(`${market} is not being tracked as a market.`)
 
   logger.debug(`Checking currency configurations for: ${market}`)
 

--- a/broker-daemon/broker-rpc/wallet-service/commit.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.js
@@ -1,5 +1,3 @@
-const { PublicError } = require('grpc-methods')
-
 const { convertBalance, Big } = require('../../utils')
 
 /**
@@ -41,12 +39,12 @@ async function commit ({ params, relayer, logger, engines, orderbooks }, { Empty
 
   if (!engine) {
     logger.error(`Could not find engine: ${symbol}`)
-    throw new PublicError(`No engine is configured for symbol: ${symbol}`)
+    throw new Error(`No engine is configured for symbol: ${symbol}`)
   }
 
   if (!inverseEngine) {
     logger.error(`Could not find inverse engine: ${inverseSymbol}`)
-    throw new PublicError(`No engine is configured for symbol: ${inverseSymbol}`)
+    throw new Error(`No engine is configured for symbol: ${inverseSymbol}`)
   }
 
   const maxChannelBalance = Big(engine.maxChannelBalance)
@@ -61,11 +59,11 @@ async function commit ({ params, relayer, logger, engines, orderbooks }, { Empty
   // friendly errors to the user.
   // TODO: Get correct fee amount from engine
   if (MINIMUM_FUNDING_AMOUNT.gt(balanceCommon)) {
-    throw new PublicError(`Minimum balance of ${MINIMUM_FUNDING_AMOUNT} needed to commit to the relayer`)
+    throw new Error(`Minimum balance of ${MINIMUM_FUNDING_AMOUNT} needed to commit to the relayer`)
   } else if (maxChannelBalance.lt(balance)) {
     const maxChannelBalanceCommon = Big(maxChannelBalance).div(engine.quantumsPerCommon).toString()
     logger.error(`Balance from the client exceeds maximum balance allowed (${maxChannelBalance.toString()}).`, { balance })
-    throw new PublicError(`Maximum balance of ${maxChannelBalanceCommon} ${symbol} exceeded for ` +
+    throw new Error(`Maximum balance of ${maxChannelBalanceCommon} ${symbol} exceeded for ` +
       `committing of ${balanceCommon} ${symbol} to the Relayer. Please try again.`)
   }
 
@@ -78,7 +76,7 @@ async function commit ({ params, relayer, logger, engines, orderbooks }, { Empty
     const convertedBalanceCommon = Big(convertedBalance).div(inverseEngine.quantumsPerCommon).toString()
     const convertedMaxChannelBalanceCommon = Big(convertedMaxChannelBalance).div(inverseEngine.quantumsPerCommon).toString()
     logger.error(`Balance in desired inbound channel exceeds maximum balance allowed (${convertedMaxChannelBalance.toString()}).`, { convertedBalance })
-    throw new PublicError(`Maximum balance of ${convertedMaxChannelBalanceCommon} ${inverseSymbol} exceeded for ` +
+    throw new Error(`Maximum balance of ${convertedMaxChannelBalanceCommon} ${inverseSymbol} exceeded for ` +
       `requesting inbound channel of ${convertedBalanceCommon} ${inverseSymbol} from the Relayer. Please try again.`)
   }
 
@@ -96,12 +94,12 @@ async function commit ({ params, relayer, logger, engines, orderbooks }, { Empty
 
     if (insufficientOutboundBalance) {
       logger.error('Existing outbound channel of insufficient size', { desiredBalance: balance, feeEstimate: engine.feeEstimate, existingBalance: maxOutboundBalance })
-      throw new PublicError('You have an existing outbound channel with a balance lower than desired, release that channel and try again.')
+      throw new Error('You have an existing outbound channel with a balance lower than desired, release that channel and try again.')
     }
 
     if (insufficientInboundBalance) {
       logger.error('Existing inbound channel of insufficient size', { desiredBalance: convertedBalance, feeEstimate: inverseEngine.feeEstimate, existingBalance: maxInboundBalance })
-      throw new PublicError('You have an existing inbound channel with a balance lower than desired, release that channel and try again.')
+      throw new Error('You have an existing inbound channel with a balance lower than desired, release that channel and try again.')
     }
   }
 
@@ -112,7 +110,7 @@ async function commit ({ params, relayer, logger, engines, orderbooks }, { Empty
       await engine.createChannel(address, balance)
     } catch (e) {
       logger.error('Received error when creating outbound channel', { error: e.stack })
-      throw new PublicError(`Funding error: ${e.message}`)
+      throw new Error(`Funding error: ${e.message}`)
     }
   } else {
     logger.debug('Outbound channel already exists', { balance: maxOutboundBalance })
@@ -132,7 +130,7 @@ async function commit ({ params, relayer, logger, engines, orderbooks }, { Empty
       }, authorization)
     } catch (e) {
       // TODO: Close channel that was open if relayer call has failed
-      throw new PublicError(`Error requesting inbound channel from Relayer: ${e.message}`, e)
+      throw new Error(`Error requesting inbound channel from Relayer: ${e.message}`)
     }
   } else {
     logger.debug('Inbound channel already exists', { balance: maxInboundBalance })

--- a/broker-daemon/broker-rpc/wallet-service/commit.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.spec.js
@@ -1,6 +1,5 @@
 const path = require('path')
 const { expect, rewire, sinon } = require('test/test-helper')
-const { PublicError } = require('grpc-methods')
 const { Big } = require('../../utils')
 
 const commit = rewire(path.resolve(__dirname, 'commit'))
@@ -83,7 +82,7 @@ describe('commit', () => {
     params.balance = '0.00000100'
     return expect(
       commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })
-    ).to.be.rejectedWith(PublicError, 'Minimum balance of')
+    ).to.be.rejectedWith(Error, 'Minimum balance of')
   })
 
   it('balance over allowed maximum value throws an error for an incorrect balance', () => {
@@ -91,7 +90,7 @@ describe('commit', () => {
     params.balance = maxBalance + 1
     return expect(
       commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })
-    ).to.be.rejectedWith(PublicError, 'Maximum balance')
+    ).to.be.rejectedWith(Error, 'Maximum balance')
   })
 
   it('throws an error if the inbound channel exceeds the maximum value', () => {
@@ -100,7 +99,7 @@ describe('commit', () => {
     params.balance = btcEngine.maxChannelBalance - 1
     return expect(
       commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })
-    ).to.be.rejectedWith(PublicError, 'Maximum balance')
+    ).to.be.rejectedWith(Error, 'Maximum balance')
   })
 
   it('throws an error if creating a channel fails', () => {
@@ -108,7 +107,7 @@ describe('commit', () => {
 
     expect(
       commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })
-    ).to.be.rejectedWith(PublicError, 'Funding error')
+    ).to.be.rejectedWith(Error, 'Funding error')
   })
 
   it('throws an error if requesting an inbound channel fails', () => {
@@ -116,7 +115,7 @@ describe('commit', () => {
 
     expect(
       commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })
-    ).to.be.rejectedWith(PublicError, 'Error requesting inbound channel')
+    ).to.be.rejectedWith(Error, 'Error requesting inbound channel')
   })
 
   describe('committing a balance to the relayer', () => {
@@ -185,7 +184,7 @@ describe('commit', () => {
       const badEngines = new Map([['BTC', btcEngine]])
       return expect(
         commit({ params, relayer, logger, engines: badEngines, orderbooks }, { EmptyResponse })
-      ).to.be.rejectedWith(PublicError, 'No engine is configured for symbol')
+      ).to.be.rejectedWith(Error, 'No engine is configured for symbol')
     })
   })
 
@@ -224,7 +223,7 @@ describe('commit', () => {
       getMaxInboundChannelStub.resolves({ maxBalance: '100000' })
       return expect(
         commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })
-      ).to.be.rejectedWith(PublicError, 'You have an existing outbound channel with a balance lower than desired, release that channel and try again.')
+      ).to.be.rejectedWith(Error, 'You have an existing outbound channel with a balance lower than desired, release that channel and try again.')
     })
 
     it('throws an error if the inbound channel does not have the desired amount excluding the fee estimate', () => {
@@ -232,7 +231,7 @@ describe('commit', () => {
       getMaxInboundChannelStub.resolves({ maxBalance: '70000' })
       return expect(
         commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })
-      ).to.be.rejectedWith(PublicError, 'You have an existing inbound channel with a balance lower than desired, release that channel and try again.')
+      ).to.be.rejectedWith(Error, 'You have an existing inbound channel with a balance lower than desired, release that channel and try again.')
     })
   })
 })

--- a/broker-daemon/broker-rpc/wallet-service/create-wallet.js
+++ b/broker-daemon/broker-rpc/wallet-service/create-wallet.js
@@ -1,5 +1,3 @@
-const { PublicError } = require('grpc-methods')
-
 /**
  * Creates a new wallet for a specific engine
  *
@@ -19,7 +17,7 @@ async function createWallet ({ logger, params, engines }, { CreateWalletResponse
 
   if (!engine) {
     logger.error(`Could not find engine: ${symbol}`)
-    throw new PublicError(`Unable to create wallet for engine: ${symbol}`)
+    throw new Error(`Unable to create wallet for engine: ${symbol}`)
   }
 
   const recoverySeed = await engine.createWallet(password)

--- a/broker-daemon/broker-rpc/wallet-service/get-payment-channel-network-address.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-payment-channel-network-address.js
@@ -1,5 +1,3 @@
-const { PublicError } = require('grpc-methods')
-
 /**
  * Gets the payment channel network address from the specified engine
  *
@@ -17,7 +15,7 @@ async function getPaymentChannelNetworkAddress ({ logger, params, engines }, { G
 
   if (!engine) {
     logger.error(`Could not find engine: ${symbol}`)
-    throw new PublicError(`Unable to get network address for symbol: ${symbol}`)
+    throw new Error(`Unable to get network address for symbol: ${symbol}`)
   }
 
   const paymentChannelNetworkAddress = await engine.getPaymentChannelNetworkAddress()

--- a/broker-daemon/broker-rpc/wallet-service/new-deposit-address.js
+++ b/broker-daemon/broker-rpc/wallet-service/new-deposit-address.js
@@ -1,5 +1,3 @@
-const { PublicError } = require('grpc-methods')
-
 /**
  * Generates a new wallet address from the specified engine
  *
@@ -17,7 +15,7 @@ async function newDepositAddress ({ logger, params, engines }, { NewDepositAddre
 
   if (!engine) {
     logger.error(`Could not find engine: ${symbol}`)
-    throw new PublicError(`Unable to generate address for symbol: ${symbol}`)
+    throw new Error(`Unable to generate address for symbol: ${symbol}`)
   }
 
   const address = await engine.createNewAddress()

--- a/broker-daemon/broker-rpc/wallet-service/release-channels.js
+++ b/broker-daemon/broker-rpc/wallet-service/release-channels.js
@@ -1,5 +1,3 @@
-const { PublicError } = require('grpc-methods')
-
 /**
  * @constant
  * @type {Object}
@@ -64,7 +62,7 @@ async function releaseChannels ({ params, logger, engines, orderbooks, blockOrde
   const orderbook = orderbooks.get(market)
 
   if (!orderbook) {
-    throw new PublicError(`${market} is not being tracked as a market.`)
+    throw new Error(`${market} is not being tracked as a market.`)
   }
 
   const { cancelledOrders, failedToCancelOrders } = await blockOrderWorker.cancelActiveOrders(market)
@@ -77,8 +75,8 @@ async function releaseChannels ({ params, logger, engines, orderbooks, blockOrde
   const baseEngine = engines.get(baseSymbol)
   const counterEngine = engines.get(counterSymbol)
 
-  if (!baseEngine) throw new PublicError(`No engine available for ${baseSymbol}`)
-  if (!counterEngine) throw new PublicError(`No engine available for ${counterSymbol}`)
+  if (!baseEngine) throw new Error(`No engine available for ${baseSymbol}`)
+  if (!counterEngine) throw new Error(`No engine available for ${counterSymbol}`)
 
   // We want to try and close channels for both the base and counter engines
   // however if one of the engines fail to release channel, instead of failing

--- a/broker-daemon/broker-rpc/wallet-service/release-channels.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/release-channels.spec.js
@@ -1,6 +1,5 @@
 const path = require('path')
 const { expect, rewire, sinon } = require('test/test-helper')
-const { PublicError } = require('grpc-methods')
 const releaseChannels = rewire(path.resolve(__dirname, 'release-channels'))
 
 describe('releaseChannels', () => {
@@ -120,14 +119,14 @@ describe('releaseChannels', () => {
       engines = new Map([['LTC', counterEngineStub]])
       return expect(
         releaseChannels({ params, logger, engines, orderbooks, blockOrderWorker }, { ReleaseChannelsResponse })
-      ).to.eventually.be.rejectedWith(PublicError, `No engine available for BTC`)
+      ).to.eventually.be.rejectedWith(Error, `No engine available for BTC`)
     })
 
     it('throws an error if the counter engine does not exist for symbol', () => {
       engines = new Map([['BTC', baseEngineStub]])
       return expect(
         releaseChannels({ params, logger, engines, orderbooks, blockOrderWorker }, { ReleaseChannelsResponse })
-      ).to.be.rejectedWith(PublicError, `No engine available for LTC`)
+      ).to.be.rejectedWith(Error, `No engine available for LTC`)
     })
   })
 

--- a/broker-daemon/broker-rpc/wallet-service/unlock-wallet.js
+++ b/broker-daemon/broker-rpc/wallet-service/unlock-wallet.js
@@ -1,5 +1,3 @@
-const { PublicError } = require('grpc-methods')
-
 /**
  * Unlock an engine's wallet
  *
@@ -11,8 +9,8 @@ const { PublicError } = require('grpc-methods')
  * @param {Map<Engine>} request.engines
  * @param {Object} responses
  * @param {Function} responses.EmptyResponse
- * @throws {PublicError} If Engine does not exist for the given symbol
- * @throws {PublicError} If Engine is not in a LOCKED state
+ * @throws {Error} If Engine does not exist for the given symbol
+ * @throws {Error} If Engine is not in a LOCKED state
  * @return {EmptyResponse}
  */
 async function unlockWallet ({ logger, params, engines }, { EmptyResponse }) {
@@ -21,12 +19,12 @@ async function unlockWallet ({ logger, params, engines }, { EmptyResponse }) {
 
   if (!engine) {
     logger.error(`Could not find engine: ${symbol}`)
-    throw new PublicError(`Unable to unlock wallet. No engine available for ${symbol}`)
+    throw new Error(`Unable to unlock wallet. No engine available for ${symbol}`)
   }
 
   if (!engine.isLocked) {
     logger.error(`Engine for ${symbol} is not locked. Current status: ${engine.status}`)
-    throw new PublicError(`Unable to unlock wallet, engine for ${symbol} is currently: ${engine.status}`)
+    throw new Error(`Unable to unlock wallet, engine for ${symbol} is currently: ${engine.status}`)
   }
 
   await engine.unlockWallet(password)

--- a/broker-daemon/broker-rpc/wallet-service/withdraw-funds.js
+++ b/broker-daemon/broker-rpc/wallet-service/withdraw-funds.js
@@ -1,4 +1,3 @@
-const { PublicError } = require('grpc-methods')
 const { currencies } = require('../../config')
 const { Big } = require('../../utils')
 /**
@@ -19,23 +18,20 @@ async function withdrawFunds ({ params, relayer, logger, engines }, { WithdrawFu
 
   const engine = engines.get(symbol)
   if (!engine) {
-    throw new PublicError(`No engine available for ${symbol}`)
+    throw new Error(`No engine available for ${symbol}`)
   }
 
   const { quantumsPerCommon: multiplier } = currencies.find(({ symbol: configSymbol }) => configSymbol === symbol) || {}
   if (!multiplier) {
-    throw new PublicError(`Invalid configuration: missing quantumsPerCommon for ${symbol}`)
+    throw new Error(`Invalid configuration: missing quantumsPerCommon for ${symbol}`)
   }
   const amountInSat = Big(amount).times(multiplier)
 
-  try {
-    logger.info(`Attempting to withdraw ${amount} ${symbol} from wallet to ${address}`)
-    const txid = await engine.withdrawFunds(address, amountInSat.toString())
-    logger.info(`Successfully withdrew ${amount} ${symbol} from wallet to ${address}, transaction id: ${txid}`)
-    return new WithdrawFundsResponse({ txid })
-  } catch (err) {
-    throw new PublicError(err.message, err)
-  }
+  logger.info(`Attempting to withdraw ${amount} ${symbol} from wallet to ${address}`)
+  const txid = await engine.withdrawFunds(address, amountInSat.toString())
+  logger.info(`Successfully withdrew ${amount} ${symbol} from wallet to ${address}, transaction id: ${txid}`)
+
+  return new WithdrawFundsResponse({ txid })
 }
 
 module.exports = withdrawFunds

--- a/broker-daemon/broker-rpc/wallet-service/withdraw-funds.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/withdraw-funds.spec.js
@@ -1,6 +1,5 @@
 const path = require('path')
 const { expect, rewire, sinon } = require('test/test-helper')
-const { PublicError } = require('grpc-methods')
 const { Big } = require('../../utils')
 const withdrawFunds = rewire(path.resolve(__dirname, 'withdraw-funds'))
 
@@ -75,17 +74,17 @@ describe('withdrawFunds', () => {
       const badEngines = new Map([['BTC', undefined]])
       return expect(
         withdrawFunds({ params, relayer, logger, engines: badEngines }, { WithdrawFundsResponse })
-      ).to.be.rejectedWith(PublicError, `No engine available for ${params.symbol}`)
+      ).to.be.rejectedWith(Error, `No engine available for ${params.symbol}`)
     })
   })
 
   describe('balance under minimum amount', () => {
-    it('throws a PublicError on withdraw failure', () => {
+    it('throws an Error on withdraw failure', () => {
       withdrawFundsStub.throws('Error', 'Insufficient Funds')
 
       return expect(
         withdrawFunds({ params, relayer, logger, engines }, { WithdrawFundsResponse })
-      ).to.be.rejectedWith(PublicError, 'Insufficient Funds')
+      ).to.be.rejectedWith(Error, 'Insufficient Funds')
     })
   })
 
@@ -96,7 +95,7 @@ describe('withdrawFunds', () => {
     it('throws an error currency multiplier does not exist', () => {
       return expect(
         withdrawFunds({ params, relayer, logger, engines }, { WithdrawFundsResponse })
-      ).to.be.rejectedWith(PublicError, `Invalid configuration: missing quantumsPerCommon for ${params.symbol}`)
+      ).to.be.rejectedWith(Error, `Invalid configuration: missing quantumsPerCommon for ${params.symbol}`)
     })
   })
 })

--- a/broker-daemon/utils/create-basic-auth.js
+++ b/broker-daemon/utils/create-basic-auth.js
@@ -1,5 +1,3 @@
-const { PublicError } = require('grpc-methods')
-
 /**
  * @constant
  * @type {Boolean}
@@ -26,7 +24,7 @@ function createBasicAuth (rpcUser, rpcPass, disableAuth = false) {
 
     if (!authToken) {
       logger.debug('Basic Authentication has failed. No auth token could be found')
-      throw new PublicError('Basic Authentication Failed, please check your authorization credentials')
+      throw new Error('Basic Authentication Failed, please check your authorization credentials')
     }
 
     const [scheme, base64Token] = authToken.split(' ')
@@ -42,7 +40,7 @@ function createBasicAuth (rpcUser, rpcPass, disableAuth = false) {
     // grpc-method handles the authorization middleware
     if (username !== rpcUser || password !== rpcPass) {
       logger.debug('Basic Authentication has failed. Username/Password did not match')
-      throw new PublicError('Basic Authentication Failed, please check your authorization credentials')
+      throw new Error('Basic Authentication Failed, please check your authorization credentials')
     }
   }
 }

--- a/broker-daemon/utils/create-basic-auth.spec.js
+++ b/broker-daemon/utils/create-basic-auth.spec.js
@@ -1,6 +1,5 @@
 const path = require('path')
 const { expect, sinon, rewire } = require('test/test-helper')
-const { PublicError } = require('grpc-methods')
 
 const createBasicAuth = rewire(path.resolve(__dirname, 'create-basic-auth'))
 const credentialGenerator = rewire(path.resolve(__dirname, '..', '..', 'broker-cli', 'utils', 'basic-auth'))
@@ -34,7 +33,7 @@ describe('createBasicAuth', () => {
     const rpcUser = 'sparkswap'
     const rpcPass = 'sparkswap'
     grpcAuthHandler = createBasicAuth(rpcUser, rpcPass)
-    return expect(grpcAuthHandler({ metadata, logger })).to.eventually.be.rejectedWith(PublicError)
+    return expect(grpcAuthHandler({ metadata, logger })).to.eventually.be.rejectedWith(Error)
   })
 
   it('does not error if credentials are verified', async () => {
@@ -55,7 +54,7 @@ describe('createBasicAuth', () => {
     const metadata = { authorization: token }
     const badUser = 'sperkswap'
     grpcAuthHandler = createBasicAuth(badUser, rpcPass)
-    return expect(grpcAuthHandler({ metadata, logger })).to.eventually.be.rejectedWith(PublicError)
+    return expect(grpcAuthHandler({ metadata, logger })).to.eventually.be.rejectedWith(Error)
   })
 
   it('errors if password is incorrect', () => {
@@ -65,7 +64,7 @@ describe('createBasicAuth', () => {
     const metadata = { authorization: token }
     const badPass = 'sperkswap'
     grpcAuthHandler = createBasicAuth(rpcUser, badPass)
-    return expect(grpcAuthHandler({ metadata, logger })).to.eventually.be.rejectedWith(PublicError)
+    return expect(grpcAuthHandler({ metadata, logger })).to.eventually.be.rejectedWith(Error)
   })
 
   it('errors if username and password are incorrect', () => {
@@ -76,6 +75,6 @@ describe('createBasicAuth', () => {
     const badUser = 'sperkswap'
     const badPass = 'sperkswap'
     grpcAuthHandler = createBasicAuth(badUser, badPass)
-    return expect(grpcAuthHandler({ metadata, logger })).to.eventually.be.rejectedWith(PublicError)
+    return expect(grpcAuthHandler({ metadata, logger })).to.eventually.be.rejectedWith(Error)
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -3183,7 +3183,6 @@
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3202,7 +3201,6 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3382,8 +3380,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "optional": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3489,8 +3486,7 @@
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "optional": true
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
     },
@@ -4266,10 +4262,439 @@
       }
     },
     "grpc-methods": {
-      "version": "github:sparkswap/grpc-methods#4cb89ff8f32fcf0e30642d3659640f6e4eaa6dd3",
-      "from": "github:sparkswap/grpc-methods#v0.6.3",
+      "version": "github:sparkswap/grpc-methods#fc40650bae45194157d8dc59b8cc8d1324bf1c6c",
+      "from": "github:sparkswap/grpc-methods#v0.7.0",
       "requires": {
-        "grpc": "1.11.3"
+        "grpc": "1.15.1"
+      },
+      "dependencies": {
+        "grpc": {
+          "version": "1.15.1",
+          "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.15.1.tgz",
+          "integrity": "sha512-BfJ6BpFE93xQW69oYfgVQDxSb7LqdQbnddvhFq4tUsj7s0NAIRrrN3fmN2Bi3qpGFRemsKsWPIchw3YNNq2Xjg==",
+          "requires": {
+            "lodash": "^4.17.5",
+            "nan": "^2.0.0",
+            "node-pre-gyp": "^0.10.0",
+            "protobufjs": "^5.0.3"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.5",
+              "bundled": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "deep-extend": {
+              "version": "0.6.0",
+              "bundled": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "fs-minipass": {
+              "version": "1.2.5",
+              "bundled": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "iconv-lite": {
+              "version": "0.4.23",
+              "bundled": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "minipass": {
+              "version": "2.3.3",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "bundled": true
+                }
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "needle": {
+              "version": "2.2.2",
+              "bundled": true,
+              "requires": {
+                "debug": "^2.1.2",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.10.3",
+              "bundled": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.1",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.2.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "npm-packlist": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "rc": {
+              "version": "1.2.8",
+              "bundled": true,
+              "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.2",
+              "bundled": true,
+              "requires": {
+                "glob": "^7.0.5"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true
+            },
+            "semver": {
+              "version": "5.5.0",
+              "bundled": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "tar": {
+              "version": "4.4.6",
+              "bundled": true,
+              "requires": {
+                "chownr": "^1.0.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.3.3",
+                "minizlib": "^1.1.0",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.2"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "wide-align": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "string-width": "^1.0.2 || 2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "protobufjs": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
+          "integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
+          "requires": {
+            "ascli": "~1",
+            "bytebuffer": "~5",
+            "glob": "^7.0.5",
+            "yargs": "^3.10.0"
+          }
+        }
       }
     },
     "has": {
@@ -6316,7 +6741,6 @@
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -6331,13 +6755,13 @@
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "append-transform": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
           "dev": true,
           "requires": {
@@ -6386,7 +6810,7 @@
         },
         "caching-transform": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-tTfemGmFWe7KZ3KN6VsSgQZbd9Bgo7A40wlp4PTsJJvFu4YAnEC5YnfdiKq6Vh2i9XJLnA9n8OXD46orVpnPMw==",
           "dev": true,
           "requires": {
@@ -6455,7 +6879,7 @@
         },
         "convert-source-map": {
           "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+          "resolved": false,
           "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
           "dev": true,
           "requires": {
@@ -6474,7 +6898,7 @@
         },
         "debug": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "resolved": false,
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
@@ -6495,7 +6919,7 @@
         },
         "default-require-extensions": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
           "dev": true,
           "requires": {
@@ -6504,7 +6928,7 @@
         },
         "error-ex": {
           "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+          "resolved": false,
           "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
           "dev": true,
           "requires": {
@@ -6513,7 +6937,7 @@
         },
         "es6-error": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
           "dev": true
         },
@@ -6547,7 +6971,7 @@
         },
         "find-cache-dir": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
           "dev": true,
           "requires": {
@@ -6558,7 +6982,7 @@
         },
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
@@ -6583,7 +7007,7 @@
         },
         "get-caller-file": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "resolved": false,
           "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
           "dev": true
         },
@@ -6595,7 +7019,7 @@
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "resolved": false,
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
@@ -6638,13 +7062,13 @@
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+          "resolved": false,
           "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
           "dev": true
         },
@@ -6686,8 +7110,7 @@
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -6718,13 +7141,13 @@
         },
         "istanbul-lib-coverage": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA==",
           "dev": true
         },
         "istanbul-lib-hook": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha512-ufiZoiJ8CxY577JJWEeFuxXZoMqiKpq/RqZtOAYuQLvlkbJWscq9n3gc4xrCGH9n4pW0qnTxOz1oyMmVtk8E1w==",
           "dev": true,
           "requires": {
@@ -6733,7 +7156,7 @@
         },
         "istanbul-lib-report": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.2.tgz",
+          "resolved": false,
           "integrity": "sha512-rJ8uR3peeIrwAxoDEbK4dJ7cqqtxBisZKCuwkMtMv0xYzaAnsAi3AHrHPAAtNXzG/bcCgZZ3OJVqm1DTi9ap2Q==",
           "dev": true,
           "requires": {
@@ -6744,7 +7167,7 @@
         },
         "istanbul-lib-source-maps": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha512-30l40ySg+gvBLcxTrLzR4Z2XTRj3HgRCA/p2rnbs/3OiTaoj054gAbuP5DcLOtwqmy4XW8qXBHzrmP2/bQ9i3A==",
           "dev": true,
           "requires": {
@@ -6757,7 +7180,7 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "resolved": false,
               "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
               "dev": true
             }
@@ -6765,7 +7188,7 @@
         },
         "istanbul-reports": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha512-CT0QgMBJqs6NJLF678ZHcquUAZIoBIUNzdJrRJfpkI9OnzG6MkUfHxbJC3ln981dMswC7/B1mfX3LNkhgJxsuw==",
           "dev": true,
           "requires": {
@@ -6774,7 +7197,7 @@
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
           "dev": true
         },
@@ -6783,7 +7206,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -6806,7 +7228,7 @@
         },
         "load-json-file": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
@@ -6818,7 +7240,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
@@ -6828,7 +7250,7 @@
         },
         "lodash.flattendeep": {
           "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+          "resolved": false,
           "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
           "dev": true
         },
@@ -6836,8 +7258,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -6851,7 +7272,7 @@
         },
         "make-dir": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "resolved": false,
           "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
           "dev": true,
           "requires": {
@@ -6860,7 +7281,7 @@
         },
         "md5-hex": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
           "dev": true,
           "requires": {
@@ -6916,7 +7337,7 @@
         },
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": false,
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
@@ -6931,7 +7352,7 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": false,
               "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true
             }
@@ -7014,7 +7435,7 @@
         },
         "p-limit": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
           "dev": true,
           "requires": {
@@ -7023,7 +7444,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
@@ -7032,13 +7453,13 @@
         },
         "p-try": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
           "dev": true
         },
         "package-hash": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
           "dev": true,
           "requires": {
@@ -7050,7 +7471,7 @@
         },
         "parse-json": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
@@ -7060,7 +7481,7 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
@@ -7078,7 +7499,7 @@
         },
         "path-type": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
@@ -7087,13 +7508,13 @@
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
         "pkg-dir": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
           "dev": true,
           "requires": {
@@ -7108,7 +7529,7 @@
         },
         "read-pkg": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
@@ -7119,7 +7540,7 @@
         },
         "read-pkg-up": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
           "dev": true,
           "requires": {
@@ -7129,7 +7550,7 @@
         },
         "release-zalgo": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
           "dev": true,
           "requires": {
@@ -7140,8 +7561,7 @@
           "version": "1.6.1",
           "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "require-directory": {
           "version": "2.1.1",
@@ -7157,7 +7577,7 @@
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         },
@@ -7182,7 +7602,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true
         },
@@ -7284,7 +7704,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -7293,7 +7713,7 @@
         },
         "strip-bom": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         },
@@ -7305,7 +7725,7 @@
         },
         "supports-color": {
           "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "resolved": false,
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
@@ -7314,7 +7734,7 @@
         },
         "test-exclude": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-bO3Lj5+qFa9YLfYW2ZcXMOV1pmQvw+KS/DpjqhyX6Y6UZ8zstpZJ+mA2ERkXfpOqhxsJlQiLeVXD3Smsrs6oLw==",
           "dev": true,
           "requires": {
@@ -7360,7 +7780,7 @@
         },
         "uuid": {
           "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "resolved": false,
           "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
           "dev": true
         },
@@ -7376,7 +7796,7 @@
         },
         "which": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "resolved": false,
           "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
           "requires": {
@@ -7414,7 +7834,7 @@
           "dependencies": {
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "resolved": false,
               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true
             },
@@ -7440,7 +7860,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": false,
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
@@ -7457,7 +7877,7 @@
         },
         "write-file-atomic": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+          "resolved": false,
           "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
           "dev": true,
           "requires": {
@@ -7511,7 +7931,7 @@
             },
             "find-up": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+              "resolved": false,
               "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
               "dev": true,
               "requires": {
@@ -7520,7 +7940,7 @@
             },
             "locate-path": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
               "dev": true,
               "requires": {
@@ -7530,7 +7950,7 @@
             },
             "p-limit": {
               "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+              "resolved": false,
               "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
               "dev": true,
               "requires": {
@@ -7539,7 +7959,7 @@
             },
             "p-locate": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
               "dev": true,
               "requires": {
@@ -7548,7 +7968,7 @@
             },
             "p-try": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
               "dev": true
             }
@@ -7556,7 +7976,7 @@
         },
         "yargs-parser": {
           "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "express": "4.16.3",
     "grpc": "1.11.3",
     "grpc-caller": "0.5.0",
-    "grpc-methods": "sparkswap/grpc-methods#v0.6.3",
+    "grpc-methods": "sparkswap/grpc-methods#v0.7.0",
     "helmet": "3.13.0",
     "javascript-state-machine": "3.0.1",
     "level": "3.0.1",


### PR DESCRIPTION
## Description
This change upgrades to grpc-methods 0.7.0 which makes errors public by default. It allows us to remove all of the PublicError code in the Broker.

## Related PRs
https://github.com/sparkswap/grpc-methods/pull/16
