### PR TITLE
Fix - Add Docker installation steps to install script

### DIFF
--- a/setup-scripts/install.sh
+++ b/setup-scripts/install.sh
@@ -120,6 +120,7 @@ fi
 msg "Installing node.js@8.11" $WHITE
 nvm install 8.11 --latest-npm
 
+# Check if Docker is installed. Fail install if not
 if [ "$(command -v docker)" == "" ]; then
   msg "Docker is not installed." $RED
   if [[ "$OSTYPE" == "linux-gnu" ]]; then
@@ -140,7 +141,7 @@ if [ "$(command -v docker)" == "" ]; then
   exit 1
 fi
 
-# Ensure version of Docker meets minimum requirements. Warn if version is not the latest
+# Ensure version of Docker meets minimum requirements. Fail install if not
 DOCKER_VERSION=$(docker version | grep Version | head -n 1 | grep -oE '[.0-9]*$')
 compare_versions $DOCKER_VERSION $MIN_DOCKER_VERSION
 if [[ $? == 2 ]]; then
@@ -159,6 +160,7 @@ if [[ $? == 2 ]]; then
   exit 1
 fi
 
+# Check if running the latest version of Docker. Warn if not and continue with install
 compare_versions $DOCKER_VERSION $CURRENT_DOCKER_VERSION
 if [[ $? == 2 ]]; then
   msg "Your version of Docker ($DOCKER_VERSION) isn't up to date. It's recommended that you upgrade to version $CURRENT_DOCKER_VERSION or greater." $YELLOW
@@ -174,6 +176,7 @@ if [[ $? == 2 ]]; then
   fi
 fi
 
+# Check if Docker Compose is installed. Fail install if not
 if [ "$(command -v docker-compose)" == "" ]; then
   msg "Docker Compose is not installed." $RED
   if [[ "$OSTYPE" == "linux-gnu" ]]; then
@@ -191,7 +194,7 @@ if [ "$(command -v docker-compose)" == "" ]; then
   exit 1
 fi
 
-# Ensure version of Docker Compose meets minimum requirements. Warn if version is not the latest
+# Ensure version of Docker Compose meets minimum requirements. Fail install if not
 DOCKER_COMPOSE_VERSION=$(docker-compose version | grep 'docker-compose version' | sed 's/,.*//' | grep -oE '[.0-9]*$')
 compare_versions $DOCKER_COMPOSE_VERSION $MIN_DOCKER_COMPOSE_VERSION
 if [[ $? == 2 ]]; then
@@ -208,6 +211,7 @@ if [[ $? == 2 ]]; then
   exit 1
 fi
 
+# Check if running the latest version of Docker Compose. Warn if not and continue with install
 compare_versions $DOCKER_COMPOSE_VERSION $CURRENT_DOCKER_COMPOSE_VERSION
 if [[ $? == 2 ]]; then
   msg "Your version of Docker Compose ($DOCKER_COMPOSE_VERSION) isn't up to date. It's recommended you upgrade to version $CURRENT_DOCKER_COMPOSE_VERSION or greater." $YELLOW

--- a/setup-scripts/install.sh
+++ b/setup-scripts/install.sh
@@ -144,13 +144,34 @@ fi
 DOCKER_VERSION=$(docker version | grep Version | head -n 1 | grep -oE '[.0-9]*$')
 compare_versions $DOCKER_VERSION $MIN_DOCKER_VERSION
 if [[ $? == 2 ]]; then
