### PR TITLE
Use locked Relayer proto files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .git
 node_modules
 broker-cli/node_modules
-proto/
 *.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -63,8 +63,8 @@ typings/
 # Mac
 .DS_Store
 
-# Proto build files
-proto
+# Local Relayer proto build files
+proto-local
 
 # Override file which we use dynamically in the broker setup
 docker-compose.override.yml

--- a/.gitignore
+++ b/.gitignore
@@ -63,8 +63,5 @@ typings/
 # Mac
 .DS_Store
 
-# Local Relayer proto build files
-proto-local
-
 # Override file which we use dynamically in the broker setup
 docker-compose.override.yml

--- a/broker-daemon/relayer/relayer-client.js
+++ b/broker-daemon/relayer/relayer-client.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const { readFileSync } = require('fs')
+const { readFileSync, existsSync } = require('fs')
 const { credentials } = require('grpc')
 const caller = require('grpc-caller')
 
@@ -13,8 +13,17 @@ const consoleLogger = console
 consoleLogger.debug = console.log.bind(console)
 
 /**
+ * Path for Proto files for the Relayer when doing local development
  * @constant
  * @type {string}
+ * @default
+ */
+const LOCAL_RELAYER_PROTO_PATH = './proto-local/relayer.proto'
+
+/**
+ * Path for the Proto files for the Relayer
+ * @type {string}
+ * @constant
  * @default
  */
 const RELAYER_PROTO_PATH = './proto/relayer.proto'
