### PR TITLE
unfreeze grpc options objects

### DIFF
--- a/broker-cli/broker-daemon-client/index.js
+++ b/broker-cli/broker-daemon-client/index.js
@@ -39,11 +39,13 @@ const DEFAULT_RPC_PORT = 27492
  * cancelled, leaving the broker in an offline/weird state where communication
  * is dead, but the broker hasn't been notified
  *
+ * NOTE: This object will be mutated by gRPC (do not use Object.freeze)
+ *
  * @constant
  * @type {Object}
  * @default
  */
-const GRPC_STREAM_OPTIONS = Object.freeze({
+const GRPC_STREAM_OPTIONS = {
   // Set to 30 seconds, keep-alive time is an arbitrary number, but needs to be
   // less than default tcp timeout of AWS/ELB which is 1 minute
   'grpc.keepalive_time_ms': 30000,
@@ -54,7 +56,7 @@ const GRPC_STREAM_OPTIONS = Object.freeze({
   'grpc.http2.min_time_between_pings_ms': 30000,
   // Set to infinity, this means the server will continually send keep-alive pings
   'grpc.http2.max_pings_without_data': 0
-})
+}
 
 class BrokerDaemonClient {
   /**

--- a/broker-daemon/broker-rpc/broker-rpc-server.js
+++ b/broker-daemon/broker-rpc/broker-rpc-server.js
@@ -32,11 +32,13 @@ const IS_PRODUCTION = (process.env.NODE_ENV === 'production')
  * gRPC server options that add keep-alive configuration for all streaming service
  * calls
  *
+ * NOTE: This object will be mutated by gRPC (do not use Object.freeze)
+ *
  * @constant
  * @type {Object}
  * @default
  */
-const GRPC_SERVER_OPTIONS = Object.freeze({
+const GRPC_SERVER_OPTIONS = {
   // keep-alive time is an arbitrary number, but needs to be less than default
   // timeout of AWS/ELB which is 1 minute
   'grpc.keepalive_time_ms': 30000,
@@ -44,7 +46,7 @@ const GRPC_SERVER_OPTIONS = Object.freeze({
   'grpc.keepalive_permit_without_calls': 1,
   // Set to infinity, this means the server will continually send keep-alive pings
   'grpc.http2.max_pings_without_data': 0
-})
+}
 
 /**
  * @class User-facing gRPC server for controling the BrokerDaemon

--- a/broker-daemon/interchain-router/index.js
+++ b/broker-daemon/interchain-router/index.js
@@ -13,11 +13,13 @@ const PROTO_PATH = path.resolve(__dirname, 'rpc.proto')
  * gRPC server options that add keep-alive configuration for all streaming service
  * calls
  *
+ * NOTE: This object will be mutated by gRPC (do not use Object.freeze)
+ *
  * @constant
  * @type {Object}
  * @default
  */
-const GRPC_SERVER_OPTIONS = Object.freeze({
+const GRPC_SERVER_OPTIONS = {
   // keep-alive time is an arbitrary number, but needs to be less than default
   // timeout of AWS/ELB which is 1 minute
   'grpc.keepalive_time_ms': 30000,
@@ -25,7 +27,7 @@ const GRPC_SERVER_OPTIONS = Object.freeze({
   'grpc.keepalive_permit_without_calls': 1,
   // Set to infinity, this means the server will continually send keep-alive pings
   'grpc.http2.max_pings_without_data': 0
-})
+}
 
 /**
  * Interchain Router for retriving preimages from other payment channel networks

--- a/broker-daemon/relayer/relayer-client.js
+++ b/broker-daemon/relayer/relayer-client.js
@@ -33,11 +33,13 @@ const PRODUCTION = process.env.NODE_ENV === 'production'
  * cancelled, leaving the broker in an offline/weird state where communication
  * is dead, but the broker hasn't been notified
  *
+ * NOTE: This object will be mutated by gRPC (do not use Object.freeze)
+ *
  * @constant
  * @type {Object}
  * @default
  */
-const GRPC_STREAM_OPTIONS = Object.freeze({
+const GRPC_STREAM_OPTIONS = {
   // Set to 30 seconds, keep-alive time is an arbitrary number, but needs to be
   // less than default tcp timeout of AWS/ELB which is 1 minute
   'grpc.keepalive_time_ms': 30000,
@@ -48,7 +50,7 @@ const GRPC_STREAM_OPTIONS = Object.freeze({
   'grpc.http2.min_time_between_pings_ms': 30000,
   // Set to infinity, this means the server will continually send keep-alive pings
   'grpc.http2.max_pings_without_data': 0
-})
+}
 
 /**
  * Interface for daemon to interact with a SparkSwap Relayer


### PR DESCRIPTION
## Description
I introduced a regression in <https://github.com/sparkswap/broker/pull/438>. I used `Object.freeze` on all grpc options, however grpc will try to modify the object and will fail because it cant.

This PR removes Object.freeze from all grpc options

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
