### PR TITLE
Fix - Install script exits when `compare_versions` is called

### DIFF
--- a/setup-scripts/install.sh
+++ b/setup-scripts/install.sh
@@ -32,6 +32,9 @@ MIN_DOCKER_COMPOSE_VERSION=1.23.0
 CURRENT_DOCKER_VERSION=18.09
 CURRENT_DOCKER_COMPOSE_VERSION=1.24
 
+# Used for generating download URL
+RECOMMENDED_DOCKER_COMPOSE_VERSION=1.24.0
+
 # print a message with a color, like msg "my message" $GRAY
 msg () {
   echo -e "${GRAY}${TAG}${NC}:  $2$1${NC}"
@@ -127,9 +130,11 @@ if [ "$(command -v docker)" == "" ]; then
     LINUX_DISTRO=$(cat /etc/*-release | grep -E '^ID=' | sed 's/^.*=//' | tr -d \")
     msg "Looks like you're using Linux." $GREEN
     msg "To install Docker using the convenience script for Linux, run" $GREEN
-    msg "    $ curl -fsSL https://get.docker.com -o get-docker.sh" $WHITE
-    msg "    $ sudo sh get-docker.sh" $WHITE
+    msg "    curl -fsSL https://get.docker.com -o get-docker.sh && sudo sh get-docker.sh" $WHITE
     msg "Alternatively, you can follow Docker's installation steps for Linux (https://docs.docker.com/install/linux/docker-ce/$(echo $LINUX_DISTRO)/)" $GREEN
+    msg "You will also need Docker Compose. Once you've installed Docker in the previous step, run" $GREEN
+    msg "    curl -L \"https://github.com/docker/compose/releases/download/$RECOMMENDED_DOCKER_COMPOSE_VERSION/docker-compose-$(uname -s)-$(uname -m)\" -o /usr/local/bin/docker-compose && sudo chmod +x /usr/local/bin/docker-compose" $WHITE
+    msg "Alternatively, you can follow Docker's installation steps for Linux (https://docs.docker.com/compose/install/)" $GREEN
   elif [[ "$OSTYPE" == "darwin"* ]]; then
     msg "Looks like you're using Mac." $GREEN
     msg "You can use the following link to download and install Docker for Mac Version 2.0.0.3 or greater (this installs Docker Community Edition and Docker Compose)" $GREEN
@@ -180,8 +185,7 @@ if [ "$(command -v docker-compose)" == "" ]; then
   msg "Docker Compose is not installed." $RED
   if [[ "$OSTYPE" == "linux-gnu" ]]; then
     msg "To install Docker Compose using Linux, run" $GREEN
-    msg '    $ curl -L "https://github.com/docker/compose/releases/download/1.23.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose' $WHITE
-    msg "    $ sudo chmod +x /usr/local/bin/docker-compose" $WHITE
+    msg "    curl -L \"https://github.com/docker/compose/releases/download/$RECOMMENDED_DOCKER_COMPOSE_VERSION/docker-compose-$(uname -s)-$(uname -m)\" -o /usr/local/bin/docker-compose && sudo chmod +x /usr/local/bin/docker-compose" $WHITE
     msg "Alternatively, you can follow Docker's installation steps for Linux (https://docs.docker.com/compose/install/)" $GREEN
   elif [[ "$OSTYPE" == "darwin"* ]]; then
     msg "Looks like you're using Mac." $GREEN

--- a/setup-scripts/install.sh
+++ b/setup-scripts/install.sh
@@ -38,10 +38,12 @@ msg () {
 }
 
 # Compares two versions using dot notation (e.g. 1.2.3 < 1.2.4)
+compare_result=""
 compare_versions () {
   if [[ $1 == $2 ]]
   then
-    return 0
+    compare_result=0
+    return
   fi
   local IFS=.
   local i ver1=($1) ver2=($2)
@@ -59,14 +61,17 @@ compare_versions () {
     fi
     if ((10#${ver1[i]} > 10#${ver2[i]}))
     then
-      return 1
+      compare_result=1
+      return
     fi
     if ((10#${ver1[i]} < 10#${ver2[i]}))
     then
-      return 2
+      compare_result=2
+      return
     fi
   done
-  return 0
+  compare_result=0
+  return
 }
 
 # parse options
@@ -138,7 +143,7 @@ fi
 # Ensure version of Docker meets minimum requirements. Fail install if not
 DOCKER_VERSION=$(docker version | grep Version | head -n 1 | grep -oE '[.0-9]*$')
 compare_versions $DOCKER_VERSION $MIN_DOCKER_VERSION
-if [[ $? == 2 ]]; then
+if [[ $compare_result == 2 ]]; then
   msg "Your version of Docker ($DOCKER_VERSION) is older than the minimum required version. Please upgrade to version $CURRENT_DOCKER_VERSION or greater." $RED
 
   if [[ "$OSTYPE" == "linux-gnu" ]]; then
@@ -156,7 +161,7 @@ fi
 
 # Check if running the latest version of Docker. Warn if not and continue with install
 compare_versions $DOCKER_VERSION $CURRENT_DOCKER_VERSION
-if [[ $? == 2 ]]; then
+if [[ $compare_result == 2 ]]; then
   msg "Your version of Docker ($DOCKER_VERSION) isn't up to date. It's recommended that you upgrade to version $CURRENT_DOCKER_VERSION or greater." $YELLOW
 
   if [[ "$OSTYPE" == "linux-gnu" ]]; then
@@ -191,7 +196,7 @@ fi
 # Ensure version of Docker Compose meets minimum requirements. Fail install if not
 DOCKER_COMPOSE_VERSION=$(docker-compose version | grep 'docker-compose version' | sed 's/,.*//' | grep -oE '[.0-9]*$')
 compare_versions $DOCKER_COMPOSE_VERSION $MIN_DOCKER_COMPOSE_VERSION
-if [[ $? == 2 ]]; then
+if [[ $compare_result == 2 ]]; then
   msg "Your version of Docker Compose ($DOCKER_COMPOSE_VERSION) is older than the minimum required version. Please upgrade to version $CURRENT_DOCKER_COMPOSE_VERSION or greater." $RED
 
   if [[ "$OSTYPE" == "linux-gnu" ]]; then
@@ -207,7 +212,7 @@ fi
 
 # Check if running the latest version of Docker Compose. Warn if not and continue with install
 compare_versions $DOCKER_COMPOSE_VERSION $CURRENT_DOCKER_COMPOSE_VERSION
-if [[ $? == 2 ]]; then
+if [[ $compare_result == 2 ]]; then
   msg "Your version of Docker Compose ($DOCKER_COMPOSE_VERSION) isn't up to date. It's recommended you upgrade to version $CURRENT_DOCKER_COMPOSE_VERSION or greater." $YELLOW
 
   if [[ "$OSTYPE" == "linux-gnu" ]]; then

--- a/setup-scripts/install.sh
+++ b/setup-scripts/install.sh
@@ -129,12 +129,14 @@ if [ "$(command -v docker)" == "" ]; then
     # Get the version of Linux distribution
     LINUX_DISTRO=$(cat /etc/*-release | grep -E '^ID=' | sed 's/^.*=//' | tr -d \")
     msg "Looks like you're using Linux." $GREEN
-    msg "To install Docker using the convenience script for Linux, run" $GREEN
-    msg "    curl -fsSL https://get.docker.com -o get-docker.sh && sudo sh get-docker.sh" $WHITE
-    msg "Alternatively, you can follow Docker's installation steps for Linux (https://docs.docker.com/install/linux/docker-ce/$(echo $LINUX_DISTRO)/)" $GREEN
-    msg "You will also need Docker Compose. Once you've installed Docker in the previous step, run" $GREEN
-    msg "    curl -L \"https://github.com/docker/compose/releases/download/$RECOMMENDED_DOCKER_COMPOSE_VERSION/docker-compose-$(uname -s)-$(uname -m)\" -o /usr/local/bin/docker-compose && sudo chmod +x /usr/local/bin/docker-compose" $WHITE
-    msg "Alternatively, you can follow Docker's installation steps for Linux (https://docs.docker.com/compose/install/)" $GREEN
+    msg "You will need to install Docker and Docker Compose. To install both, run" $GREEN
+    echo ""
+    echo "curl -fsSL https://get.docker.com -o get-docker.sh && \\"
+    echo "sudo sh get-docker.sh && \\"
+    echo "curl -L \"https://github.com/docker/compose/releases/download/$RECOMMENDED_DOCKER_COMPOSE_VERSION/docker-compose-$(uname -s)-$(uname -m)\" -o /usr/local/bin/docker-compose && \\"
+    echo "sudo chmod +x /usr/local/bin/docker-compose"
+    echo ""
+    msg "Alternatively, you can follow Docker's installation steps for Linux (https://docs.docker.com/install/linux/docker-ce/$(echo $LINUX_DISTRO)/) and Docker's installation steps for Docker Compose (https://docs.docker.com/compose/install/)" $GREEN
   elif [[ "$OSTYPE" == "darwin"* ]]; then
     msg "Looks like you're using Mac." $GREEN
     msg "You can use the following link to download and install Docker for Mac Version 2.0.0.3 or greater (this installs Docker Community Edition and Docker Compose)" $GREEN
@@ -186,7 +188,7 @@ if [ "$(command -v docker-compose)" == "" ]; then
   if [[ "$OSTYPE" == "linux-gnu" ]]; then
     msg "To install Docker Compose using Linux, run" $GREEN
     msg "    curl -L \"https://github.com/docker/compose/releases/download/$RECOMMENDED_DOCKER_COMPOSE_VERSION/docker-compose-$(uname -s)-$(uname -m)\" -o /usr/local/bin/docker-compose && sudo chmod +x /usr/local/bin/docker-compose" $WHITE
-    msg "Alternatively, you can follow Docker's installation steps for Linux (https://docs.docker.com/compose/install/)" $GREEN
+    msg "Alternatively, you can follow Docker's installation steps for Docker Compose (https://docs.docker.com/compose/install/)" $GREEN
   elif [[ "$OSTYPE" == "darwin"* ]]; then
     msg "Looks like you're using Mac." $GREEN
     msg "You can use the following link to install Docker Compose for Mac." $GREEN


### PR DESCRIPTION
## Description
This PR fixes the implementation of `compare_verison`, which was recently introduced to the install script.

`compare_versions` previously returned a value based on the result of the string comparison (comparing versions using dot notation i.e. "1.2.3" < "1.2.4"). Since the install script uses `set -e`, the script fails when any command return a non 0 exit code. `compare_versions` has been updated to set a variable to the result of the comparison.

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