@@ -81,6 +90,11 @@ class RelayerClient {
     if (!PRODUCTION) {
       logger.info('Using local certs for relayer client', { production: PRODUCTION })
       channelCredentials = credentials.createSsl(readFileSync(certPath))
+
+      if (existsSync(path.resolve(LOCAL_RELAYER_PROTO_PATH))) {
+        logger.info('Using local proto files for the relayer client', { production: PRODUCTION, path: LOCAL_RELAYER_PROTO_PATH })
+        this.proto = loadProto(path.resolve(LOCAL_RELAYER_PROTO_PATH))
+      }
     }
 
     this.credentials = channelCredentials

--- a/broker-daemon/relayer/relayer-client.js
+++ b/broker-daemon/relayer/relayer-client.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const { readFileSync, existsSync } = require('fs')
+const { readFileSync } = require('fs')
 const { credentials } = require('grpc')
 const caller = require('grpc-caller')
 
@@ -11,14 +11,6 @@ const { grpcDeadlineInterceptor } = require('../../broker-cli/utils')
 
 const consoleLogger = console
 consoleLogger.debug = console.log.bind(console)
-
-/**
- * Path for Proto files for the Relayer when doing local development
- * @constant
- * @type {string}
- * @default
- */
-const LOCAL_RELAYER_PROTO_PATH = './proto-local/relayer.proto'
 
 /**
  * Path for the Proto files for the Relayer
@@ -90,11 +82,6 @@ class RelayerClient {
     if (!PRODUCTION) {
       logger.info('Using local certs for relayer client', { production: PRODUCTION })
       channelCredentials = credentials.createSsl(readFileSync(certPath))
-
-      if (existsSync(path.resolve(LOCAL_RELAYER_PROTO_PATH))) {
-        logger.info('Using local proto files for the relayer client', { production: PRODUCTION, path: LOCAL_RELAYER_PROTO_PATH })
-        this.proto = loadProto(path.resolve(LOCAL_RELAYER_PROTO_PATH))
-      }
     }
 
     this.credentials = channelCredentials

--- a/broker-daemon/relayer/relayer-client.spec.js
+++ b/broker-daemon/relayer/relayer-client.spec.js
@@ -7,7 +7,6 @@ describe('RelayerClient', () => {
   let logger
   let createSslStub
   let readFileSync
-  let existsSync
   let pathResolve
   let Identity
   let identityIdentify
@@ -86,8 +85,6 @@ describe('RelayerClient', () => {
 
     readFileSync = sinon.stub()
     RelayerClient.__set__('readFileSync', readFileSync)
-    existsSync = sinon.stub()
-    RelayerClient.__set__('existsSync', existsSync)
 
     proto = {
       MakerService,
@@ -165,43 +162,6 @@ describe('RelayerClient', () => {
       expect(readFileSync).to.have.been.calledOnce()
       expect(readFileSync).to.have.been.calledWith(fakePath)
       expect(createSslStub).to.have.been.calledWith(fakeCert)
-    })
-
-    it('uses a local proto file if in development and the file exists', () => {
-      RelayerClient.__set__('PRODUCTION', false)
-      pathResolve.withArgs('./proto-local/relayer.proto').returns('fake local path')
-      existsSync.withArgs('fake local path').returns(true)
-
-      // eslint-disable-next-line
-      new RelayerClient(idKeyPath, { host: relayerHost }, logger)
-
-      expect(pathResolve).to.have.been.calledWith('./proto-local/relayer.proto')
-      expect(existsSync).to.have.been.calledOnce()
-      expect(existsSync).to.have.been.calledWith('fake local path')
-      expect(loadProto).to.have.been.calledWith('fake local path')
-    })
-
-    it('does not use the local proto file if the file does not exist', () => {
-      RelayerClient.__set__('PRODUCTION', false)
-      existsSync.withArgs('./proto-local/relayer.proto').returns(false)
-      pathResolve.withArgs('./proto-local/relayer.proto').returns('fake local path')
-
-      // eslint-disable-next-line
-      new RelayerClient(idKeyPath, { host: relayerHost }, logger)
-
-      expect(loadProto).to.not.have.been.calledWith('fake local path')
-    })
-
-    it('does not use the local proto file if not in development', () => {
-      RelayerClient.__set__('PRODUCTION', true)
-      existsSync.withArgs('./proto-local/relayer.proto').returns(false)
-      pathResolve.withArgs('./proto-local/relayer.proto').returns('fake local path')
-
-      // eslint-disable-next-line
-      new RelayerClient(idKeyPath, { host: relayerHost }, logger)
-
-      expect(loadProto).to.have.been.calledOnce()
-      expect(loadProto).to.not.have.been.calledWith('fake local path')
     })
 
     it('creates ssl credentials', () => {

--- a/docker/sparkswapd/Dockerfile
+++ b/docker/sparkswapd/Dockerfile
@@ -39,6 +39,7 @@ COPY --from=builder /home/app/pm2.json /home/app/pm2.json
 
 # Copy relayer-proto files
 COPY --from=builder /home/app/proto /home/app/proto
+COPY --from=builder /home/app/proto-local /home/app/proto-local
 
 # Copy node_modules
 COPY --from=builder /home/app/node_modules /home/app/node_modules

--- a/docker/sparkswapd/Dockerfile
+++ b/docker/sparkswapd/Dockerfile
@@ -39,7 +39,6 @@ COPY --from=builder /home/app/pm2.json /home/app/pm2.json
 
 # Copy relayer-proto files
 COPY --from=builder /home/app/proto /home/app/proto
-COPY --from=builder /home/app/proto-local /home/app/proto-local
 
 # Copy node_modules
 COPY --from=builder /home/app/node_modules /home/app/node_modules

--- a/proto/README.md
+++ b/proto/README.md
@@ -1,0 +1,3 @@
+# relayer-proto
+
+Endpoints to reach relayer from broker

--- a/proto/relayer.proto
+++ b/proto/relayer.proto
@@ -1,0 +1,243 @@
+syntax = "proto3";
+
+enum Side {
+
+    BID = 0;
+    ASK = 1;
+}
+
+enum OrderStatus {
+
+    CREATED = 0;
+    PLACED = 1;
+    CANCELLED = 2;
+    FILLED = 3;
+    COMPLETED = 4;
+}
+
+message CreateOrderRequest {
+
+    string base_symbol = 2;
+    string counter_symbol = 3;
+    int64 base_amount = 4;
+    int64 counter_amount = 5;
+    Side side = 6;
+    string maker_base_address = 7;
+    string maker_counter_address = 8;
+}
+
+message CreateOrderResponse {
+
+    string order_id = 0;
+    string fee_payment_request = 1;
+    string deposit_payment_request = 2;
+    bool fee_required = 3;
+    bool deposit_required = 4;
+}
+
+message PlaceOrderRequest {
+
+    string order_id = 0;
+    string deposit_refund_payment_request = 1;
+    string fee_refund_payment_request = 2;
+}
+
+message CancelOrderRequest {
+
+    string order_id = 0;
+}
+
+message Fill {
+
+    bytes swap_hash = 0;
+    int64 fill_amount = 1;
+    string taker_address = 2;
+}
+
+message PlaceOrderResponse {
+
+    OrderStatus order_status = 0;
+    Fill fill = 1;
+}
+
+message ExecuteOrderRequest {
+
+    string order_id = 0;
+}
+
+message CompleteOrderRequest {
+
+    string order_id = 0;
+    bytes swap_preimage = 1;
+}
+service MakerService {
+    rpc CreateOrder (CreateOrderRequest) returns (CreateOrderResponse);
+    rpc PlaceOrder (PlaceOrderRequest) returns (stream PlaceOrderResponse);
+    rpc CancelOrder (CancelOrderRequest) returns (google.protobuf.Empty);
+    rpc ExecuteOrder (ExecuteOrderRequest) returns (google.protobuf.Empty);
+    rpc CompleteOrder (CompleteOrderRequest) returns (google.protobuf.Empty);
+}
+
+message google {
+
+    message protobuf {
+
+        message Empty {
+        }
+    }
+}
+
+enum Code {
+
+    ORDER_NOT_PLACED = 0;
+}
+
+message FillError {
+
+    string message = 0;
+    Code code = 1;
+}
+
+message CreateFillRequest {
+
+    string order_id = 0;
+    bytes swap_hash = 1;
+    int64 fill_amount = 2;
+    string taker_base_address = 3;
+    string taker_counter_address = 4;
+}
+
+message CreateFillResponse {
+
+    string fill_id = 0;
+    string fee_payment_request = 1;
+    string deposit_payment_request = 2;
+    bool fee_required = 3;
+    bool deposit_required = 4;
+    FillError fill_error = 10;
+}
+
+message FillOrderRequest {
+
+    string fill_id = 0;
+    string deposit_refund_payment_request = 1;
+    string fee_refund_payment_request = 2;
+}
+
+message FillOrderResponse {
+
+    FillError fill_error = 0;
+}
+
+message SubscribeExecuteRequest {
+
+    string fill_id = 0;
+}
+
+message SubscribeExecuteResponse {
+
+    string maker_address = 0;
+}
+service TakerService {
+    rpc CreateFill (CreateFillRequest) returns (CreateFillResponse);
+    rpc FillOrder (FillOrderRequest) returns (FillOrderResponse);
+    rpc SubscribeExecute (SubscribeExecuteRequest) returns (stream SubscribeExecuteResponse);
+}
+
+message MarketEvent {
+
+    string event_id = 1;
+    EventType event_type = 2;
+    int64 timestamp = 3;
+    string order_id = 4;
+    int64 sequence = 5;
+    int64 base_amount = 10;
+    int64 counter_amount = 11;
+    Side side = 12;
+    int64 fill_amount = 20;
+
+    enum EventType {
+
+        PLACED = 1;
+        CANCELLED = 2;
+        FILLED = 3;
+    }
+}
+
+message WatchMarketResponse {
+
+    ResponseType type = 1;
+    MarketEvent market_event = 2;
+    bytes checksum = 3;
+
+    enum ResponseType {
+
+        NEW_EVENT = 1;
+        EXISTING_EVENT = 2;
+        EXISTING_EVENTS_DONE = 3;
+        START_OF_EVENTS = 4;
+    }
+}
+
+message WatchMarketRequest {
+
+    string base_symbol = 1;
+    string counter_symbol = 2;
+    int64 last_updated = 3;
+    int64 sequence = 4;
+}
+service OrderBookService {
+    rpc WatchMarket (WatchMarketRequest) returns (stream WatchMarketResponse);
+}
+
+message GetAddressRequest {
+
+    string symbol = 1;
+}
+
+message GetAddressResponse {
+
+    string address = 1;
+}
+
+message Channel {
+
+    string address = 1;
+    string symbol = 2;
+    int64 balance = 3;
+}
+
+message CreateChannelRequest {
+
+    Channel outbound = 1;
+    Channel inbound = 2;
+}
+service PaymentChannelNetworkService {
+    rpc GetAddress (GetAddressRequest) returns (GetAddressResponse);
+    rpc CreateChannel (CreateChannelRequest) returns (google.protobuf.Empty);
+}
+
+message RegisterRequest {
+
+    string public_key = 1;
+}
+
+message RegisterResponse {
+
+    string entity_id = 1;
+}
+
+message HealthCheckResponse {
+
+    string status = 1;
+}
+
+message GetMarketsResponse {
+
+    repeated string markets = 1;
+}
+service AdminService {
+    rpc Register (RegisterRequest) returns (RegisterResponse);
+    rpc HealthCheck (google.protobuf.Empty) returns (HealthCheckResponse);
+    rpc GetMarkets (google.protobuf.Empty) returns (GetMarketsResponse);
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -26,12 +26,6 @@ echo "░  ░  ░  ░░         ░   ▒     ░░   ░ ░ ░░ ░ �
 echo "      ░                 ░  ░   ░     ░  ░         ░      ░          ░  ░         ";
 echo "                                                                                 ";
 
-# Setting this env is ONLY required for a hosted broker setup.
-#
-# This address is used during the build process so that certs can be generated
-# correctly for a hosted (remote) broker daemon.
-RELAYER_PROTO_VERSION='master'
-
 # The directory where we store the sparkswap configuration, certs, and keys.
 SPARKSWAP_DIRECTORY=~/.sparkswap
 
@@ -40,6 +34,11 @@ NO_CLI="false"
 NO_DOCKER="false"
 NO_CERTS="false"
 NO_IDENTITY="false"
+
+# Setting this env is ONLY required for a hosted broker setup.
+#
+# This address is used during the build process so that certs can be generated
+# correctly for a hosted (remote) broker daemon.
 EXTERNAL_ADDRESS="localhost"
 LOCAL="false"
 for i in "$@"
@@ -83,15 +82,6 @@ fi
 echo ""
 echo "It's time to BUILD! All resistance is futile."
 echo ""
-
-echo "Downloading relayer proto files"
-# Blow away proto directory and recreate or git-clone will yell at us
-if [ -d ./proto ]; then
-  rm -rf ./proto
-fi
-
-git clone -b ${RELAYER_PROTO_VERSION} https://github.com/sparkswap/relayer-proto.git ./proto
-rm -rf ./proto/.git
 
 #############################################
 # Keypair Generation for SSL to the broker
@@ -154,6 +144,26 @@ elif [[ -f "$ID_PUB_KEY" ]]; then
 elif [ "$NO_IDENTITY" != "true" ]; then
   openssl ecparam -name prime256v1 -genkey -noout -out $ID_PRIV_KEY
   openssl ec -in $ID_PRIV_KEY -pubout -out $ID_PUB_KEY
+fi
+
+# Create proto directories so they can be copied by Docker
+mkdir -p ./proto
+mkdir -p ./proto-local
+
+if [ "$LOCAL" == "true" ]; then
+  # When running locally we can rely on our local proto files from the Relayer
+  echo "Downloading relayer proto files"
+  # Blow away proto directory and recreate or git-clone will yell at us
+  if [ -d ./proto-local ]; then
+    rm -rf ./proto-local
+  fi
+
+  # Using anything other than "master" is unsupported since this repository does
+  # not correctly pick up all Relayer changes and only changes that affect the proto
+  # files themselves.
+  RELAYER_PROTO_VERSION='master'
+  git clone -b ${RELAYER_PROTO_VERSION} https://github.com/sparkswap/relayer-proto.git ./proto-local
+  rm -rf ./proto-local/.git
 fi
 
 if [ "$NO_DOCKER" == "false" ]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -146,24 +146,23 @@ elif [ "$NO_IDENTITY" != "true" ]; then
   openssl ec -in $ID_PRIV_KEY -pubout -out $ID_PUB_KEY
 fi
 
-# Create proto directories so they can be copied by Docker
-mkdir -p ./proto
-mkdir -p ./proto-local
-
 if [ "$LOCAL" == "true" ]; then
   # When running locally we can rely on our local proto files from the Relayer
   echo "Downloading relayer proto files"
   # Blow away proto directory and recreate or git-clone will yell at us
-  if [ -d ./proto-local ]; then
-    rm -rf ./proto-local
+  if [ -d ./proto ]; then
+    rm -rf ./proto
   fi
 
   # Using anything other than "master" is unsupported since this repository does
   # not correctly pick up all Relayer changes and only changes that affect the proto
   # files themselves.
   RELAYER_PROTO_VERSION='master'
-  git clone -b ${RELAYER_PROTO_VERSION} https://github.com/sparkswap/relayer-proto.git ./proto-local
-  rm -rf ./proto-local/.git
+
+  # Note: this will override the proto files in version control. You should not commit changes
+  # to these files unless it is part of the change you are making to the Broker.
+  git clone -b ${RELAYER_PROTO_VERSION} https://github.com/sparkswap/relayer-proto.git ./proto
+  rm -rf ./proto/.git
 fi
 
 if [ "$NO_DOCKER" == "false" ]; then


### PR DESCRIPTION
## Description
This change commits the Relayer's proto files to the Broker's version control rather than downloading it from GitHub during the build.

To support local development it still supports downloading from GitHub using the `build-local` command.

Because Docker can't do conditional copying, both the local and packaged proto files are copied into the built container.

## Todos
- [x] Tests
- [x] Documentation
