### PR TITLE
run uncommitted balance checks only when there is not already an outbound channel open

### DIFF
--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -163,10 +163,6 @@ async function commit (args, opts, logger) {
 
     const totalUncommittedBalance = Big(uncommittedBalance)
 
-    if (totalUncommittedBalance.eq(0)) {
-      return logger.info('Your current uncommitted balance is 0, please add funds to your daemon')
-    }
-
     // We try to take the lowest total here between 2 Big numbers due to a
     // commit limit specified as `maxChannelBalance` in the currency configuration
     let maxSupportedBalance = totalUncommittedBalance
@@ -192,10 +188,6 @@ async function commit (args, opts, logger) {
     const answer = await askQuestion(`Are you OK committing ${maxSupportedBalance.toString()} ${symbol} to sparkswap? (Y/N)`)
 
     if (!ACCEPTED_ANSWERS.includes(answer.toLowerCase())) return
-
-    if (maxSupportedBalance.gt(uncommittedBalance)) {
-      throw new Error(`Amount specified is larger than your current uncommitted balance of ${uncommittedBalance} ${symbol}`)
-    }
 
     await client.walletService.commit({ balance: maxSupportedBalance.toString(), symbol, market })
 

--- a/broker-daemon/broker-rpc/wallet-service/commit.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.js
@@ -89,7 +89,10 @@ async function commit ({ params, relayer, logger, engines, orderbooks }, { Empty
 
     if ((Big(balance).plus(engine.feeEstimate)).gt(totalUncommittedBalance)) {
       const uncommittedCommon = totalUncommittedBalance.div(engine.quantumsPerCommon)
-      throw new Error(`Amount specified is larger than your current uncommitted balance of ${uncommittedCommon.toString()} ${symbol}`)
+      const feeEstimateCommon = Big(engine.feeEstimate).div(engine.quantumsPerCommon)
+      const errorMessage = `Amount specified ${balanceCommon} plus the fee estimate ${feeEstimateCommon} is larger than ` +
+      `your current uncommitted balance of ${uncommittedCommon.toString()} ${symbol}`
+      throw new Error(errorMessage)
     }
 
     logger.debug('Creating outbound channel', { address, balance })

--- a/broker-daemon/broker-rpc/wallet-service/commit.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.js
@@ -87,10 +87,6 @@ async function commit ({ params, relayer, logger, engines, orderbooks }, { Empty
     const uncommittedBalance = await engine.getUncommittedBalance()
     const totalUncommittedBalance = Big(uncommittedBalance)
 
-    if (totalUncommittedBalance.eq(0)) {
-      throw new Error('Your current uncommitted balance is 0, please add funds to your daemon')
-    }
-
     if (Big(balance).gt(totalUncommittedBalance)) {
       const uncommittedCommon = totalUncommittedBalance.div(engine.quantumsPerCommon)
       throw new Error(`Amount specified is larger than your current uncommitted balance of ${uncommittedCommon.toString()} ${symbol}`)

--- a/broker-daemon/broker-rpc/wallet-service/commit.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.js
@@ -87,7 +87,7 @@ async function commit ({ params, relayer, logger, engines, orderbooks }, { Empty
     const uncommittedBalance = await engine.getUncommittedBalance()
     const totalUncommittedBalance = Big(uncommittedBalance)
 
-    if (Big(balance).gt(totalUncommittedBalance)) {
+    if ((Big(balance).plus(engine.feeEstimate)).gt(totalUncommittedBalance)) {
       const uncommittedCommon = totalUncommittedBalance.div(engine.quantumsPerCommon)
       throw new Error(`Amount specified is larger than your current uncommitted balance of ${uncommittedCommon.toString()} ${symbol}`)
     }

--- a/broker-daemon/broker-rpc/wallet-service/commit.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.js
@@ -84,6 +84,18 @@ async function commit ({ params, relayer, logger, engines, orderbooks }, { Empty
   }
 
   if (!maxOutboundBalance) {
+    const uncommittedBalance = await engine.getUncommittedBalance()
+    const totalUncommittedBalance = Big(uncommittedBalance)
+
+    if (totalUncommittedBalance.eq(0)) {
+      throw new Error('Your current uncommitted balance is 0, please add funds to your daemon')
+    }
+
+    if (Big(balance).gt(totalUncommittedBalance)) {
+      const uncommittedCommon = totalUncommittedBalance.div(engine.quantumsPerCommon)
+      throw new Error(`Amount specified is larger than your current uncommitted balance of ${uncommittedCommon.toString()} ${symbol}`)
+    }
+
     logger.debug('Creating outbound channel', { address, balance })
 
     try {

--- a/broker-daemon/broker-rpc/wallet-service/commit.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.spec.js
@@ -107,14 +107,6 @@ describe('commit', () => {
     ).to.be.rejectedWith(Error, 'Error requesting inbound channel')
   })
 
-  it('throws an error if uncommitted balance is 0', () => {
-    getUncommittedBalanceStub.resolves('0')
-
-    expect(
-      commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })
-    ).to.be.rejectedWith(Error, 'Your current uncommitted balance is 0, please add funds to your daemon')
-  })
-
   it('throws an error if uncommitted balance is less than outbound channel to be opened', () => {
     getUncommittedBalanceStub.resolves('1000000')
 

--- a/broker-daemon/broker-rpc/wallet-service/commit.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.spec.js
@@ -110,9 +110,10 @@ describe('commit', () => {
   it('throws an error if uncommitted balance is less than outbound channel balance and feeEstimate to be opened', () => {
     getUncommittedBalanceStub.resolves('10019999')
 
+    const errorMessage = 'Amount specified 0.10000000 plus the fee estimate 0.0002 is larger than your current uncommitted balance of 0.10019999 BTC'
     expect(
       commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })
-    ).to.be.rejectedWith(Error, 'Amount specified is larger than your current uncommitted balance of 0.10019999 BTC')
+    ).to.be.rejectedWith(Error, errorMessage)
   })
 
   describe('committing a balance to the relayer', () => {

--- a/broker-daemon/broker-rpc/wallet-service/commit.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.spec.js
@@ -107,12 +107,12 @@ describe('commit', () => {
     ).to.be.rejectedWith(Error, 'Error requesting inbound channel')
   })
 
-  it('throws an error if uncommitted balance is less than outbound channel to be opened', () => {
-    getUncommittedBalanceStub.resolves('1000000')
+  it('throws an error if uncommitted balance is less than outbound channel balance and feeEstimate to be opened', () => {
+    getUncommittedBalanceStub.resolves('10019999')
 
     expect(
       commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })
-    ).to.be.rejectedWith(Error, 'Amount specified is larger than your current uncommitted balance of 0.01 BTC')
+    ).to.be.rejectedWith(Error, 'Amount specified is larger than your current uncommitted balance of 0.10019999 BTC')
   })
 
   describe('committing a balance to the relayer', () => {


### PR DESCRIPTION
## Description
When a user opens channels, and the outbound succeeds but the inbound fails, we made it so they can commit again and we will just bypass creating the outbound channel. However, we still have checks in place that if they have an uncommitted balance lower than the channel they are trying to create, we do not allow them to commit funds. We need to run this check only if there is not already an outbound channel open.

## Related PRs
List related PRs if applicable


## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
