### PR TITLE
Fix - Deadline healthcheck

### DIFF
--- a/broker-daemon/broker-rpc/admin-service/health-check.js
+++ b/broker-daemon/broker-rpc/admin-service/health-check.js
@@ -1,3 +1,5 @@
+const { grpcDeadline } = require('../../utils')
+
 /**
  * @constant
  * @type {Object}
@@ -19,7 +21,7 @@ const STATUS_CODES = Object.freeze({
  */
 async function getRelayerStatus (relayer, { logger }) {
   try {
-    await relayer.adminService.healthCheck({})
+    await relayer.adminService.healthCheck({}, { deadline: grpcDeadline() })
     return STATUS_CODES.OK
   } catch (e) {
     logger.error(`Relayer error during status check: `, { error: e.stack })

--- a/broker-daemon/broker-rpc/admin-service/health-check.spec.js
+++ b/broker-daemon/broker-rpc/admin-service/health-check.spec.js
@@ -95,10 +95,15 @@ describe('health-check', () => {
       getRelayerStatus = healthCheck.__get__('getRelayerStatus')
     })
 
-    it('returns an OK if relayer#healtCheck is successful', async () => {
+    it('returns an OK if relayer#healthCheck is successful', async () => {
       const { OK } = healthCheck.__get__('STATUS_CODES')
       const res = await getRelayerStatus(relayerStub, { logger })
       expect(res).to.eql(OK)
+    })
+
+    it('adds a deadline to the relayer#healthCheck call', async () => {
+      await getRelayerStatus(relayerStub, { logger })
+      expect(relayerStub.adminService.healthCheck.args[0][1]).to.have.property('deadline')
     })
 
     it('returns an UNAVAILABLE status code if the call to relayer fails', async () => {


### PR DESCRIPTION
## Description
This PR adds a deadline to the `sparkswap healthcheck` command when trying to get a status on the relayer.

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
