### PR TITLE
remove IP address from install script

### DIFF
--- a/scripts/env-setup.sh
+++ b/scripts/env-setup.sh
@@ -5,7 +5,6 @@
 #
 # Options:
 # -n=, --network=[network] 'm' for MainNet, 'r' for RegTest hosted by Sparkswap (removes prompt)
-# -i=, --public-ip=[ip address] Your public IP Address (removes prompt)
 #
 ##########################################################
 RED='\033[0;31m'
@@ -13,16 +12,11 @@ NC='\033[0m'
 
 # parse options
 NETWORK=""
-IP_ADDRESS=""
 for i in "$@"
 do
 case $i in
     -n=*|--network=*)
     NETWORK="${i#*=}"
-
-    ;;
-    -i=*|--public-ip=*)
-    IP_ADDRESS="${i#*=}"
 
     ;;
     *)
@@ -53,23 +47,6 @@ elif [ $NETWORK = 'r' ]; then
 else
   echo "$NETWORK is not a valid option for network"
   exit 1
-fi
-
-# Set the external btc/ltc addresses in the .env file based on user public IP address
-if [ "$IP_ADDRESS" == "" ]; then
-  echo "Enter your public IP address:"
-  read IP_ADDRESS
-fi
-
-OS=`uname`
-if [ "$OS" = 'Darwin' ]; then
-  # for MacOS
-  sed -i '' -e "s/^EXTERNAL_BTC_ADDRESS.*/EXTERNAL_BTC_ADDRESS=$IP_ADDRESS/" .env
-  sed -i '' -e "s/^EXTERNAL_LTC_ADDRESS.*/EXTERNAL_LTC_ADDRESS=$IP_ADDRESS/" .env
-else
-  # for Linux and Windows
-  sed -i'' -e "s/^EXTERNAL_BTC_ADDRESS.*/EXTERNAL_BTC_ADDRESS=$IP_ADDRESS/" .env
-  sed -i'' -e "s/^EXTERNAL_LTC_ADDRESS.*/EXTERNAL_LTC_ADDRESS=$IP_ADDRESS/" .env
 fi
 
 array=(BTC_RPC_USER

--- a/setup-scripts/install.sh
+++ b/setup-scripts/install.sh
@@ -6,7 +6,6 @@
 # Options:
 # -y, --yes                     answer "Yes" to all yes/no prompts to allow for non-interactive scripting
 # -n=, --network=[network]      'm' for MainNet, 'r' for RegTest hosted by Sparkswap (removes prompt)
-# -i=, --public-ip=[ip address] Your public IP Address (removes prompt)
 # -b, --build                   build the images locally instead of pulling from dockerhub
 #
 #################################
@@ -73,7 +72,6 @@ compare_versions () {
 # parse options
 FORCE_YES="false"
 NETWORK=""
-IP_ADDRESS=""
 BUILD="false"
 for i in "$@"
 do
@@ -84,10 +82,6 @@ case $i in
     ;;
     -n=*|--network=*)
     NETWORK="${i#*=}"
-
-    ;;
-    -i=*|--public-ip=*)
-    IP_ADDRESS="${i#*=}"
 
     ;;
     -b|--build)
@@ -259,11 +253,11 @@ else
 
   if [[ $BUILD == "true" ]]; then
     # Build images locally for the broker
-    npm run build -- -e=$IP_ADDRESS
+    npm run build
   else
     # Run the broker build to generate certs and identity, but do not build
     # docker images
-    npm run build -- -e=$IP_ADDRESS --no-docker
+    npm run build -- --no-docker
   fi
 fi
 
@@ -294,7 +288,7 @@ cd broker
 
 # Set up environment
 msg "Setting up your Broker" $WHITE
-npm run env-setup -- -n=$NETWORK -i=$IP_ADDRESS
+npm run env-setup -- -n=$NETWORK
 
 # Install CLI
 msg "Installing the CLI" $WHITE


### PR DESCRIPTION
## Description
This change removes the external IP from the install script since it is no longer required for LND and is only used for controlling the broker remotely.

## Related PRs
#447 
