### PR TITLE
remove cli installation from setup script

### DIFF
--- a/setup-scripts/install.sh
+++ b/setup-scripts/install.sh
@@ -161,11 +161,6 @@ cd broker
 msg "Setting up your Broker" $WHITE
 npm run env-setup -- -n=$NETWORK -i=$IP_ADDRESS
 
-# Install CLI
-msg "Installing the CLI" $WHITE
-npm install -g ./broker-cli
-(cd $(dirname $(which sparkswap))/../lib/node_modules/broker-cli && npm run install-config)
-
 msg "Creating random username and password" $WHITE
 ## Re-do this step so we can copy into the config
 array=(RPC_USER:rpcUser


### PR DESCRIPTION
## Description
We no longer do this by default. The cli is installed in the dockerfile, and if users want to use the remote version these instructions are in the docs. 

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
