### PR TITLE
FIX dont initialize blockorders before engines are validated

### DIFF
--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -80,11 +80,16 @@ class BlockOrderWorker extends EventEmitter {
 
   /**
    * Initialize the BlockOrderWorker by clearing and rebuilding the ordersByHash index
+   * @param {Promise} enginesAreValidated - promise that returns when engines are validated
    * @returns {void}
    */
-  async initialize () {
+  async initialize (enginesAreValidated) {
     await this.ordersByHash.ensureIndex()
     await this.ordersByOrderId.ensureIndex()
+    // This will return when engines are validated on the Broker. We do not want
+    // to settle orders until we know that engines are full functional or else we'll
+    // have inadvertent failures in orders that _could_ have been settled
+    await enginesAreValidated
     await this.settleIndeterminateOrdersFills()
   }
 

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -8,7 +8,8 @@ const {
   getRecords,
   SublevelIndex,
   generateId,
-  retry
+  retry,
+  logger
 } = require('../utils')
 
 /**
@@ -86,19 +87,28 @@ class BlockOrderWorker extends EventEmitter {
   async initialize (enginesAreValidated) {
     await this.ordersByHash.ensureIndex()
     await this.ordersByOrderId.ensureIndex()
-    // This will return when engines are validated on the Broker. We do not want
-    // to settle orders until we know that engines are full functional or else we'll
-    // have inadvertent failures in orders that _could_ have been settled
-    await enginesAreValidated
-    await this.settleIndeterminateOrdersFills()
+    // We do not await the settlement of indeterminate orders to allow indexes
+    // which can be a long process, to be awaited on start, but prevents locking
+    // the event loop if our engines are not validated.
+    this.settleIndeterminateOrdersFills(enginesAreValidated)
   }
 
   /**
    * When the broker goes down, there can be orders and fills in an unresolved state. We should rehydrate the state machines
    * from the database and attempt to trigger them into a resolved state
+   * @param {Promise} enginesAreValidated - promise that returns when engines are validated
    * @returns {void}
    */
-  async settleIndeterminateOrdersFills () {
+  async settleIndeterminateOrdersFills (enginesAreValidated) {
+    logger.info('Waiting on engine validation to settle outstanding orders')
+
+    // This function will be ran when engines are validated on the Broker. We do not
+    // want to settle orders until we know that engines are full functional or else
+    // we'll have inadvertent failures in orders that _could_ have been settled
+    await enginesAreValidated
+
+    logger.info('Starting settlement of outstanding orders')
+
     const blockOrders = await getRecords(this.store, BlockOrder.fromStorage.bind(BlockOrder))
     for (let blockOrder of blockOrders) {
       const orderStateMachines = await this.getOrderStateMachines(blockOrder)

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -292,11 +292,10 @@ describe('BlockOrderWorker', () => {
 
   describe('initialize', () => {
     let worker
-    let resolve
     let engineValidPromise
 
     beforeEach(() => {
-      engineValidPromise = new Promise((_resolve) => { resolve = _resolve }) // eslint-disable-line
+      engineValidPromise = sinon.stub()
       worker = new BlockOrderWorker({ orderbooks, store, logger, relayer, engines })
       worker.ordersByHash = { ensureIndex: sinon.stub().resolves() }
       worker.ordersByOrderId = { ensureIndex: sinon.stub().resolves() }
@@ -304,14 +303,12 @@ describe('BlockOrderWorker', () => {
     })
 
     it('rebuilds the ordersByHash index', async () => {
-      resolve()
       await worker.initialize(engineValidPromise)
 
       expect(worker.ordersByHash.ensureIndex).to.have.been.calledOnce()
     })
 
     it('rebuilds the ordersByOrderId index', async () => {
-      resolve()
       await worker.initialize(engineValidPromise)
 
       expect(worker.ordersByOrderId.ensureIndex).to.have.been.calledOnce()
@@ -320,23 +317,13 @@ describe('BlockOrderWorker', () => {
     it('waits for index rebuilding to complete', () => {
       worker.ordersByHash.ensureIndex.rejects()
 
-      resolve()
       return expect(worker.initialize(engineValidPromise)).to.eventually.be.rejectedWith(Error)
     })
 
     it('settles orders and fills in indeterminate states', async () => {
-      resolve()
       await worker.initialize(engineValidPromise)
 
-      expect(worker.settleIndeterminateOrdersFills).to.have.been.calledOnce()
-    })
-
-    it('settles orders and fills in indeterminate states when engines are valid ', async () => {
-      const init = worker.initialize(engineValidPromise)
-      expect(worker.settleIndeterminateOrdersFills).to.not.have.been.calledOnce()
-      resolve()
-      await init
-      expect(worker.settleIndeterminateOrdersFills).to.have.been.calledOnce()
+      expect(worker.settleIndeterminateOrdersFills).to.have.been.calledOnceWith(engineValidPromise)
     })
   })
 
@@ -349,8 +336,11 @@ describe('BlockOrderWorker', () => {
     let executedFsm
     let fillStateMachines
     let getRecords
+    let resolve
+    let engineValidPromise
 
     beforeEach(() => {
+      engineValidPromise = new Promise((_resolve) => { resolve = _resolve }) // eslint-disable-line
       cancelledOsm = { state: 'cancelled', triggerState: sinon.stub() }
       createdOsm = { state: 'created', triggerState: sinon.stub() }
       createdFsm = { state: 'created', triggerState: sinon.stub() }
@@ -371,68 +361,72 @@ describe('BlockOrderWorker', () => {
       worker.applyFsmListeners = sinon.stub()
     })
 
+    beforeEach(() => {
+      resolve()
+    })
+
     it('retrieves all blockOrders from the store', async () => {
-      await worker.settleIndeterminateOrdersFills()
+      await worker.settleIndeterminateOrdersFills(engineValidPromise)
 
       expect(getRecords).to.have.been.calledWith(store, BlockOrder.fromStorage.bind(BlockOrder))
     })
 
     it('retrieves orderStateMachines for each blockOrder', async () => {
-      await worker.settleIndeterminateOrdersFills()
+      await worker.settleIndeterminateOrdersFills(engineValidPromise)
 
       expect(worker.getFillStateMachines).to.have.been.calledWith({ blockOrderId: '1234' })
     })
 
     it('does not apply listeners to osm in finished state', async () => {
-      await worker.settleIndeterminateOrdersFills()
+      await worker.settleIndeterminateOrdersFills(engineValidPromise)
 
       expect(worker.applyOsmListeners).to.not.have.been.calledWith(cancelledOsm, { blockOrderId: '1234' })
     })
 
     it('applies listeners to each osm in an indeterminate state', async () => {
-      await worker.settleIndeterminateOrdersFills()
+      await worker.settleIndeterminateOrdersFills(engineValidPromise)
 
       expect(worker.applyOsmListeners).to.have.been.calledWith(createdOsm, { blockOrderId: '1234' })
     })
 
     it('triggers the osm to the next state if the osm is in an indeterminate state', async () => {
-      await worker.settleIndeterminateOrdersFills()
+      await worker.settleIndeterminateOrdersFills(engineValidPromise)
 
       expect(createdOsm.triggerState).to.have.been.called()
     })
 
     it('does not trigger the osm to the next state if the osm is in a finished state', async () => {
-      await worker.settleIndeterminateOrdersFills()
+      await worker.settleIndeterminateOrdersFills(engineValidPromise)
 
       expect(cancelledOsm.triggerState).to.not.have.been.called()
     })
 
     it('retrieves fillStateMachines for each blockOrder', async () => {
-      await worker.settleIndeterminateOrdersFills()
+      await worker.settleIndeterminateOrdersFills(engineValidPromise)
 
       expect(worker.getOrderStateMachines).to.have.been.calledWith({ blockOrderId: '1234' })
     })
 
     it('does not apply listeners to fsm in finished state', async () => {
-      await worker.settleIndeterminateOrdersFills()
+      await worker.settleIndeterminateOrdersFills(engineValidPromise)
 
       expect(worker.applyFsmListeners).to.not.have.been.calledWith(executedFsm, { blockOrderId: '1234' })
     })
 
     it('applies listeners to each fsm in an indeterminate state', async () => {
-      await worker.settleIndeterminateOrdersFills()
+      await worker.settleIndeterminateOrdersFills(engineValidPromise)
 
       expect(worker.applyFsmListeners).to.have.been.calledWith(createdFsm, { blockOrderId: '1234' })
     })
 
     it('triggers the fsm to the next state if the fsm is in an indeterminate state', async () => {
-      await worker.settleIndeterminateOrdersFills()
+      await worker.settleIndeterminateOrdersFills(engineValidPromise)
 
       expect(createdFsm.triggerState).to.have.been.called()
     })
 
     it('does not trigger the fsm to the next state if the fsm is in a finished state', async () => {
-      await worker.settleIndeterminateOrdersFills()
+      await worker.settleIndeterminateOrdersFills(engineValidPromise)
 
       expect(executedFsm.triggerState).to.not.have.been.called()
     })

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -290,7 +290,7 @@ describe('BlockOrderWorker', () => {
     })
   })
 
-  describe.only('initialize', () => {
+  describe('initialize', () => {
     let worker
     let resolve
     let engineValidPromise

--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -185,7 +185,9 @@ class BrokerDaemon {
     try {
       await this.initializeMarkets(this.marketNames)
 
-      // Start the validation of the engines
+      // Starts the validation of all engines on the broker. We do not await this
+      // function because we want the validations to run in the background as it
+      // can take time for the engines to be ready
       const enginesAreValidated = this.validateEngines()
 
       // We run this asynchronously so that it doesn't block the start of the rpc
@@ -258,8 +260,6 @@ class BrokerDaemon {
 
   /**
    * Validates engines
-   * We do not await this function because we want the validations to run in the background
-   * as it can take time for the engines to be ready
    * @returns {void}
    */
   validateEngines () {

--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -183,9 +183,13 @@ class BrokerDaemon {
    */
   async initialize () {
     try {
+      await this.initializeMarkets(this.marketNames)
+
+      // Start the validation of the engines
       const enginesAreValidated = this.validateEngines()
 
-      this.initializeMarkets(this.marketNames)
+      // We run this asynchronously so that it doesn't block the start of the rpc
+      // server. This function will not return until the engines are validated
       this.initializeBlockOrder(enginesAreValidated)
 
       this.rpcServer.listen(this.rpcAddress)

--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -48,6 +48,13 @@ const DEFAULT_INTERCHAIN_ROUTER_ADDRESS = '0.0.0.0:40369'
 const DEFAULT_RELAYER_HOST = 'localhost:28492'
 
 /**
+ * @constant
+ * @type {number}
+ * @default
+ */
+const BLOCK_ORDER_RETRY = 10000
+
+/**
  * Create an instance of an engine from provided configuration
  * @param {string} symbol         - Symbol that this engine is responsible for
  * @param {Object} engineConfig   - Configuration object for this engine
@@ -173,6 +180,10 @@ class BrokerDaemon {
     })
   }
 
+  get allEnginesValid () {
+    return Array.from(this.engines).every(([ symbol, engine ]) => engine.validated)
+  }
+
   /**
    * Initialize the broker daemon which:
    * - Sets up the orderbooks (listens to market events on the Relayer, re-indexes data store)
@@ -186,17 +197,10 @@ class BrokerDaemon {
       // Since these are potentially long-running operations, we run them in parallel to speed
       // up BrokerDaemon startup time.
       await Promise.all([
+        this.validateEngines(),
         this.initializeMarkets(this.marketNames),
-        (async () => {
-          this.logger.info(`Initializing BlockOrderWorker`)
-          await this.blockOrderWorker.initialize()
-          this.logger.info('BlockOrderWorker initialized')
-        })()
+        this.initializeBlockOrder()
       ])
-
-      // This will run in the background. It is implemented with exponential backoff so
-      // the validation will be retried on the engine until successful or until final failure.
-      this.validateEngines()
 
       this.rpcServer.listen(this.rpcAddress)
       this.logger.info(`BrokerDaemon RPC server started: gRPC Server listening on ${this.rpcAddress}`)
@@ -208,6 +212,26 @@ class BrokerDaemon {
       this.logger.error(e.toString(), e)
       this.logger.info('BrokerDaemon shutting down...')
       process.exit(1)
+    }
+  }
+
+  /**
+   * Initializes all block orders for the engine.
+   * @returns {void}
+   */
+  async initializeBlockOrder () {
+    // All engines must be validated before we continue or else we may try to work
+    // an indeterminate blockorder and inadvertently cause it to fail cause the engines
+    // aren't validated
+    if (this.allEnginesValid) {
+      this.logger.info(`Initializing BlockOrderWorker`)
+      await this.blockOrderWorker.initialize()
+      this.logger.info('BlockOrderWorker initialized')
+    } else {
+      setTimeout(() => {
+        this.logger.debug('Waiting on engines, Retrying block order initialization')
+        this.initializeBlockOrder()
+      }, BLOCK_ORDER_RETRY)
     }
   }
 

--- a/broker-daemon/index.spec.js
+++ b/broker-daemon/index.spec.js
@@ -536,6 +536,13 @@ describe('broker daemon', () => {
       expect(btcEngine.validateEngine).to.have.been.called()
       expect(ltcEngine.validateEngine).to.have.been.called()
     })
+
+    it('synchronously validates the node config on each engine', async () => {
+      await brokerDaemon.validateEngines()
+
+      expect(btcEngine.validateEngine).to.have.been.called()
+      expect(ltcEngine.validateEngine).to.have.been.called()
+    })
   })
 
   describe('rpcAddress', () => {

--- a/broker-daemon/index.spec.js
+++ b/broker-daemon/index.spec.js
@@ -459,10 +459,27 @@ describe('broker daemon', () => {
     })
   })
 
-  describe('#initialize', () => {
+  describe('#initializeBlockOrder', () => {
+    let engineValidatePromise
+
     beforeEach(() => {
+      engineValidatePromise = sinon.stub()
       brokerDaemon = new BrokerDaemon(brokerDaemonOptions)
-      brokerDaemon.validateEngines = sinon.stub().returns()
+    })
+
+    it('calls initialize on the blockorder', async () => {
+      await brokerDaemon.initializeBlockOrder(engineValidatePromise)
+      expect(brokerDaemon.blockOrderWorker.initialize).to.have.been.calledOnceWith(engineValidatePromise)
+    })
+  })
+
+  describe('#initialize', () => {
+    let validatePromise
+
+    beforeEach(() => {
+      validatePromise = sinon.stub()
+      brokerDaemon = new BrokerDaemon(brokerDaemonOptions)
+      brokerDaemon.validateEngines = sinon.stub().returns(validatePromise)
       brokerDaemon.initializeMarkets = sinon.stub().resolves()
     })
 
@@ -490,7 +507,7 @@ describe('broker daemon', () => {
     })
 
     it('initializes the block order worker', async () => {
-      expect(BlockOrderWorker.prototype.initialize).to.have.been.calledOnce()
+      expect(BlockOrderWorker.prototype.initialize).to.have.been.calledOnceWith(validatePromise)
     })
   })
 


### PR DESCRIPTION
## Description
This PR solves a bug where, on restart, the broker tries to re-work indeterminate orders (orders that are still executing/placed/create) however, if the engines are in a non-validated state, the orders will fail and subsequently be cancelled.

We now check if engines have been validated before we try to work indeterminate orders.

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
