### PR TITLE
Install: Reduce dependencies in install script

### DIFF
--- a/docker/openssl/Dockerfile
+++ b/docker/openssl/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine
+RUN apk add --no-cache ca-certificates openssl
+WORKDIR /root
+ENTRYPOINT [ "openssl" ]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,7 +6,7 @@
 # Options:
 # -c, --no-cli                    do not copy certs for local cli installation
 # -d, --no-docker                 do not build docker images
-# -e=, --external-address=        your public IP address (removes prompt)
+# -e=, --external-address=        your public IP address (used for cert generation)
 # -i, --no-identity               does not generate keys for the daemons identity
 # -n, --no-certs                  does not re-generate tls certs for the daemon
 #
@@ -79,8 +79,7 @@ esac
 done
 
 if [ "$EXTERNAL_ADDRESS" == "" ]; then
-  echo "Please provide your public IP address or hostname"
-  read EXTERNAL_ADDRESS
+  EXTERNAL_ADDRESS="localhost"
 fi
 
 # Create an openssl docker image if the command does not exist

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -79,6 +79,19 @@ if [ "$EXTERNAL_ADDRESS" == "" ]; then
   read EXTERNAL_ADDRESS
 fi
 
+# Create an openssl docker image if the command does not exist
+if [ "$(command -v openssl)" == "" ]; then
+  echo "WARNING: openssl is not installed, using a Docker image instead."
+
+  if [ "$NO_DOCKER" == "false" ]; then
+    echo "Building openssl docker image"
+    docker build -t sparkswap/openssl -f ./docker/openssl/Dockerfile ./
+  fi
+
+  alias openssl="docker run sparkswap/openssl"
+fi
+
+
 echo ""
 echo "It's time to BUILD! All resistance is futile."
 echo ""
@@ -107,18 +120,18 @@ elif [[ -f "$CERT_PATH" ]]; then
 elif [ "$NO_CERTS" != "true" ]; then
   echo "Generating TLS certs for Broker Daemon"
 
-  openssl ecparam -genkey -name prime256v1 -out $KEY_PATH
-  openssl req -new -sha256 -key $KEY_PATH -out $CSR_PATH \
+  openssl ecparam -genkey -name prime256v1 > $KEY_PATH
+  openssl req -new -sha256 -key $KEY_PATH \
     -reqexts SAN \
     -extensions SAN \
     -config <(cat /etc/ssl/openssl.cnf \
       <(printf "\n[SAN]\nsubjectAltName=DNS:$EXTERNAL_ADDRESS,DNS:localhost")) \
-    -subj "/CN=$EXTERNAL_ADDRESS/O=sparkswap"
-  openssl req -x509 -sha256 -key $KEY_PATH -in $CSR_PATH -out $CERT_PATH -days 36500 \
+    -subj "/CN=$EXTERNAL_ADDRESS/O=sparkswap" > $CSR_PATH
+  openssl req -x509 -sha256 -key $KEY_PATH -in $CSR_PATH -days 36500 \
     -reqexts SAN \
     -extensions SAN \
     -config <(cat /etc/ssl/openssl.cnf \
-      <(printf "\n[SAN]\nsubjectAltName=DNS:$EXTERNAL_ADDRESS,DNS:localhost"))
+      <(printf "\n[SAN]\nsubjectAltName=DNS:$EXTERNAL_ADDRESS,DNS:localhost")) > $CERT_PATH
 
   rm -f $CSR_PATH
 fi
@@ -142,8 +155,8 @@ if [[ -f "$ID_PRIV_KEY" ]]; then
 elif [[ -f "$ID_PUB_KEY" ]]; then
   echo "WARNING: ID Public Key already exists for Broker Daemon. Skipping ID generation"
 elif [ "$NO_IDENTITY" != "true" ]; then
-  openssl ecparam -name prime256v1 -genkey -noout -out $ID_PRIV_KEY
-  openssl ec -in $ID_PRIV_KEY -pubout -out $ID_PUB_KEY
+  openssl ecparam -name prime256v1 -genkey -noout > $ID_PRIV_KEY
+  openssl ec -in $ID_PRIV_KEY -pubout > $ID_PUB_KEY
 fi
 
 if [ "$LOCAL" == "true" ]; then

--- a/setup-scripts/install.sh
+++ b/setup-scripts/install.sh
@@ -22,6 +22,9 @@ RED='\033[0;31m'
 GRAY='\033[0;37m'
 NC='\033[0m' # No Color
 