-  msg "Your version of Docker is older than the minimum required version. Please update to the latest version of Docker." $RED
+  msg "Your version of Docker ($DOCKER_VERSION) is older than the minimum required version. Please upgrade to version $CURRENT_DOCKER_VERSION or greater." $RED
+
+  if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    # Get the version of Linux distribution
+    LINUX_DISTRO=$(cat /etc/*-release | grep -E '^ID=' | sed 's/^.*=//' | tr -d \")
+    msg "You can find steps to upgrade Docker for Linux using the following link." $WHITE
+    msg "https://docs.docker.com/install/linux/docker-ce/$(echo $LINUX_DISTRO)/" $WHITE
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    msg "You can find steps to upgrade Docker for Mac using the following link." $WHITE
+    msg "https://docs.docker.com/docker-for-mac/release-notes/" $WHITE
+  fi
+
   exit 1
 fi
 
 compare_versions $DOCKER_VERSION $CURRENT_DOCKER_VERSION
 if [[ $? == 2 ]]; then
-  msg "Your version of Docker isn't up to date. Please update to the latest version." $YELLOW
+  msg "Your version of Docker ($DOCKER_VERSION) isn't up to date. It's recommended that you upgrade to version $CURRENT_DOCKER_VERSION or greater." $YELLOW
+
+  if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    # Get the version of Linux distribution
+    LINUX_DISTRO=$(cat /etc/*-release | grep -E '^ID=' | sed 's/^.*=//' | tr -d \")
+    msg "You can find steps to upgrade Docker for Linux using the following link." $WHITE
+    msg "https://docs.docker.com/install/linux/docker-ce/$(echo $LINUX_DISTRO)/" $WHITE
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    msg "You can find steps to upgrade Docker for Mac using the following link." $WHITE
+    msg "https://docs.docker.com/docker-for-mac/release-notes/" $WHITE
+  fi
 fi
 
 if [ "$(command -v docker-compose)" == "" ]; then
@@ -174,13 +195,30 @@ fi
 DOCKER_COMPOSE_VERSION=$(docker-compose version | grep 'docker-compose version' | sed 's/,.*//' | grep -oE '[.0-9]*$')
 compare_versions $DOCKER_COMPOSE_VERSION $MIN_DOCKER_COMPOSE_VERSION
 if [[ $? == 2 ]]; then
-  msg "Your version of Docker Compose is older than the minimum required version. Please update to the latest version of Docker Compose." $RED
+  msg "Your version of Docker Compose ($DOCKER_COMPOSE_VERSION) is older than the minimum required version. Please upgrade to version $CURRENT_DOCKER_COMPOSE_VERSION or greater." $RED
+
+  if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    msg "You can find steps to upgrade Docker Compose for Linux using the following link." $WHITE
+    msg "https://docs.docker.com/compose/install/" $WHITE
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    msg "You can find steps to upgrade Docker for Mac using the following link." $WHITE
+    msg "https://docs.docker.com/docker-for-mac/release-notes/" $WHITE
+  fi
+
   exit 1
 fi
 
 compare_versions $DOCKER_COMPOSE_VERSION $CURRENT_DOCKER_COMPOSE_VERSION
 if [[ $? == 2 ]]; then
-  msg "Your version of Docker Compose isn't up to date. Please update to the latest version." $YELLOW
+  msg "Your version of Docker Compose ($DOCKER_COMPOSE_VERSION) isn't up to date. It's recommended you upgrade to version $CURRENT_DOCKER_COMPOSE_VERSION or greater." $YELLOW
+
+  if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    msg "You can find steps to upgrade Docker Compose for Linux using the following link." $WHITE
+    msg "https://docs.docker.com/compose/install/" $WHITE
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    msg "You can find steps to upgrade Docker for Mac using the following link." $WHITE
+    msg "https://docs.docker.com/docker-for-mac/release-notes/" $WHITE
+  fi
 fi
 
 msg "We're about to create a directory named 'sparkswap' in ${PWD}." $WHITE

--- a/setup-scripts/install.sh
+++ b/setup-scripts/install.sh
@@ -81,12 +81,39 @@ msg "Installing node.js@8.11" $WHITE
 nvm install 8.11 --latest-npm
 
 if [ "$(command -v docker)" == "" ]; then
-  msg "Docker is not installed. Please install it before continuing" $RED
+  msg "Docker is not installed." $RED
+  if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    # Get the version of Linux distribution
+    LINUX_DISTRO=$(cat /etc/*-release | grep -E '^ID=' | sed 's/^.*=//' | tr -d \")
+    msg "Looks like you're using Linux." $GREEN
+    msg "To install Docker using the convenience script for Linux, run" $GREEN
+    msg "    $ curl -fsSL https://get.docker.com -o get-docker.sh" $WHITE
+    msg "    $ sudo sh get-docker.sh" $WHITE
+    msg "Alternatively, you can follow Docker's installation steps for Linux (https://docs.docker.com/install/linux/docker-ce/$(echo $LINUX_DISTRO)/)" $GREEN
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    msg "Looks like you're using Mac." $GREEN
+    msg "Please use the following link to download and install Docker for Mac Version 2.0.0.3 or greater (this installs Docker Community Edition and Docker Compose)" $GREEN
+    msg "https://docs.docker.com/docker-for-mac/release-notes/#docker-community-edition-2003-2019-02-15" $WHITE
+  else
+    msg "Please install Docker before continuing." $GREEN
+  fi
   exit 1
 fi
 
 if [ "$(command -v docker-compose)" == "" ]; then
-  msg "Docker Compose is not installed. Please install it before continuing" $RED
+  msg "Docker Compose is not installed." $RED
+  if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    msg "To install Docker Compose using Linux, run" $GREEN
+    msg '    $ curl -L "https://github.com/docker/compose/releases/download/1.23.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose' $WHITE
+    msg "    $ sudo chmod +x /usr/local/bin/docker-compose" $WHITE
+    msg "Alternatively, you can follow Docker's installation steps for Linux (https://docs.docker.com/compose/install/)" $GREEN
+  elif [[ "" == "" ]]; then
+    msg "Looks like you're using Mac." $GREEN
+    msg "Please use the following link to download and install Docker for Mac Version 2.0.0.3 or greater (this installs Docker Community Edition and Docker Compose)" $GREEN
+    msg "https://docs.docker.com/docker-for-mac/release-notes/#docker-community-edition-2003-2019-02-15" $WHITE
+  else
+    msg "Please install Docker before continuing" $RED
+  fi
   exit 1
 fi
 

--- a/setup-scripts/install.sh
+++ b/setup-scripts/install.sh
@@ -25,9 +25,49 @@ NC='\033[0m' # No Color
 
 BROKER_VERSION="v0.5.2-beta"
 
+# Set the minimum to approx. 6 months prior
+MIN_DOCKER_VERSION=18.09.0
+MIN_DOCKER_COMPOSE_VERSION=1.23.0
+
+# For current versions, don't include patches
+CURRENT_DOCKER_VERSION=18.09
+CURRENT_DOCKER_COMPOSE_VERSION=1.24
+
 # print a message with a color, like msg "my message" $GRAY
 msg () {
   echo -e "${GRAY}${TAG}${NC}:  $2$1${NC}"
+}
+
+# Compares two versions using dot notation (e.g. 1.2.3 < 1.2.4)
+compare_versions () {
+  if [[ $1 == $2 ]]
+  then
+    return 0
+  fi
+  local IFS=.
+  local i ver1=($1) ver2=($2)
+  # fill empty fields in ver1 with zeros
+  for ((i=${#ver1[@]}; i<${#ver2[@]}; i++))
+  do
+    ver1[i]=0
+  done
+  for ((i=0; i<${#ver1[@]}; i++))
+  do
+    if [[ -z ${ver2[i]} ]]
+    then
+      # fill empty fields in ver2 with zeros
+      ver2[i]=0
+    fi
+    if ((10#${ver1[i]} > 10#${ver2[i]}))
+    then
+      return 1
+    fi
+    if ((10#${ver1[i]} < 10#${ver2[i]}))
+    then
+      return 2
+    fi
+  done
+  return 0
 }
 
 # parse options
@@ -92,12 +132,25 @@ if [ "$(command -v docker)" == "" ]; then
     msg "Alternatively, you can follow Docker's installation steps for Linux (https://docs.docker.com/install/linux/docker-ce/$(echo $LINUX_DISTRO)/)" $GREEN
   elif [[ "$OSTYPE" == "darwin"* ]]; then
     msg "Looks like you're using Mac." $GREEN
-    msg "Please use the following link to download and install Docker for Mac Version 2.0.0.3 or greater (this installs Docker Community Edition and Docker Compose)" $GREEN
+    msg "You can use the following link to download and install Docker for Mac Version 2.0.0.3 or greater (this installs Docker Community Edition and Docker Compose)" $GREEN
     msg "https://docs.docker.com/docker-for-mac/release-notes/#docker-community-edition-2003-2019-02-15" $WHITE
   else
     msg "Please install Docker before continuing." $GREEN
   fi
   exit 1
+fi
+
+# Ensure version of Docker meets minimum requirements. Warn if version is not the latest
+DOCKER_VERSION=$(docker version | grep Version | head -n 1 | grep -oE '[.0-9]*$')
+compare_versions $DOCKER_VERSION $MIN_DOCKER_VERSION
+if [[ $? == 2 ]]; then
+  msg "Your version of Docker is older than the minimum required version. Please update to the latest version of Docker." $RED
+  exit 1
+fi
+
+compare_versions $DOCKER_VERSION $CURRENT_DOCKER_VERSION
+if [[ $? == 2 ]]; then
+  msg "Your version of Docker isn't up to date. Please update to the latest version." $YELLOW
 fi
 
 if [ "$(command -v docker-compose)" == "" ]; then
@@ -107,14 +160,27 @@ if [ "$(command -v docker-compose)" == "" ]; then
     msg '    $ curl -L "https://github.com/docker/compose/releases/download/1.23.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose' $WHITE
     msg "    $ sudo chmod +x /usr/local/bin/docker-compose" $WHITE
     msg "Alternatively, you can follow Docker's installation steps for Linux (https://docs.docker.com/compose/install/)" $GREEN
-  elif [[ "" == "" ]]; then
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
     msg "Looks like you're using Mac." $GREEN
-    msg "Please use the following link to download and install Docker for Mac Version 2.0.0.3 or greater (this installs Docker Community Edition and Docker Compose)" $GREEN
-    msg "https://docs.docker.com/docker-for-mac/release-notes/#docker-community-edition-2003-2019-02-15" $WHITE
+    msg "You can use the following link to install Docker Compose for Mac." $GREEN
+    msg "https://docs.docker.com/compose/install/" $WHITE
   else
-    msg "Please install Docker before continuing" $RED
+    msg "Please install Docker Compose before continuing" $RED
   fi
   exit 1
+fi
+
+# Ensure version of Docker Compose meets minimum requirements. Warn if version is not the latest
+DOCKER_COMPOSE_VERSION=$(docker-compose version | grep 'docker-compose version' | sed 's/,.*//' | grep -oE '[.0-9]*$')
+compare_versions $DOCKER_COMPOSE_VERSION $MIN_DOCKER_COMPOSE_VERSION
+if [[ $? == 2 ]]; then
+  msg "Your version of Docker Compose is older than the minimum required version. Please update to the latest version of Docker Compose." $RED
+  exit 1
+fi
+
+compare_versions $DOCKER_COMPOSE_VERSION $CURRENT_DOCKER_COMPOSE_VERSION
+if [[ $? == 2 ]]; then
+  msg "Your version of Docker Compose isn't up to date. Please update to the latest version." $YELLOW
 fi
 
 msg "We're about to create a directory named 'sparkswap' in ${PWD}." $WHITE


### PR DESCRIPTION
## Description
The PR adds better help messages for missing installations of Docker and Docker Compose based on the user's operating system (only Mac and Linux are currently supported). Previously, we were exiting the script and telling the user to "please install it before continuing."

The script also detects the distribution of Linux running the installation script to provide a link to the correct Docker docs.

Before
---
![image](https://user-images.githubusercontent.com/11034691/55268175-a3bf7c80-5244-11e9-9439-8506d56992af.png)


After
---
![image](https://user-images.githubusercontent.com/11034691/55268223-f26d1680-5244-11e9-9f39-f084b3b134eb.png)

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [x] Link to Trello
