### PR TITLE
Restart LND on errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,7 @@ services:
     logging:
       options:
         max-size: 50m
+    restart: on-failure
 
   lnd_ltc:
     image: sparkswap/lnd_ltc:0.5.0-beta-rc2
@@ -91,6 +92,7 @@ services:
     logging:
       options:
         max-size: 50m
+    restart: on-failure
 
 volumes:
   shared:


### PR DESCRIPTION
## Description
This change causes LND to restart on errors. LND will still be locked and will need to be manually unlocked, but this is better than simply being down.

In particular, this solves an edge case where LND starts up faster than the underlying litecoind/bitcoind and shuts down. Instead, it will restart in a locked state.
