### PR TITLE
Remove re-validation of wallets

### DIFF
--- a/broker-daemon/broker-rpc/wallet-service/create-wallet.js
+++ b/broker-daemon/broker-rpc/wallet-service/create-wallet.js
@@ -22,13 +22,6 @@ async function createWallet ({ logger, params, engines }, { CreateWalletResponse
 
   const recoverySeed = await engine.createWallet(password)
 
-  // We need to re-validate the node after wallet creation, however, this might
-  // cause the daemon to have multiple validation processes running at the same time.
-  //
-  // Additionally, we do not await the validation of an engine as it will be retried
-  // on its own.
-  engine.validateEngine()
-
   return new CreateWalletResponse({ recoverySeed })
 }
 

--- a/broker-daemon/broker-rpc/wallet-service/create-wallet.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/create-wallet.spec.js
@@ -20,8 +20,7 @@ describe('create-wallet', () => {
     CreateWalletResponse = sinon.stub()
     seeds = ['my', 'seeds']
     engineStub = {
-      createWallet: sinon.stub().resolves(seeds),
-      validateEngine: sinon.stub()
+      createWallet: sinon.stub().resolves(seeds)
     }
     engines = new Map([['BTC', engineStub]])
     params = {
@@ -38,11 +37,6 @@ describe('create-wallet', () => {
   it('creates a wallet', async () => {
     await createWallet({ logger, params, engines }, { CreateWalletResponse })
     expect(engineStub.createWallet).to.have.been.calledWith(params.password)
-  })
-
-  it('validates an engine after wallet creation', async () => {
-    await createWallet({ logger, params, engines }, { CreateWalletResponse })
-    expect(engineStub.validateEngine).to.have.been.calledOnce()
   })
 
   it('returns a recovery seed', async () => {


### PR DESCRIPTION
## Description
Engines are now validated perpetually and at short intervals, so we no longer need to re-validate when creating wallets.

## Related PRs
https://github.com/sparkswap/lnd-engine/pull/180
