### PR TITLE
FEATURE - removed process.env.NODE_ENV for global setting

### DIFF
--- a/broker-cli/utils/validations.js
+++ b/broker-cli/utils/validations.js
@@ -21,6 +21,16 @@ const BLOCKCHAIN_NETWORKS = Object.freeze([
 ])
 
 /**
+ * @constant
+ * @type {Object}
+ * @default
+ */
+const APP_ENVIRONMENTS = Object.freeze([
+  'dev',
+  'production'
+])
+
+/**
  * Checks if the specified string is a valid decimal format
  *
  * @param {string} str
@@ -198,6 +208,14 @@ function isBlockchainNetwork (network) {
   throw new Error(`Invalid blockchain network: ${network}`)
 }
 
+function isValidEnvironment (env) {
+  if (APP_ENVIRONMENTS.includes(env)) {
+    return env
+  }
+
+  throw new Error(`Invalid application environment: ${env}`)
+}
+
 module.exports = {
   isDecimal,
   isMarketName,
@@ -207,5 +225,6 @@ module.exports = {
   isBlockOrderId,
   isDate,
   isPositiveInteger,
-  isBlockchainNetwork
+  isBlockchainNetwork,
+  isValidEnvironment
 }

--- a/broker-daemon/bin/sparkswapd.js
+++ b/broker-daemon/bin/sparkswapd.js
@@ -111,9 +111,18 @@ program
     // `markets` will be a string of market symbols that are delimited by a comma
     const marketNames = (markets || '').split(',').filter(m => m)
 
+    // Set a global namespace for sparkswap that we can use for properties not
+    // related to application configuration
+    if (!global.sparkswap) {
+      global.sparkswap = {}
+    }
+
+    // Set the network in the global sparkswap namespace
+    global.sparkswap.network = network
+    // Set environment in the global sparkswap namespace
+    global.sparkswap.env = environment
+
     const brokerOptions = {
-      network,
-      environment,
       pubRpcKeyPath,
       privRpcKeyPath,
       privIdKeyPath,

--- a/broker-daemon/bin/sparkswapd.js
+++ b/broker-daemon/bin/sparkswapd.js
@@ -37,6 +37,7 @@ program
   // Broker configuration options
   .option('--data-dir [data-dir]', 'Location to store SparkSwap data', validations.isFormattedPath, config.dataDir)
   .option('--network [network]', 'The current blockchain network. (mainnet, testnet, or regtest)', validations.isBlockchainNetwork, null, true)
+  .option('--environment [environment]', 'The current application environment (dev or production)', validations.isValidEnvironment, null, true)
   .option('--interchain-router-address [interchain-router-address]', 'Add a host/port to listen for interchain router RPC connections', validations.isHost, config.interchainRouterAddress)
   .option('--id-pub-key-path [id-pub-key-path]', 'Location of the public key for the broker\'s identity', validations.isFormattedPath, config.idPubKeyPath)
   .option('--id-priv-key-path [id-priv-key-path]', 'Location of private key for the broker\'s identity', validations.isFormattedPath, config.idPrivKeyPath)
@@ -73,6 +74,7 @@ program
     const {
       dataDir,
       network,
+      environment,
       interchainRouterAddress,
       idPubKeyPath: pubIdKeyPath,
       idPrivKeyPath: privIdKeyPath,
@@ -111,6 +113,7 @@ program
 
     const brokerOptions = {
       network,
+      environment,
       pubRpcKeyPath,
       privRpcKeyPath,
       privIdKeyPath,

--- a/broker-daemon/bin/sparkswapd.spec.js
+++ b/broker-daemon/bin/sparkswapd.spec.js
@@ -4,13 +4,15 @@ const { sinon, rewire, expect } = require('test/test-helper')
 const sparkswapd = rewire(path.resolve(__dirname, 'sparkswapd.js'))
 const config = rewire(path.resolve(__dirname, '..', 'config.json'))
 
-describe('sparkswapd', () => {
+describe.only('sparkswapd', () => {
   let BrokerDaemon
   let argv
   let network
+  let env
 
   beforeEach(() => {
     network = 'regtest'
+    env = 'production'
     BrokerDaemon = sinon.stub()
     BrokerDaemon.prototype.initialize = sinon.stub()
 
@@ -19,7 +21,8 @@ describe('sparkswapd', () => {
     argv = [
       'node',
       './broker-daemon/bin/sparkswapd',
-      `--network=${network}`
+      `--network=${network}`,
+      `--environment=${env}`
     ]
   })
 

--- a/broker-daemon/broker-rpc/broker-rpc-server.js
+++ b/broker-daemon/broker-rpc/broker-rpc-server.js
@@ -17,15 +17,6 @@ const { createBasicAuth, createHttpServer } = require('../utils')
 const BROKER_PROTO_PATH = './broker-daemon/proto/broker.proto'
 
 /**
- * Whether we are starting this process in production based on the NODE_ENV
- *
- * @constant
- * @type {boolean}
- * @default
- */
-const IS_PRODUCTION = (process.env.NODE_ENV === 'production')
-
-/**
  * @class User-facing gRPC server for controling the BrokerDaemon
  *
  * @author Sparkswap
@@ -87,8 +78,8 @@ class BrokerRPCServer {
    * @returns {void}
    */
   listen (host) {
-    if (IS_PRODUCTION && this.disableAuth) {
-      throw new Error(`Cannot disable TLS in production. Set DISABLE_AUTH to FALSE.`)
+    if (global.sparkswap.network === 'mainnet' && this.disableAuth) {
+      throw new Error(`Cannot disable TLS on mainnet. Set DISABLE_AUTH to FALSE.`)
     }
 
     const rpcCredentials = this.createCredentials()

--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -96,7 +96,7 @@ class BrokerDaemon {
    * @param {string} opts.relayerOptions.certPath - Absolute path to the root certificate for the relayer
    * @returns {BrokerDaemon}
    */
-  constructor ({ network, privRpcKeyPath, pubRpcKeyPath, privIdKeyPath, pubIdKeyPath, rpcAddress, interchainRouterAddress, dataDir, marketNames, engines, disableAuth = false, rpcUser = null, rpcPass = null, relayerOptions = {}, rpcHttpProxyAddress }) {
+  constructor ({ network, environment, privRpcKeyPath, pubRpcKeyPath, privIdKeyPath, pubIdKeyPath, rpcAddress, interchainRouterAddress, dataDir, marketNames, engines, disableAuth = false, rpcUser = null, rpcPass = null, relayerOptions = {}, rpcHttpProxyAddress }) {
     // Set a global namespace for sparkswap that we can use for properties not
     // related to application configuration
     if (!global.sparkswap) {
@@ -109,6 +109,8 @@ class BrokerDaemon {
 
     // Set the network in the global sparkswap namespace
     global.sparkswap.network = network
+    // Set environment in the global sparkswap namespace
+    global.sparkswap.env = environment
 
     const { relayerRpcHost, relayerCertPath } = relayerOptions
 

--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -96,21 +96,9 @@ class BrokerDaemon {
    * @param {string} opts.relayerOptions.certPath - Absolute path to the root certificate for the relayer
    * @returns {BrokerDaemon}
    */
-  constructor ({ network, environment, privRpcKeyPath, pubRpcKeyPath, privIdKeyPath, pubIdKeyPath, rpcAddress, interchainRouterAddress, dataDir, marketNames, engines, disableAuth = false, rpcUser = null, rpcPass = null, relayerOptions = {}, rpcHttpProxyAddress }) {
-    // Set a global namespace for sparkswap that we can use for properties not
-    // related to application configuration
-    if (!global.sparkswap) {
-      global.sparkswap = {}
-    }
-
-    if (!network) throw new Error('Network is required to create a BrokerDaemon')
+  constructor ({ privRpcKeyPath, pubRpcKeyPath, privIdKeyPath, pubIdKeyPath, rpcAddress, interchainRouterAddress, dataDir, marketNames, engines, disableAuth = false, rpcUser = null, rpcPass = null, relayerOptions = {}, rpcHttpProxyAddress }) {
     if (!privIdKeyPath) throw new Error('Private Key path is required to create a BrokerDaemon')
     if (!pubIdKeyPath) throw new Error('Public Key path is required to create a BrokerDaemon')
-
-    // Set the network in the global sparkswap namespace
-    global.sparkswap.network = network
-    // Set environment in the global sparkswap namespace
-    global.sparkswap.env = environment
 
     const { relayerRpcHost, relayerCertPath } = relayerOptions
 

--- a/broker-daemon/index.spec.js
+++ b/broker-daemon/index.spec.js
@@ -4,7 +4,6 @@ const { expect, sinon, rewire } = require('test/test-helper')
 const BrokerDaemon = rewire(path.resolve('broker-daemon', 'index'))
 
 describe('broker daemon', () => {
-  let network
   let rpcServer
   let interchainRouter
   let eventEmitter
@@ -96,7 +95,6 @@ describe('broker daemon', () => {
     BrokerDaemon.__set__('InterchainRouter', interchainRouter)
     BrokerDaemon.__set__('logger', logger)
 
-    network = 'mainnet'
     privRpcKeyPath = '/my/private/rpc/key/path'
     pubRpcKeyPath = '/my/public/rpc/key/path'
     privIdKeyPath = '/my/private/id/key/path'
@@ -138,8 +136,7 @@ describe('broker daemon', () => {
       disableAuth,
       rpcUser,
       rpcPass,
-      relayerOptions,
-      network
+      relayerOptions
     }
   })
 
@@ -147,16 +144,12 @@ describe('broker daemon', () => {
     expect(() => new BrokerDaemon({})).to.throw()
   })
 
-  it('throws if network is null', () => {
-    expect(() => new BrokerDaemon({})).to.throw('Network is required to create')
-  })
-
   it('throws if the public key path is null', () => {
-    expect(() => new BrokerDaemon({ network, privIdKeyPath: 'somepath' })).to.throw('Public Key path is required')
+    expect(() => new BrokerDaemon({ privIdKeyPath: 'somepath' })).to.throw('Public Key path is required')
   })
 
   it('throws if the private key path is null', () => {
-    expect(() => new BrokerDaemon({ network, privIdKeyPath: null })).to.throw('Private Key path is required')
+    expect(() => new BrokerDaemon({ privIdKeyPath: null })).to.throw('Private Key path is required')
   })
 
   it('throws for unrecognized engine types', () => {

--- a/broker-daemon/relayer/relayer-client.js
+++ b/broker-daemon/relayer/relayer-client.js
@@ -19,22 +19,15 @@ consoleLogger.debug = console.log.bind(console)
 const RELAYER_PROTO_PATH = './proto/relayer.proto'
 
 /**
- * @constant
- * @type {string}
- * @default
- */
-const PRODUCTION = process.env.NODE_ENV === 'production'
-
-/**
  * Interface for daemon to interact with a SparkSwap Relayer
  *
- * @author SparkSwap
+ * @author Sparkswap
  */
 class RelayerClient {
   /**
    * @typedef {Object} KeyPath
-   * @property {String} privKeyPath Path to a private key
-   * @property {String} pubKeyPath  Path to the public key corresponding to the private key
+   * @property {string} privKeyPath Path to a private key
+   * @property {string} pubKeyPath  Path to the public key corresponding to the private key
    */
 
   /**
@@ -53,8 +46,8 @@ class RelayerClient {
 
     let channelCredentials = credentials.createSsl()
 
-    if (!PRODUCTION) {
-      logger.info('Using local certs for relayer client', { production: PRODUCTION })
+    if (global.sparkswap.network === 'regtest' && global.sparkswap.env !== 'production') {
+      logger.info('Using local certs for relayer client', { env: global.sparkswap.env, network: global.sparkswap.network })
       channelCredentials = credentials.createSsl(readFileSync(certPath))
     }
 

--- a/broker-daemon/utils/logger.js
+++ b/broker-daemon/utils/logger.js
@@ -50,7 +50,7 @@ function createLogger () {
   })
 
   const logger = winston.createLogger({
-    level: (process.env.NODE_ENV === 'production') ? 'info' : 'debug',
+    level: (global.sparkswap.env === 'production') ? 'info' : 'debug',
     format: winston.format.combine(
       filterSensitive(),
       winston.format.timestamp(),

--- a/scripts/start-sparkswapd.sh
+++ b/scripts/start-sparkswapd.sh
@@ -13,6 +13,7 @@ set -eu
 # this script is called outside of docker-compose
 DATA_DIR=${DATA_DIR:-""}
 NETWORK=${NETWORK:-""}
+NODE_ENV=${NODE_ENV:-""}
 RPC_ADDRESS=${RPC_ADDRESS:-""}
 RPC_USER=${RPC_USER:-""}
 RPC_PASS=${RPC_PASS:-""}
@@ -33,6 +34,10 @@ fi
 
 if [ ! -z "$NETWORK" ]; then
   PARAMS="$PARAMS --network=$NETWORK"
+fi
+
+if [ ! -z "$NODE_ENV" ]; then
+  PARAMS="$PARAMS --environment=$NODE_ENV"
 fi
 
 if [ ! -z "$ID_PUB_KEY" ]; then


### PR DESCRIPTION
## Description
This PR adds a global var `global.sparkswap.env` to replace `process.env` usage for the broker.

Configuration works as follows:
1. .env is loaded
2. variables in docker-compose are loaded
3. all variables from the docker container are input into sparkswapd via `start-sparkswapd.sh`
4. default configuration is loaded from `config.json` in broker daemon

We've decided to omit the usage of environment variables from within the application to have a single point of configuration into the app to avoid conflicts with other programs/software

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
