### PR TITLE
Enable cors via config

### DIFF
--- a/broker-daemon/bin/sparkswapd.js
+++ b/broker-daemon/bin/sparkswapd.js
@@ -50,6 +50,7 @@ program
   .option('--rpc.address [rpc-address]', 'Add a host/port to listen for daemon RPC connections', validations.isHost, config.rpc.address)
   .option('--rpc.http-proxy-address [rpc-http-proxy-address]', 'Add a host/port to listen for HTTP RPC proxy connections', validations.isHost, config.rpc.httpProxyAddress)
   .option('--rpc.http-proxy-methods [rpc-http-proxy-methods]', 'Comma-separated methods for the HTTP RPC Proxy', program.String, config.rpc.httpProxyMethods)
+  .option('--rpc.http-proxy-cors [enable-cors]', 'Enable CORS for the HTTP RPC Proxy', program.BOOL, config.enableCors)
   .option('--rpc.user [rpc-user]', 'Broker rpc user name', program.String, config.rpc.user)
   .option('--rpc.pass [rpc-pass]', 'Broker rpc password', program.String, config.rpc.pass)
   .option('--rpc.pub-key-path [rpc-pub-key-path]', 'Location of the public key for the broker\'s rpc', validations.isFormattedPath, config.rpc.pubKeyPath)
@@ -79,6 +80,7 @@ program
       idPrivKeyPath: privIdKeyPath,
       markets,
       disableAuth,
+      enableCors
       relayerRpcHost,
       relayerCertPath,
       rpcAddress,
@@ -128,6 +130,7 @@ program
       marketNames,
       engines,
       disableAuth,
