### PR TITLE
remove commit balance check that also exists on engine

### DIFF
--- a/broker-daemon/broker-rpc/wallet-service/commit.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.js
@@ -84,17 +84,6 @@ async function commit ({ params, relayer, logger, engines, orderbooks }, { Empty
   }
 
   if (!maxOutboundBalance) {
-    const uncommittedBalance = await engine.getUncommittedBalance()
-    const totalUncommittedBalance = Big(uncommittedBalance)
-
-    if ((Big(balance).plus(engine.feeEstimate)).gt(totalUncommittedBalance)) {
-      const uncommittedCommon = totalUncommittedBalance.div(engine.quantumsPerCommon)
-      const feeEstimateCommon = Big(engine.feeEstimate).div(engine.quantumsPerCommon)
-      const errorMessage = `Amount specified ${balanceCommon} plus the fee estimate ${feeEstimateCommon} is larger than ` +
-      `your current uncommitted balance of ${uncommittedCommon.toString()} ${symbol}`
-      throw new Error(errorMessage)
-    }
-
     logger.debug('Creating outbound channel', { address, balance })
 
     try {

--- a/broker-daemon/broker-rpc/wallet-service/commit.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/commit.spec.js
@@ -107,15 +107,6 @@ describe('commit', () => {
     ).to.be.rejectedWith(Error, 'Error requesting inbound channel')
   })
 
-  it('throws an error if uncommitted balance is less than outbound channel balance and feeEstimate to be opened', () => {
-    getUncommittedBalanceStub.resolves('10019999')
-
-    const errorMessage = 'Amount specified 0.10000000 plus the fee estimate 0.0002 is larger than your current uncommitted balance of 0.10019999 BTC'
-    expect(
-      commit({ params, relayer, logger, engines, orderbooks }, { EmptyResponse })
-    ).to.be.rejectedWith(Error, errorMessage)
-  })
-
   describe('committing a balance to the relayer', () => {
     let fakeAuth
     beforeEach(async () => {


### PR DESCRIPTION
## Description
When committing a balance, we added a check on the broker that throws an error if the desired balance plus the fees is larger than the uncommitted balance. However, given that this check also exists on the engine, it is duplicative and can lead to some confusing error messages in certain edge cases. So we remove it here in favor of relying completely on the engine's validation.

## Related PRs
https://github.com/sparkswap/lnd-engine/pull/177


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
