### PR TITLE
use a configurable internal address for the rpc proxy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,14 +17,14 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v2-dependencies-{{ checksum "package.json" }}
+          - v3-dependencies-{{ checksum "package.json" }}
 
       - run: npm install
 
       - save_cache:
           paths:
             - node_modules
-          key: v2-dependencies-{{ checksum "package.json" }}
+          key: v3-dependencies-{{ checksum "package.json" }}
 
       # This checks if the broker proto files are valid during our CI run
       - run: npm run broker-proto
@@ -39,14 +39,14 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v2-dependencies-{{ checksum "package.json" }}
+          - v3-dependencies-{{ checksum "package.json" }}
 
       - run: npm install
 
       - save_cache:
           paths:
             - node_modules
-          key: v2-dependencies-{{ checksum "package.json" }}
+          key: v3-dependencies-{{ checksum "package.json" }}
 
       - run: npm run dist-cli
 

--- a/broker-daemon/bin/sparkswapd.js
+++ b/broker-daemon/bin/sparkswapd.js
@@ -48,6 +48,7 @@ program
   .option('--relayer.cert-path [cert-path]', 'Location of the root certificate for the SparkSwap Relayer (only used in development)', validations.isFormattedPath, config.relayer.certPath)
   // Broker RPC configuration options
   .option('--rpc.address [rpc-address]', 'Add a host/port to listen for daemon RPC connections', validations.isHost, config.rpc.address)
+  .option('--rpc.proxy-address [rpc-proxy-address]', 'Add a host/port where the daemon RPC will be reachable', validations.isHost, config.rpc.proxyAddress)
   .option('--rpc.http-proxy-address [rpc-http-proxy-address]', 'Add a host/port to listen for HTTP RPC proxy connections', validations.isHost, config.rpc.httpProxyAddress)
   .option('--rpc.http-proxy-methods [rpc-http-proxy-methods]', 'Comma-separated methods for the HTTP RPC Proxy', program.String, config.rpc.httpProxyMethods)
   .option('--rpc.http-proxy-cors [enable-cors]', 'Enable CORS for the HTTP RPC Proxy', program.BOOL, config.enableCors)
@@ -83,6 +84,7 @@ program
       relayerRpcHost,
       relayerCertPath,
       rpcAddress,
+      rpcProxyAddress: rpcInternalProxyAddress,
       rpcHttpProxyAddress,
       rpcHttpProxyMethods: proxyMethods,
       rpcHttpProxyCors: enableCors,
@@ -123,6 +125,7 @@ program
       privIdKeyPath,
       pubIdKeyPath,
       rpcAddress,
+      rpcInternalProxyAddress,
       rpcHttpProxyAddress,
       rpcHttpProxyMethods,
       interchainRouterAddress,

