### PR TITLE
Fix - Update handleError for unregistered entity IDs

### DIFF
--- a/broker-cli/utils/error-handler.js
+++ b/broker-cli/utils/error-handler.js
@@ -2,6 +2,13 @@ require('colors')
 const { status } = require('grpc')
 
 /**
+ * String to match errors for unregistered entity IDs on the Relayer.
+ * @constant
+ * @type {string}
+ */
+const NOT_REGISTERED_ERROR = 'not registered'
+
+/**
  * Takes in an error object and throws a friendly error if the broker daemon is down
  *
  * @param {Error} error
@@ -11,10 +18,23 @@ function handleError (error) {
   if (error.code === status.UNAVAILABLE) {
     return 'Broker Daemon is unavailable'.red + ', you may want to check if it\'s still up.'
   } else if (error.code === status.INTERNAL) {
-    return `Broker Daemon encountered an Internal Error: ${error.details} `.red +
-      '\nCheck your Broker Daemon logs (`docker-compose logs -f sparkswapd`) for more information.'
+    return handleInternalError(error)
   } else {
     return error
   }
+}
+
+/**
+ * Handling for internal error messages. Adds action item for user if Relayer encounters an unregistered Broker.
+ *
+ * @param {Error} error
+ * @returns {string}
+ */
+function handleInternalError (error) {
+  const message = `Broker Daemon encountered an Internal Error: ${error.details} `.red +
+    '\nCheck your Broker Daemon logs (`docker-compose logs -f sparkswapd`) for more information.'
+  const actionMessage = '\nPlease run `sparkswap register` to register your Broker Daemon with the Relayer.'
+
+  return error.details.includes(NOT_REGISTERED_ERROR) ? message + actionMessage : message
 }
 module.exports = handleError

--- a/broker-cli/utils/error-handler.js
+++ b/broker-cli/utils/error-handler.js
@@ -31,10 +31,12 @@ function handleError (error) {
  * @returns {string}
  */
 function handleInternalError (error) {
-  const message = `Broker Daemon encountered an Internal Error: ${error.details} `.red +
+  let message = `Broker Daemon encountered an Internal Error: ${error.details} `.red +
     '\nCheck your Broker Daemon logs (`docker-compose logs -f sparkswapd`) for more information.'
-  const actionMessage = '\nPlease run `sparkswap register` to register your Broker Daemon with the Relayer.'
 
-  return error.details.includes(NOT_REGISTERED_ERROR) ? message + actionMessage : message
+  if (error.details.includes(NOT_REGISTERED_ERROR)) {
+    message += '\nPlease run `sparkswap register` to register your Broker Daemon with the Relayer.'
+  }
+  return message
 }
 module.exports = handleError

--- a/broker-cli/utils/error-handler.spec.js
+++ b/broker-cli/utils/error-handler.spec.js
@@ -24,6 +24,15 @@ describe('handleError', () => {
     expect(handleError(error)).to.include(expectedMessage)
   })
 
+  it('logs a suggested action if broker daemon encountered an internal error from an unregistered entity', () => {
+    error = new Error('13 INTERNAL: Call terminated before completion')
+    error.details = 'not registered'
+    error.code = 13
+    expectedMessage = 'Please run `sparkswap register` to register your Broker Daemon with the Relayer.'
+
+    expect(handleError(error)).to.include(expectedMessage)
+  })
+
   it('logs the error message of the original error if the broker daemon is not down', () => {
     error = new Error('normal error')
     expectedMessage = 'normal error'


### PR DESCRIPTION
## Description
When a user attempts to commit funds to the Relayer, if they haven't previously registered they will receive a cryptic error `No active entity exists for the provided Public Key`. This PR adds error handling for this case and prints a suggested help message to run `sparkswap register`.

![image](https://user-images.githubusercontent.com/11034691/55038651-d0725a80-4fde-11e9-959c-0efcc885119f.png)

## Related PRs


## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
