### PR TITLE
Feature - Add --force-certs to build command

### DIFF
--- a/broker-cli/utils/grpc-deadline.js
+++ b/broker-cli/utils/grpc-deadline.js
@@ -4,17 +4,11 @@
  */
 
 /**
- * Default gRPC deadline timeout for rpc calls on the broker.
- *
- * We've chosen 10 seconds as a conservative deadline because some calls to
- * engine RPCs take around 5 seconds which produced false negatives when the default
- * was set at a lower number
- *
  * @constant
  * @type {number}
  * @default
  */
-const DEFAULT_TIMEOUT_IN_SECONDS = 10
+const DEFAULT_TIMEOUT_IN_SECONDS = 5
 
 /**
  * gRPC uses the term `deadline` which is a timeout feature that is an absolute

--- a/broker-cli/utils/grpc-deadline.js
+++ b/broker-cli/utils/grpc-deadline.js
@@ -4,11 +4,17 @@
  */
 
 /**
+ * Default gRPC deadline timeout for rpc calls on the broker.
+ *
+ * We've chosen 10 seconds as a conservative deadline because some calls to
+ * engine RPCs take around 5 seconds which produced false negatives when the default
+ * was set at a lower number
+ *
  * @constant
  * @type {number}
  * @default
  */
-const DEFAULT_TIMEOUT_IN_SECONDS = 5
+const DEFAULT_TIMEOUT_IN_SECONDS = 10
 
 /**
  * gRPC uses the term `deadline` which is a timeout feature that is an absolute

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,6 +9,8 @@
 # -e=, --external-address=        your public IP address (removes prompt)
 # -i, --no-identity               does not generate keys for the daemons identity
 # -n, --no-certs                  does not re-generate tls certs for the daemon
+# -l, --local                     run the build script for development
+# -f, --force-certs               forces the generation tls certs for the daemon
 #
 ################################################
 
@@ -105,9 +107,15 @@ KEY_PATH=$SPARKSWAP_DIRECTORY/secure/broker-rpc-tls.key
 CERT_PATH=$SPARKSWAP_DIRECTORY/secure/broker-rpc-tls.cert
 CSR_PATH=$SPARKSWAP_DIRECTORY/secure/broker-rpc-csr.csr
 
+# We want to fail out if the user has both cert flags set in the script
+if [[ "$FORCE_CERTS" == "true" ]] && [[ "$NO_CERTS" == "true " ]]; then
+  echo "ERROR: You cannot have --force-certs and --no-certs enabled at the same time"
+  exit 0
+fi
+
 # If we force the cert creation, we'll simply remove the certs from the sparkswap
 # directory, and then regenerate them below
-if [[ "$FORCE_CERTS" == "true" ]] && [[ "$NO_CERTS" != "true" ]]; then
+if [[ "$FORCE_CERTS" == "true" ]]; then
   echo "Removing existing Broker TLS certs: --force-certs set to true"
   rm -f $KEY_PATH
   rm -f $CERT_PATH

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -108,7 +108,7 @@ CERT_PATH=$SPARKSWAP_DIRECTORY/secure/broker-rpc-tls.cert
 CSR_PATH=$SPARKSWAP_DIRECTORY/secure/broker-rpc-csr.csr
 
 # We want to fail out if the user has both cert flags set in the script
-if [[ "$FORCE_CERTS" == "true" ]] && [[ "$NO_CERTS" == "true " ]]; then
+if [[ "$FORCE_CERTS" == "true" ]] && [[ "$NO_CERTS" == "true" ]]; then
   echo "ERROR: You cannot have --force-certs and --no-certs enabled at the same time"
   exit 0
 fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,6 +38,7 @@ NO_CLI="false"
 NO_DOCKER="false"
 NO_CERTS="false"
 NO_IDENTITY="false"
+FORCE_CERTS="false"
 
 # Setting this env is ONLY required for a hosted broker setup.
 #
@@ -72,6 +73,10 @@ case $i in
     LOCAL="true"
 
     ;;
+    -f|--force-certs)
+    FORCE_CERTS="true"
+
+    ;;
     *)
             # unknown option
     ;;
@@ -99,6 +104,14 @@ mkdir -p $SPARKSWAP_DIRECTORY/secure
 KEY_PATH=$SPARKSWAP_DIRECTORY/secure/broker-rpc-tls.key
 CERT_PATH=$SPARKSWAP_DIRECTORY/secure/broker-rpc-tls.cert
 CSR_PATH=$SPARKSWAP_DIRECTORY/secure/broker-rpc-csr.csr
+
+# If we force the cert creation, we'll simply remove the certs from the sparkswap
+# directory, and then regenerate them below
+if [[ "$FORCE_CERTS" == "true" ]] && [[ "$NO_CERTS" != "true" ]]; then
+  echo "Removing existing Broker TLS certs: --force-certs set to true"
+  rm -f $KEY_PATH
+  rm -f $CERT_PATH
+fi
 
 if [[ -f "$KEY_PATH" ]]; then
   echo "WARNING: TLS Private Key already exists at $KEY_PATH for Broker Daemon. Skipping cert generation"


### PR DESCRIPTION
## Description
This PR adds a `--force-certs` command so the user can regenerate the Broker's TLS certs and have the option to include an external address (needed for remote brokers)

**Usage:**

`bash ./scripts/build.sh --force-certs --external-address=my.ip.address`

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