+      enableCors,
       rpcUser,
       rpcPass,
       relayerOptions: {

--- a/broker-daemon/bin/sparkswapd.js
+++ b/broker-daemon/bin/sparkswapd.js
@@ -80,12 +80,12 @@ program
       idPrivKeyPath: privIdKeyPath,
       markets,
       disableAuth,
-      enableCors
       relayerRpcHost,
       relayerCertPath,
       rpcAddress,
       rpcHttpProxyAddress,
       rpcHttpProxyMethods: proxyMethods,
+      rpcHttpProxyCors: enableCors,
       rpcUser,
       rpcPass,
       rpcPubKeyPath: pubRpcKeyPath,

--- a/broker-daemon/bin/sparkswapd.spec.js
+++ b/broker-daemon/bin/sparkswapd.spec.js
@@ -46,6 +46,7 @@ describe('sparkswapd', () => {
       idPrivKeyPath: privIdKeyPath,
       markets,
       disableAuth,
+      enableCors,
       rpc: {
         address: rpcAddress,
         user: rpcUser,
@@ -69,6 +70,7 @@ describe('sparkswapd', () => {
       privIdKeyPath,
       marketNames: [markets],
       disableAuth,
+      enableCors,
       rpcAddress,
       rpcUser,
       rpcPass,
@@ -208,6 +210,15 @@ describe('sparkswapd', () => {
       sparkswapd(argv)
 
       expect(BrokerDaemon).to.have.been.calledWith(sinon.match({ rpcHttpProxyMethods: ['/v1/admin/healthcheck', '/v1/admin/id'] }))
+    })
+
+    it('provides whether to enable CORS', () => {
+      argv.push('--rpc.http-proxy-cors')
+      argv.push(true)
+
+      sparkswapd(argv)
+
+      expect(BrokerDaemon).to.have.been.calledWith(sinon.match({ enableCors: true }))
     })
   })
 

--- a/broker-daemon/bin/sparkswapd.spec.js
+++ b/broker-daemon/bin/sparkswapd.spec.js
@@ -214,7 +214,7 @@ describe('sparkswapd', () => {
 
     it('provides whether to enable CORS', () => {
       argv.push('--rpc.http-proxy-cors')
-      argv.push(true)
+      argv.push('true')
 
       sparkswapd(argv)
 

--- a/broker-daemon/config.json
+++ b/broker-daemon/config.json
@@ -6,6 +6,7 @@
   "markets": "BTC/LTC",
   "//": "WARNING: Only disable broker SSL during development",
   "disableAuth": false,
+  "enableCors": false,
   "supportedEngineTypes": ["LND"],
   "registerUrls": {
     "mainnet": "https://sparkswap.com/register/",

--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -89,6 +89,7 @@ class BrokerDaemon {
    * @param {Array}  opts.marketNames - List of market names (e.g. 'BTC/LTC') to support
    * @param {Object} opts.engines - Configuration for all the engines to instantiate
    * @param {boolean} [opts.disableAuth=false] - Disable SSL for the daemon
+   * @param {boolean} [opts.enableCors=false] - Enable CORS for the HTTP Proxy
    * @param {string} [opts.rpcUser] - RPC username, only used when auth is enabled
    * @param {string} [opts.rpcPass] - RPC password, only used when auth is enabled
    * @param {Object} [opts.relayerOptions={}]

--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -158,7 +158,7 @@ class BrokerDaemon {
       privKeyPath: privRpcKeyPath,
       pubKeyPath: pubRpcKeyPath,
       disableAuth,
-      enableCors
+      enableCors,
       rpcUser,
       rpcPass
     })

--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -96,7 +96,7 @@ class BrokerDaemon {
    * @param {string} opts.relayerOptions.certPath - Absolute path to the root certificate for the relayer
    * @returns {BrokerDaemon}
    */
-  constructor ({ network, privRpcKeyPath, pubRpcKeyPath, privIdKeyPath, pubIdKeyPath, rpcAddress, interchainRouterAddress, dataDir, marketNames, engines, disableAuth = false, rpcUser = null, rpcPass = null, relayerOptions = {}, rpcHttpProxyAddress, rpcHttpProxyMethods }) {
+  constructor ({ network, privRpcKeyPath, pubRpcKeyPath, privIdKeyPath, pubIdKeyPath, rpcAddress, interchainRouterAddress, dataDir, marketNames, engines, disableAuth = false, enableCors = false, rpcUser = null, rpcPass = null, relayerOptions = {}, rpcHttpProxyAddress, rpcHttpProxyMethods }) {
     // Set a global namespace for sparkswap that we can use for properties not
     // related to application configuration
     if (!global.sparkswap) {
@@ -158,6 +158,7 @@ class BrokerDaemon {
       privKeyPath: privRpcKeyPath,
       pubKeyPath: pubRpcKeyPath,
       disableAuth,
+      enableCors
       rpcUser,
       rpcPass
     })

--- a/broker-daemon/index.spec.js
+++ b/broker-daemon/index.spec.js
@@ -147,6 +147,7 @@ describe('broker daemon', () => {
       marketNames,
       engines,
       disableAuth,
+      enableCors,
       rpcUser,
       rpcPass,
       relayerOptions,

--- a/broker-daemon/index.spec.js
+++ b/broker-daemon/index.spec.js
@@ -32,6 +32,7 @@ describe('broker daemon', () => {
   let dataDir
   let marketNames
   let disableAuth
+  let enableCors
   let relayerOptions
   let brokerDaemonOptions
   let rpcUser
@@ -124,6 +125,7 @@ describe('broker daemon', () => {
       }
     }
     disableAuth = false
+    enableCors = true
     relayerOptions = {
       relayerCertPath: '/fake/path',
       relayerRpcHost: 'fakehost'
@@ -242,6 +244,10 @@ describe('broker daemon', () => {
 
       it('sets the auth', () => {
         expect(rpcServer).to.have.been.calledWith(sinon.match({ disableAuth }))
+      })
+
+      it('sets cors', () => {
+        expect(rpcServer).to.have.been.calledWith(sinon.match({ enableCors }))
       })
 
       it('sets the username', () => {

--- a/broker-daemon/utils/enable-cors.js
+++ b/broker-daemon/utils/enable-cors.js
@@ -1,7 +1,8 @@
 function enableCors () {
   return (req, res, next) => {
     res.header('Access-Control-Allow-Origin', '*')
-    res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
+    res.header('Access-Control-Allow-Credentials', true)
+    res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization')
 
     next()
   }

--- a/broker-daemon/utils/enable-cors.spec.js
+++ b/broker-daemon/utils/enable-cors.spec.js
@@ -22,8 +22,12 @@ describe('enableCors', () => {
     expect(res.header).to.have.been.calledWith('Access-Control-Allow-Origin', '*')
   })
 
+  it('sets the access control allow credentials to true', () => {
+    expect(res.header).to.have.been.calledWith('Access-Control-Allow-Credentials', true)
+  })
+
   it('sets the access control allow headers header', () => {
-    expect(res.header).to.have.been.calledWith('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
+    expect(res.header).to.have.been.calledWith('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization')
   })
 
   it('moves to the next middleware', () => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "broker",
   "version": "0.6.0-beta-rc1",
-  "description": "Broker software to interact with the Sparkswap Relayer",
+  "description": "Broker software to interact with the Sparkswap Relayer.",
   "main": "src/index.js",
   "config": {
     "project_name": "broker",


### PR DESCRIPTION
## Description
This change allows CORS to be enabled for the HTTP proxy via config or command line arguments.

## Related PRs
#463 

## Todos
- [x] Tests
- [x] Documentation