--- a/broker-daemon/bin/sparkswapd.spec.js
+++ b/broker-daemon/bin/sparkswapd.spec.js
@@ -53,6 +53,7 @@ describe('sparkswapd', () => {
         pass: rpcPass,
         pubKeyPath: pubRpcKeyPath,
         privKeyPath: privRpcKeyPath,
+        proxyAddress: rpcInternalProxyAddress,
         httpProxyAddress: rpcHttpProxyAddress,
         httpProxyMethods: rpcHttpProxyMethods
       },
@@ -74,6 +75,7 @@ describe('sparkswapd', () => {
       rpcAddress,
       rpcUser,
       rpcPass,
+      rpcInternalProxyAddress,
       rpcHttpProxyAddress,
       rpcHttpProxyMethods: [rpcHttpProxyMethods],
       pubRpcKeyPath,
@@ -188,6 +190,16 @@ describe('sparkswapd', () => {
       sparkswapd(argv)
 
       expect(BrokerDaemon).to.have.been.calledWith(sinon.match({ rpcAddress }))
+    })
+
+    it('provides an internal rpc proxy address', () => {
+      const rpcProxyAddress = 'my-fake-domain:9876'
+      argv.push('--rpc.proxy-address')
+      argv.push(rpcProxyAddress)
+
+      sparkswapd(argv)
+
+      expect(BrokerDaemon).to.have.been.calledWith(sinon.match({ rpcInternalProxyAddress: rpcProxyAddress }))
     })
 
     it('provides an rpc http proxy address', () => {

--- a/broker-daemon/broker-rpc/broker-rpc-server.js
+++ b/broker-daemon/broker-rpc/broker-rpc-server.js
@@ -125,7 +125,7 @@ class BrokerRPCServer {
 
     this.httpServer.listen(this.rpcHttpProxyPort, this.rpcHttpProxyHost, () => {
       const protocol = this.disableAuth ? 'http' : 'https'
-      this.logger.info(`Listening on ${protocol}://${this.rpcHttpProxyAddress}`)
+      this.logger.info(`Listening on ${protocol}://${this.rpcHttpProxyAddress} as proxy for ${this.rpcAddress}`)
     })
   }
 

--- a/broker-daemon/config.json
+++ b/broker-daemon/config.json
@@ -19,6 +19,7 @@
   },
   "rpc": {
     "address": "0.0.0.0:27492",
+    "proxyAddress": "localhost:27492",
     "httpProxyAddress": "0.0.0.0:27592",
     "httpProxyMethods": "*",
     "user": "sparkswap",

--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -97,7 +97,7 @@ class BrokerDaemon {
    * @param {string} opts.relayerOptions.certPath - Absolute path to the root certificate for the relayer
    * @returns {BrokerDaemon}
    */
-  constructor ({ network, privRpcKeyPath, pubRpcKeyPath, privIdKeyPath, pubIdKeyPath, rpcAddress, interchainRouterAddress, dataDir, marketNames, engines, disableAuth = false, enableCors = false, rpcUser = null, rpcPass = null, relayerOptions = {}, rpcHttpProxyAddress, rpcHttpProxyMethods }) {
+  constructor ({ network, privRpcKeyPath, pubRpcKeyPath, privIdKeyPath, pubIdKeyPath, rpcAddress, interchainRouterAddress, dataDir, marketNames, engines, disableAuth = false, enableCors = false, rpcUser = null, rpcPass = null, relayerOptions = {}, rpcInternalProxyAddress, rpcHttpProxyAddress, rpcHttpProxyMethods }) {
     // Set a global namespace for sparkswap that we can use for properties not
     // related to application configuration
     if (!global.sparkswap) {
@@ -118,6 +118,7 @@ class BrokerDaemon {
       pubKeyPath: pubIdKeyPath
     }
     this.rpcAddress = rpcAddress || DEFAULT_RPC_ADDRESS
+    this.rpcInternalProxyAddress = rpcInternalProxyAddress || `localhost:${this.rpcAddress.split(':')[1]}`
     this.rpcHttpProxyAddress = rpcHttpProxyAddress
     this.dataDir = dataDir || DEFAULT_DATA_DIR
     this.marketNames = marketNames || []
@@ -148,7 +149,7 @@ class BrokerDaemon {
     })
 
     this.rpcServer = new BrokerRPCServer({
-      rpcAddress: this.rpcAddress,
+      rpcAddress: this.rpcInternalProxyAddress,
       rpcHttpProxyAddress: this.rpcHttpProxyAddress,
       rpcHttpProxyMethods,
       logger: this.logger,

--- a/broker-daemon/index.spec.js
+++ b/broker-daemon/index.spec.js
@@ -26,6 +26,7 @@ describe('broker daemon', () => {
   let privIdKeyPath
   let pubIdKeyPath
   let rpcAddress
+  let rpcInternalProxyAddress
   let rpcHttpProxyAddress
   let rpcHttpProxyMethods
   let interchainRouterAddress
@@ -105,6 +106,7 @@ describe('broker daemon', () => {
     privIdKeyPath = '/my/private/id/key/path'
     pubIdKeyPath = '/my/public/id/key/path'
     rpcAddress = '0.0.0.0:27492'
+    rpcInternalProxyAddress = 'my-fake-domain:27492'
     rpcHttpProxyAddress = '0.0.0.0:28592'
     rpcHttpProxyMethods = [ '/v1/admin/healthcheck' ]
     interchainRouterAddress = '0.0.0.0:40369'
@@ -140,6 +142,7 @@ describe('broker daemon', () => {
       privIdKeyPath,
       pubIdKeyPath,
       rpcAddress,
+      rpcInternalProxyAddress,
       rpcHttpProxyAddress,
       rpcHttpProxyMethods,
       interchainRouterAddress,
@@ -208,7 +211,14 @@ describe('broker daemon', () => {
       })
 
       it('sets the rpc address', () => {
-        expect(rpcServer).to.have.been.calledWith(sinon.match({ rpcAddress }))
+        expect(rpcServer).to.have.been.calledWith(sinon.match({ rpcAddress: rpcInternalProxyAddress }))
+      })
+
+      it('defaults to localhost', () => {
+        delete brokerDaemonOptions.rpcInternalProxyAddress
+        // eslint-disable-next-line
+        new BrokerDaemon(brokerDaemonOptions)
+        expect(rpcServer).to.have.been.calledWith(sinon.match({ rpcAddress: 'localhost:27492' }))
       })
 
       it('sets the rpc http proxy address', () => {

--- a/broker-daemon/utils/create-http-server.js
+++ b/broker-daemon/utils/create-http-server.js
@@ -50,14 +50,6 @@ function createHttpServer (protoPath, rpcAddress, { disableAuth = false, enableC
     app.use(corsMiddleware())
   }
 
-  // If the RPC address we use for daemon is set to a default route (0.0.0.0)
-  // then we want to make sure that we are instead making a request w/ grpc-gateway
-  // to `localhost`. `0.0.0.0` would be an invalid address w/ the current cert
-  // setup
-  if (rpcAddress.includes('0.0.0.0')) {
-    rpcAddress = rpcAddress.replace('0.0.0.0', 'localhost')
-  }
-
   if (disableAuth) {
     app.use('/', grpcGateway([`/${protoPath}`], rpcAddress, { whitelist: httpMethods }))
     app.use(handle404.bind(null, logger))

--- a/broker-daemon/utils/create-http-server.spec.js
+++ b/broker-daemon/utils/create-http-server.spec.js
@@ -49,11 +49,6 @@ describe('createHttpServer', () => {
       expect(expressStub.use).to.have.been.calledWith(bodyParserStub.json())
     })
 
-    it('defaults a 0.0.0.0 address to localhost for certificate normalization', () => {
-      createHttpServer(protoPath, '0.0.0.0:8080', options)
-      expect(grpcGatewayStub).to.have.been.calledWith(sinon.match.any, 'localhost:8080')
-    })
-
     it('sets the app to parse urlencoded bodies', () => {
       expect(expressStub.use).to.have.been.calledWith(bodyParserStub.urlencoded())
     })
@@ -149,11 +144,6 @@ describe('createHttpServer', () => {
 
     it('sets the app to use grpcGateway defined routing with grpc credentials', () => {
       expect(expressStub.use).to.have.been.calledWith('/', grpcGateway)
-    })
-
-    it('defaults a 0.0.0.0 address to localhost for certificate normalization', () => {
-      createHttpServer(protoPath, '0.0.0.0:8080', options)
-      expect(grpcGatewayStub).to.have.been.calledWith(sinon.match.any, 'localhost:8080', sinon.match.any)
     })
 
     it('uses the rpc address specified in the daemon', () => {


### PR DESCRIPTION
## Description
This changes how we proxy calls from the HTTP server to the gRPC server.

Previously, we used the same address to listen for the gRPC server as to direct requests to when proxying. This proved problematic when we used SSL, so we put in place a quick replacement for `0.0.0.0 -> localhost`.

However, when you want to host the HTTP proxy in such a way that it can be accessible to the public, i.e. using a provisioned certificate, this internal hostname will no longer work.

So, this change makes explicit the choice of internal hostname when making requests to gRPC in order to make dealing with certificate hostnames simpler.

## Todos
- [x] Tests