### PR TITLE
Unify fill/order states with Proto file

### DIFF
--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -355,10 +355,8 @@ message Order {
     CREATED = 0;
     // The order has been placed and communicated to other marker participants.
     PLACED = 1;
-    // The order has been filled by another market participant.
-    FILLED = 2;
-    // The swap has been executed on the Payment Channel Networks
-    EXECUTED = 3;
+    // The swap is being executed on the Payment Channel Networks
+    EXECUTING = 3;
     // The swap preimage has been returned to the Relayer.
     COMPLETED = 4;
     // The order has encountered a failure.

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -396,6 +396,8 @@ message Fill {
     COMPLETED = 3;
     // The fill has encountered a failure.
     REJECTED = 4;
+    // The fill has been cancelled.
+    CANCELLED = 5;
   }
   // The Relayer-assigned unique ID of the order that this fill is for.
   string order_id = 1;

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -355,10 +355,8 @@ message Order {
     CREATED = 0;
     // The order has been placed and communicated to other marker participants.
     PLACED = 1;
-    // The order has been filled by another market participant.
-    FILLED = 2;
-    // The swap has been executed on the Payment Channel Networks
-    EXECUTED = 3;
+    // The swap is being executed on the Payment Channel Networks
+    EXECUTING = 3;
     // The swap preimage has been returned to the Relayer.
     COMPLETED = 4;
     // The order has encountered a failure.

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -396,6 +396,8 @@ message Fill {
     COMPLETED = 3;
     // The fill has encountered a failure.
     REJECTED = 4;
+    // The fill has been cancelled.
+    CANCELLED = 5;
   }
   // The Relayer-assigned unique ID of the order that this fill is for.
   string order_id = 1;

--- a/broker-daemon/state-machines/fill-state-machine.js
+++ b/broker-daemon/state-machines/fill-state-machine.js
@@ -426,7 +426,8 @@ FillStateMachine.STATES = Object.freeze({
   CREATED: 'created',
   FILLED: 'filled',
   EXECUTED: 'executed',
-  CANCELLED: 'cancelled'
+  CANCELLED: 'cancelled',
+  REJECTED: 'rejected'
 })
 
 FillStateMachine.INDETERMINATE_STATES = Object.freeze({

--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -452,7 +452,9 @@ OrderStateMachine.STATES = Object.freeze({
   CREATED: 'created',
   PLACED: 'placed',
   CANCELLED: 'cancelled',
-  EXECUTING: 'executing'
+  EXECUTING: 'executing',
+  COMPLETED: 'completed',
+  REJECTED: 'rejected'
 })
 
 OrderStateMachine.INDETERMINATE_STATES = Object.freeze({


### PR DESCRIPTION
## Description
This fixes some inconsistencies in the Fill and Order State Machine states with the proto definitions of their states.

In particular, the Order State Machine defines a state of `EXECUTING` but the proto file defined it as `EXECUTED`, resulting in an `illegal enum` when retrieving the status of an order in that state.

This also adds the `rejected` state, added in the `StateMachineRejection` plugin as an explicit state in the `OrderStateMachine.STATES` and `FillStateMachine.STATES` objects.

In the future, we need to update the language used for these states to be more consistent overall with an actual trade lifecycle.