### PR TITLE
Whitelist HTTP Gateway methods

### DIFF
--- a/broker-daemon/bin/sparkswapd.js
+++ b/broker-daemon/bin/sparkswapd.js
@@ -49,6 +49,7 @@ program
   // Broker RPC configuration options
   .option('--rpc.address [rpc-address]', 'Add a host/port to listen for daemon RPC connections', validations.isHost, config.rpc.address)
   .option('--rpc.http-proxy-address [rpc-http-proxy-address]', 'Add a host/port to listen for HTTP RPC proxy connections', validations.isHost, config.rpc.httpProxyAddress)
+  .option('--rpc.http-proxy-methods [rpc-http-proxy-methods]', 'Comma-separated methods for the HTTP RPC Proxy', program.String, config.rpc.httpProxyMethods)
   .option('--rpc.user [rpc-user]', 'Broker rpc user name', program.String, config.rpc.user)
   .option('--rpc.pass [rpc-pass]', 'Broker rpc password', program.String, config.rpc.pass)
   .option('--rpc.pub-key-path [rpc-pub-key-path]', 'Location of the public key for the broker\'s rpc', validations.isFormattedPath, config.rpc.pubKeyPath)
@@ -82,6 +83,7 @@ program
       relayerCertPath,
       rpcAddress,
       rpcHttpProxyAddress,
+      rpcHttpProxyMethods: proxyMethods,
       rpcUser,
       rpcPass,
       rpcPubKeyPath: pubRpcKeyPath,
@@ -109,6 +111,9 @@ program
     // `markets` will be a string of market symbols that are delimited by a comma
     const marketNames = (markets || '').split(',').filter(m => m)
 
+    // proxyMethods will be a string of method names that are delimited by a comma
+    const rpcHttpProxyMethods = (proxyMethods || '').split(',').filter(p => p)
+
     const brokerOptions = {
       network,
       pubRpcKeyPath,
@@ -117,6 +122,7 @@ program
       pubIdKeyPath,
       rpcAddress,
       rpcHttpProxyAddress,
+      rpcHttpProxyMethods,
       interchainRouterAddress,
       dataDir,
       marketNames,
@@ -129,6 +135,7 @@ program
         relayerCertPath
       }
     }
+
     return new BrokerDaemon(brokerOptions).initialize()
   })
 