+# The directory where we store the sparkswap configuration, certs, and keys.
+SPARKSWAP_DIRECTORY=~/.sparkswap
+
 BROKER_VERSION="v0.5.2-beta"
 
 # Set the minimum to approx. 6 months prior
@@ -296,6 +299,13 @@ cd broker
 msg "Setting up your Broker" $WHITE
 bash ./scripts/env-setup.sh -n=$NETWORK
 
+# Create the sparkswap config file
+if [ ! -f "$SPARKSWAP_DIRECTORY/config.js" ]; then
+  cp -n ./broker-cli/sample-config.js "$SPARKSWAP_DIRECTORY/config.js"
+else
+  msg "You already have a Sparkswap configuration file, skipping creation."
+fi
+
 msg "Creating random username and password" $WHITE
 ## Re-do this step so we can copy into the config
 array=(RPC_USER:rpcUser
@@ -316,11 +326,11 @@ do
   if [ $(uname) = 'Darwin' ]; then
     # for MacOS
     sed -i '' -e "s/^${PARTS[0]}.*/${PARTS[0]}=$string/" .env
-    sed -i '' -e "s/${PARTS[1]}.*/${PARTS[1]}: '$string'${ENDOFLINE}/" ~/.sparkswap/config.js
+    sed -i '' -e "s/${PARTS[1]}.*/${PARTS[1]}: '$string'${ENDOFLINE}/" "${SPARKSWAP_DIRECTORY}/config.js"
   else
     # for Linux and Windows
     sed -i'' -e "s/^${PARTS[0]}.*/${PARTS[0]}=$string/" .env
-    sed -i'' -e "s/${PARTS[1]}.*/${PARTS[1]}: '$string'${ENDOFLINE}/" ~/.sparkswap/config.js
+    sed -i'' -e "s/${PARTS[1]}.*/${PARTS[1]}: '$string'${ENDOFLINE}/" "${SPARKSWAP_DIRECTORY}/config.js"
   fi
 done
 

--- a/setup-scripts/install.sh
+++ b/setup-scripts/install.sh
@@ -289,7 +289,7 @@ if [[ "$BUILD" == "true" ]]; then
   else
     # Detect LND-Engine version
     msg "Detecting LND Version from the Broker" $WHITE
-    LND_ENGINE_VERSION=$(sed -n 's/.*github:sparkswap\/lnd-engine#\(.*\)".*/\1/p' package.json)
+    LND_ENGINE_VERSION=$(sed -n 's/.*github:sparkswap\/lnd-engine#\(.*\)".*/\1/p' broker/package.json)
     msg "Found LND Engine version $LND_ENGINE_VERSION" $GREEN
 
     # Download the LND Engine and extract it

--- a/setup-scripts/install.sh
+++ b/setup-scripts/install.sh
@@ -352,5 +352,6 @@ docker-compose up -d
 echo ""
 echo ""
 msg "All done with installation!" $GREEN
+msg "Change directories to your Broker with ${NC}${BLUE}cd sparkswap/broker${NC}" $WHITE
 msg "Go into your container with ${NC}${BLUE}docker-compose exec sparkswapd bash${NC}" $WHITE
 msg "And run ${NC}${BLUE}sparkswap healthcheck${NC}${WHITE} to see how things are looking." $WHITE

--- a/setup-scripts/install.sh
+++ b/setup-scripts/install.sh
@@ -238,8 +238,9 @@ else
 
   # Download the Broker and extract it
   curl -L "https://github.com/sparkswap/broker/archive/${BROKER_VERSION}.tar.gz" -o "broker-${BROKER_VERSION}.tar.gz"
-  tar -xzf "broker-${BROKER_VERSION}.tar.gz"
-  mv "broker-${BROKER_VERSION}" broker
+  mkdir broker
+  tar -xzf "broker-${BROKER_VERSION}.tar.gz" -C broker --strip-components=1
+  rm "broker-${BROKER_VERSION}.tar.gz"
 
   # Move into the Broker directory to build it
   cd broker
@@ -272,8 +273,9 @@ if [[ "$BUILD" == "true" ]]; then
 
     # Download the LND Engine and extract it
     curl -L "https://github.com/sparkswap/lnd-engine/archive/${LND_ENGINE_VERSION}.tar.gz" -o "lnd-engine-${LND_ENGINE_VERSION}.tar.gz"
-    tar -xzf "lnd-engine-${LND_ENGINE_VERSION}.tar.gz"
-    mv "lnd-engine-${LND_ENGINE_VERSION}" lnd-engine
+    mkdir lnd-engine
+    tar -xzf "lnd-engine-${LND_ENGINE_VERSION}.tar.gz" -C lnd-engine --strip-components=1
+    rm "lnd-engine-${LND_ENGINE_VERSION}.tar.gz"
 
     # Build images locally for the lnd-engine
     (cd lnd-engine && bash ./scripts/build.sh)

--- a/setup-scripts/install.sh
+++ b/setup-scripts/install.sh
@@ -323,4 +323,6 @@ docker-compose up -d
 
 echo ""
 echo ""
-msg "All done with installation! Try \`${NC}${BLUE}sparkswap healthcheck${NC}${GREEN}\` to see how things are looking." $GREEN
+msg "All done with installation!" $GREEN
+msg "Go into your container with ${NC}${BLUE}docker-compose exec bash${NC}" $WHITE
+msg "And run ${NC}${BLUE}sparkswap healthcheck${NC}${WHITE} to see how things are looking." $WHITE

--- a/setup-scripts/install.sh
+++ b/setup-scripts/install.sh
@@ -318,5 +318,5 @@ docker-compose up -d
 echo ""
 echo ""
 msg "All done with installation!" $GREEN
-msg "Go into your container with ${NC}${BLUE}docker-compose exec bash${NC}" $WHITE
+msg "Go into your container with ${NC}${BLUE}docker-compose exec sparkswapd bash${NC}" $WHITE
 msg "And run ${NC}${BLUE}sparkswap healthcheck${NC}${WHITE} to see how things are looking." $WHITE

--- a/setup-scripts/install.sh
+++ b/setup-scripts/install.sh
@@ -234,9 +234,14 @@ msg "Installing the Sparkswap Broker (sparkswapd)" $WHITE
 if [ -d "broker" ]; then
   msg "You already have a folder for the broker. Skipping" $YELLOW
   msg "If you need to re-install, remove the folder and try again." $YELLOW
-  cd broker
 else
-  git clone -b "$BROKER_VERSION" --single-branch --depth 1 https://github.com/sparkswap/broker.git
+
+  # Download the Broker and extract it
+  curl -L "https://github.com/sparkswap/broker/archive/${BROKER_VERSION}.tar.gz" -o "broker-${BROKER_VERSION}.tar.gz"
+  tar -xzf "broker-${BROKER_VERSION}.tar.gz"
+  mv "broker-${BROKER_VERSION}" broker
+
+  # Move into the Broker directory to build it
   cd broker
 
   if [[ $BUILD == "true" ]]; then
@@ -247,10 +252,10 @@ else
     # docker images
     bash ./scripts/build.sh -e=$IP_ADDRESS --no-docker
   fi
-fi
 
-# Move back a directory to the `sparkswap` root
-cd ..
+  # Move back a directory to the `sparkswap` root
+  cd ..
+fi
 
 # Install LND Engine
 if [[ "$BUILD" == "true" ]]; then
@@ -265,7 +270,11 @@ if [[ "$BUILD" == "true" ]]; then
     LND_ENGINE_VERSION=$(sed -n 's/.*github:sparkswap\/lnd-engine#\(.*\)".*/\1/p' package.json)
     msg "Found LND Engine version $LND_ENGINE_VERSION" $GREEN
 
-    git clone -b "$LND_ENGINE_VERSION" --single-branch --depth 1 https://github.com/sparkswap/lnd-engine.git
+    # Download the LND Engine and extract it
+    curl -L "https://github.com/sparkswap/lnd-engine/archive/${LND_ENGINE_VERSION}.tar.gz" -o "lnd-engine-${LND_ENGINE_VERSION}.tar.gz"
+    tar -xzf "lnd-engine-${LND_ENGINE_VERSION}.tar.gz"
+    mv "lnd-engine-${LND_ENGINE_VERSION}" lnd-engine
+
     # Build images locally for the lnd-engine
     (cd lnd-engine && bash ./scripts/build.sh)
   fi


### PR DESCRIPTION
## Description
This change reduces the overall number of dependencies in the install script to make installation easier and have fewer required pre-cursor steps.

Specifically, it removes dependency on:
- `git` (replaced with `curl` and `tar`)
- `npm` (replaced with `bash`)
- `node` and `nvm` (removed installation of the CLI instead, relying on #445 )
- `openssl` (published openssl in purpose-built container)

## Related PRs
#445 was a required pre-cursor