--- a/broker-daemon/bin/sparkswapd.spec.js
+++ b/broker-daemon/bin/sparkswapd.spec.js
@@ -51,7 +51,9 @@ describe('sparkswapd', () => {
         user: rpcUser,
         pass: rpcPass,
         pubKeyPath: pubRpcKeyPath,
-        privKeyPath: privRpcKeyPath
+        privKeyPath: privRpcKeyPath,
+        httpProxyAddress: rpcHttpProxyAddress,
+        httpProxyMethods: rpcHttpProxyMethods
       },
       relayer: {
         rpcHost: relayerRpcHost,
@@ -70,6 +72,8 @@ describe('sparkswapd', () => {
       rpcAddress,
       rpcUser,
       rpcPass,
+      rpcHttpProxyAddress,
+      rpcHttpProxyMethods: [rpcHttpProxyMethods],
       pubRpcKeyPath,
       privRpcKeyPath,
       relayerOptions: {
@@ -182,6 +186,28 @@ describe('sparkswapd', () => {
       sparkswapd(argv)
 
       expect(BrokerDaemon).to.have.been.calledWith(sinon.match({ rpcAddress }))
+    })
+
+    it('provides an rpc http proxy address', () => {
+      const rpcHttpProxyAddress = '0.0.0.0:9877'
+
+      argv.push('--rpc.http-proxy-address')
+      argv.push(rpcHttpProxyAddress)
+
+      sparkswapd(argv)
+
+      expect(BrokerDaemon).to.have.been.calledWith(sinon.match({ rpcHttpProxyAddress }))
+    })
+
+    it('provides a list of rpc http proxy methods', () => {
+      const rpcHttpProxyMethods = '/v1/admin/healthcheck,/v1/admin/id'
+
+      argv.push('--rpc.http-proxy-methods')
+      argv.push(rpcHttpProxyMethods)
+
+      sparkswapd(argv)
+
+      expect(BrokerDaemon).to.have.been.calledWith(sinon.match({ rpcHttpProxyMethods: ['/v1/admin/healthcheck', '/v1/admin/id'] }))
     })
   })
 

--- a/broker-daemon/broker-rpc/broker-rpc-server.js
+++ b/broker-daemon/broker-rpc/broker-rpc-server.js
@@ -69,7 +69,7 @@ class BrokerRPCServer {
    * @param {string} opts.pubKeyPath - Path to public key for broker rpc
    * @param {boolean} [opts.disableAuth=false]
    */
-  constructor ({ logger, engines, relayer, blockOrderWorker, orderbooks, pubKeyPath, privKeyPath, disableAuth = false, enableCors = false, rpcUser = null, rpcPass = null, rpcHttpProxyAddress, rpcHttpProxyMethods = ['*'], rpcAddress } = {}) {
+  constructor ({ logger, engines, relayer, blockOrderWorker, orderbooks, pubKeyPath, privKeyPath, disableAuth = false, enableCors = false, rpcUser = null, rpcPass = null, rpcHttpProxyAddress, rpcHttpProxyMethods, rpcAddress } = {}) {
     this.logger = logger
     this.engines = engines
     this.relayer = relayer

--- a/broker-daemon/broker-rpc/broker-rpc-server.js
+++ b/broker-daemon/broker-rpc/broker-rpc-server.js
@@ -69,7 +69,7 @@ class BrokerRPCServer {
    * @param {string} opts.pubKeyPath - Path to public key for broker rpc
    * @param {boolean} [opts.disableAuth=false]
    */
-  constructor ({ logger, engines, relayer, blockOrderWorker, orderbooks, pubKeyPath, privKeyPath, disableAuth = false, enableCors = false, rpcUser = null, rpcPass = null, rpcHttpProxyAddress, rpcAddress } = {}) {
+  constructor ({ logger, engines, relayer, blockOrderWorker, orderbooks, pubKeyPath, privKeyPath, disableAuth = false, enableCors = false, rpcUser = null, rpcPass = null, rpcHttpProxyAddress, rpcHttpProxyMethods = ['*'], rpcAddress } = {}) {
     this.logger = logger
     this.engines = engines
     this.relayer = relayer
@@ -85,7 +85,7 @@ class BrokerRPCServer {
 
     this.server = new grpc.Server(GRPC_SERVER_OPTIONS)
 
-    this.httpServer = createHttpServer(this.protoPath, this.rpcAddress, { disableAuth, enableCors, privKeyPath, pubKeyPath, logger })
+    this.httpServer = createHttpServer(this.protoPath, this.rpcAddress, { disableAuth, enableCors, privKeyPath, pubKeyPath, httpMethods: rpcHttpProxyMethods, logger })
 
     this.adminService = new AdminService(this.protoPath, { logger, relayer, engines, orderbooks, auth: this.auth })
     this.server.addService(this.adminService.definition, this.adminService.implementation)

--- a/broker-daemon/broker-rpc/broker-rpc-server.spec.js
+++ b/broker-daemon/broker-rpc/broker-rpc-server.spec.js
@@ -164,8 +164,7 @@ describe('BrokerRPCServer', () => {
         enableCors,
         privKeyPath,
         pubKeyPath,
-        rpcHttpProxyMethods:
-        httpMethods,
+        rpcHttpProxyMethods: httpMethods,
         logger
       })
 

--- a/broker-daemon/broker-rpc/broker-rpc-server.spec.js
+++ b/broker-daemon/broker-rpc/broker-rpc-server.spec.js
@@ -146,6 +146,39 @@ describe('BrokerRPCServer', () => {
       expect(server.httpServer).to.be.equal(httpServerStub)
     })
 
+    it('passes through http server options', () => {
+      const rpcAddress = '0.0.0.0:27492'
+      const rpcHttpProxyAddress = '0.0.0.0:27592'
+      const disableAuth = true
+      const enableCors = true
+      const privKeyPath = '/fake/privpath'
+      const pubKeyPath = '/fake/pubpath'
+      const httpMethods = ['/fake/method']
+      const logger = { fake: 'logger' }
+
+      // eslint-disable-next-line
+      new BrokerRPCServer({
+        rpcAddress,
+        rpcHttpProxyAddress,
+        disableAuth,
+        enableCors,
+        privKeyPath,
+        pubKeyPath,
+        rpcHttpProxyMethods:
+        httpMethods,
+        logger
+      })
+
+      expect(httpServer).to.have.been.calledWith(sinon.match.any, sinon.match.any, {
+        disableAuth,
+        enableCors,
+        privKeyPath,
+        pubKeyPath,
+        httpMethods,
+        logger
+      })
+    })
+
     it('creates a admin service', () => {
       const logger = 'mylogger'
       const relayer = 'myrelayer'

--- a/broker-daemon/config.json
+++ b/broker-daemon/config.json
@@ -19,6 +19,7 @@
   "rpc": {
     "address": "0.0.0.0:27492",
     "httpProxyAddress": "0.0.0.0:27592",
+    "httpProxyMethods": "*",
     "user": "sparkswap",
     "pass": "sparkswap",
     "pubKeyPath": "/secure/broker-rpc-tls.cert",

--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -96,7 +96,7 @@ class BrokerDaemon {
    * @param {string} opts.relayerOptions.certPath - Absolute path to the root certificate for the relayer
    * @returns {BrokerDaemon}
    */
-  constructor ({ network, privRpcKeyPath, pubRpcKeyPath, privIdKeyPath, pubIdKeyPath, rpcAddress, interchainRouterAddress, dataDir, marketNames, engines, disableAuth = false, rpcUser = null, rpcPass = null, relayerOptions = {}, rpcHttpProxyAddress, rpcHttpProxyMethods = [ '*' ] }) {
+  constructor ({ network, privRpcKeyPath, pubRpcKeyPath, privIdKeyPath, pubIdKeyPath, rpcAddress, interchainRouterAddress, dataDir, marketNames, engines, disableAuth = false, rpcUser = null, rpcPass = null, relayerOptions = {}, rpcHttpProxyAddress, rpcHttpProxyMethods }) {
     // Set a global namespace for sparkswap that we can use for properties not
     // related to application configuration
     if (!global.sparkswap) {

--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -96,7 +96,7 @@ class BrokerDaemon {
    * @param {string} opts.relayerOptions.certPath - Absolute path to the root certificate for the relayer
    * @returns {BrokerDaemon}
    */
-  constructor ({ network, privRpcKeyPath, pubRpcKeyPath, privIdKeyPath, pubIdKeyPath, rpcAddress, interchainRouterAddress, dataDir, marketNames, engines, disableAuth = false, rpcUser = null, rpcPass = null, relayerOptions = {}, rpcHttpProxyAddress }) {
+  constructor ({ network, privRpcKeyPath, pubRpcKeyPath, privIdKeyPath, pubIdKeyPath, rpcAddress, interchainRouterAddress, dataDir, marketNames, engines, disableAuth = false, rpcUser = null, rpcPass = null, relayerOptions = {}, rpcHttpProxyAddress, rpcHttpProxyMethods = [ '*' ] }) {
     // Set a global namespace for sparkswap that we can use for properties not
     // related to application configuration
     if (!global.sparkswap) {
@@ -149,6 +149,7 @@ class BrokerDaemon {
     this.rpcServer = new BrokerRPCServer({
       rpcAddress: this.rpcAddress,
       rpcHttpProxyAddress: this.rpcHttpProxyAddress,
+      rpcHttpProxyMethods,
       logger: this.logger,
       engines: this.engines,
       relayer: this.relayer,

--- a/broker-daemon/utils/create-http-server.js
+++ b/broker-daemon/utils/create-http-server.js
@@ -33,7 +33,7 @@ function handle404 (logger, req, res) {
  * @param {string} opts.logger
  * @returns {ExpressApp}
  */
-function createHttpServer (protoPath, rpcAddress, { disableAuth = false, enableCors = false, privKeyPath, pubKeyPath, logger }) {
+function createHttpServer (protoPath, rpcAddress, { disableAuth = false, enableCors = false, privKeyPath, pubKeyPath, httpMethods = ['*'], logger }) {
   const app = express()
 
   app.use(helmet())
@@ -59,7 +59,7 @@ function createHttpServer (protoPath, rpcAddress, { disableAuth = false, enableC
   }
 
   if (disableAuth) {
-    app.use('/', grpcGateway([`/${protoPath}`], rpcAddress))
+    app.use('/', grpcGateway([`/${protoPath}`], rpcAddress, { whitelist: httpMethods }))
     app.use(handle404.bind(null, logger))
     return app
   } else {
@@ -69,7 +69,7 @@ function createHttpServer (protoPath, rpcAddress, { disableAuth = false, enableC
 
     logger.debug(`Securing RPC proxy connections with TLS: key: ${privKeyPath}, cert: ${pubKeyPath}`)
 
-    app.use('/', grpcGateway([`/${protoPath}`], rpcAddress, channelCredentials))
+    app.use('/', grpcGateway([`/${protoPath}`], rpcAddress, { credentials: channelCredentials, whitelist: httpMethods }))
     app.use(handle404.bind(null, logger))
     return https.createServer({ key, cert }, app)
   }

--- a/broker-daemon/utils/create-http-server.js
+++ b/broker-daemon/utils/create-http-server.js
@@ -33,7 +33,7 @@ function handle404 (logger, req, res) {
  * @param {string} opts.logger
  * @returns {ExpressApp}
  */
-function createHttpServer (protoPath, rpcAddress, { disableAuth = false, enableCors = false, privKeyPath, pubKeyPath, httpMethods = ['*'], logger }) {
+function createHttpServer (protoPath, rpcAddress, { disableAuth = false, enableCors = false, privKeyPath, pubKeyPath, httpMethods, logger }) {
   const app = express()
 
   app.use(helmet())

--- a/broker-daemon/utils/create-http-server.spec.js
+++ b/broker-daemon/utils/create-http-server.spec.js
@@ -74,12 +74,6 @@ describe('createHttpServer', () => {
       expect(grpcGatewayStub).to.have.been.calledWith(sinon.match.any, sinon.match.any, sinon.match({ whitelist: options.httpMethods }))
     })
 
-    it('uses all methods by default', () => {
-      delete options.httpMethods
-      createHttpServer(protoPath, rpcAddress, options)
-      expect(grpcGatewayStub).to.have.been.calledWith(sinon.match.any, sinon.match.any, sinon.match({ whitelist: ['*'] }))
-    })
-
     it('returns the configured app', () => {
       expect(createHttpServer(protoPath, rpcAddress, options)).to.eql(expressStub)
     })

--- a/broker-daemon/utils/create-http-server.spec.js
+++ b/broker-daemon/utils/create-http-server.spec.js
@@ -172,12 +172,6 @@ describe('createHttpServer', () => {
       expect(grpcGatewayStub).to.have.been.calledWith(sinon.match.any, sinon.match.any, sinon.match({ whitelist: options.httpMethods }))
     })
 
-    it('uses all methods by default', () => {
-      delete options.httpMethods
-      createHttpServer(protoPath, rpcAddress, options)
-      expect(grpcGatewayStub).to.have.been.calledWith(sinon.match.any, sinon.match.any, sinon.match({ whitelist: ['*'] }))
-    })
-
     it('creates an https server', () => {
       expect(createServerStub).to.have.been.calledWith({ key: privKey, cert: pubKey }, expressStub)
     })

--- a/broker-daemon/utils/grpc-gateway.js
+++ b/broker-daemon/utils/grpc-gateway.js
@@ -38,6 +38,13 @@ const supportedMethods = Object.freeze([
 const paramRegex = /{(\w+)}/g
 
 /**
+ * Wildcard method to indicate every method is available for the whitelist
+ * @type {string}
+ * @constant
+ */
+const WILDCARD = '*'
+
+/**
  * @constant
  * @type {string}
  * @default
@@ -48,11 +55,13 @@ const GRPC_API_OPTION_ID = '.google.api.http'
  * generate middleware to proxy to gRPC defined by proto files
  * @param  {Array<string>} protoFiles - Filenames of protobuf-file
  * @param  {string} grpcLocation - HOST:PORT of gRPC server
- * @param  {ChannelCredentials} credentials - credential context (default: grpc.credentials.createInsecure())
- * @param  {boolean} [debug=true]
+ * @param  {Object} options
+ * @param  {ChannelCredentials} options.credentials - credential context (default: grpc.credentials.createInsecure())
+ * @param  {boolean} [options.debug=true]
+ * @param  {Array} [options.whitelist=['*']] - Whitelist of methods to include. By default, includes all methods as a wildcard.
  * @returns {Function} Middleware
  */
-const middleware = (protoFiles, grpcLocation, credentials = grpc.credentials.createInsecure(), debug = true) => {
+const middleware = (protoFiles, grpcLocation, { credentials = grpc.credentials.createInsecure(), debug = true, whitelist = [ WILDCARD ] } = {}) => {
   const router = express.Router()
   const clients = {}
   const protos = protoFiles.map(p => grpc.load(p))
@@ -71,7 +80,10 @@ const middleware = (protoFiles, grpcLocation, credentials = grpc.credentials.cre
         s.methods.forEach(m => {
           if (m.options[GRPC_API_OPTION_ID]) {
             supportedMethods.forEach(httpMethod => {
-              if (m.options[GRPC_API_OPTION_ID][httpMethod]) {
+              // We should limit methods to those included on the whitelist
+              const shouldGateway = whitelist.includes(WILDCARD) || whitelist.includes(m.options[GRPC_API_OPTION_ID][httpMethod])
+
+              if (m.options[GRPC_API_OPTION_ID][httpMethod] && shouldGateway) {
                 if (debug) {
                   console.log(httpMethod.toUpperCase().green, m.options[GRPC_API_OPTION_ID][httpMethod].blue)
                 }

--- a/broker-daemon/utils/grpc-gateway.js
+++ b/broker-daemon/utils/grpc-gateway.js
@@ -81,9 +81,9 @@ const middleware = (protoFiles, grpcLocation, { credentials = grpc.credentials.c
           if (m.options[GRPC_API_OPTION_ID]) {
             supportedMethods.forEach(httpMethod => {
               // We should limit methods to those included on the whitelist
-              const shouldGateway = whitelist.includes(WILDCARD) || whitelist.includes(m.options[GRPC_API_OPTION_ID][httpMethod])
+              const permitMethod = whitelist.includes(WILDCARD) || whitelist.includes(m.options[GRPC_API_OPTION_ID][httpMethod])
 
-              if (m.options[GRPC_API_OPTION_ID][httpMethod] && shouldGateway) {
+              if (m.options[GRPC_API_OPTION_ID][httpMethod] && permitMethod) {
                 if (debug) {
                   console.log(httpMethod.toUpperCase().green, m.options[GRPC_API_OPTION_ID][httpMethod].blue)
                 }

--- a/broker-daemon/utils/grpc-gateway.js
+++ b/broker-daemon/utils/grpc-gateway.js
@@ -82,7 +82,7 @@ const middleware = (protoFiles, grpcLocation, credentials = grpc.credentials.cre
 
                   if (debug) {
                     const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress
-                    console.log(`GATEWAY: ${(new Date()).toISOString().yellow} (${ip.blue}): /${pkg.replace(/\./g, '.'.white).blue}.${svc.blue}/${m.name.blue}(${params})`)
+                    console.log(`GATEWAY: ${(new Date()).toISOString().yellow} (${ip.blue}): /${pkg.replace(/\./g, '.'.white).blue}.${svc.blue}/${m.name.blue}(${JSON.stringify(params)})`)
                   }
 
                   try {
@@ -109,7 +109,7 @@ const middleware = (protoFiles, grpcLocation, credentials = grpc.credentials.cre
                     }
 
                     // gRPC call (e.g. broker.rpc.AdminService.HealthCheck)
-                    services[svc][implementationName]({}, meta, requestHandler)
+                    services[svc][implementationName](params, meta, requestHandler)
                   } catch (err) {
                     console.error(`${svc}.${m.name}: `.red, err.message.red)
                     console.trace()


### PR DESCRIPTION
## Description
This change:
- fixes some bugs with the grpcGateway
- adds a new configuration for a whitelist for HTTP methods

The intention behind both of these is to allow a Broker to be deployed with an HTTP proxy in place without opening up all methods for usage over HTTP. This may be useful for developing a read-only viewer, for example.

This is pretty much a bandaid on a more fully-featured solution which would include real authentication for the HTTP solution and would have multiple levels of authentication by method.

## Todos
- [x] Tests
- [x] Documentation
