### PR TITLE
FIX - update proto to build for other languages

### DIFF
--- a/broker-cli/commands/health-check.js
+++ b/broker-cli/commands/health-check.js
@@ -16,6 +16,24 @@ const STATUS_CODES = Object.freeze({
 })
 
 /**
+ * @constant
+ * @type {Object<key, String>}
+ * @default
+ */
+const RELAYER_STATUS_CODES = Object.freeze({
+  RELAYER_OK: 'RELAYER_OK'
+})
+
+/**
+ * @constant
+ * @type {Object<key, String>}
+ * @default
+ */
+const ORDERBOOK_STATUS_CODES = Object.freeze({
+  ORDERBOOK_OK: 'ORDERBOOK_OK'
+})
+
+/**
  * Engine status codes we expect to be returned from the engine, defined in:
  * https://github.com/sparkswap/lnd-engine/blob/master/src/constants/engine-statuses.js
  * @constant
@@ -47,7 +65,7 @@ async function healthCheck (args, opts, logger) {
 
     const {
       engineStatus = [],
-      orderbookStatus = [],
+      orderbookStatus: orderbookStatuses = [],
       relayerStatus = STATUS_CODES.UNKNOWN
     } = await client.adminService.healthCheck({})
 
@@ -71,12 +89,12 @@ async function healthCheck (args, opts, logger) {
       healthcheckTable.push(['Engines', 'No Statuses Returned'.red])
     }
 
-    const relayerStatusString = (relayerStatus === STATUS_CODES.OK) ? relayerStatus.green : relayerStatus.red
+    const relayerStatusString = (relayerStatus === RELAYER_STATUS_CODES.RELAYER_OK) ? `${STATUS_CODES.OK}`.green : relayerStatus.red
     healthcheckTable.push(['Relayer', relayerStatusString])
 
-    if (orderbookStatus.length > 0) {
-      orderbookStatus.forEach(({ market, status }) => {
-        const orderbookStatusString = (status === STATUS_CODES.OK) ? status.green : status.red
+    if (orderbookStatuses.length) {
+      orderbookStatuses.forEach(({ market, status: orderbookStatus }) => {
+        const orderbookStatusString = (orderbookStatus === ORDERBOOK_STATUS_CODES.ORDERBOOK_OK) ? `${STATUS_CODES.OK}`.green : orderbookStatus.red
         healthcheckTable.push([`${market} Orderbook`, orderbookStatusString])
       })
     } else {

--- a/broker-cli/commands/health-check.spec.js
+++ b/broker-cli/commands/health-check.spec.js
@@ -33,12 +33,12 @@ describe('healthCheck', () => {
     healthCheckStub = sinon.stub().returns({
       engineStatus: [
         { symbol: 'BTC', status: 'VALIDATED' },
-        { symbol: 'LTC', status: 'NOT VALIDATED' }
+        { symbol: 'LTC', status: 'NOT_SYNCED' }
       ],
-      relayerStatus: 'OK',
+      relayerStatus: 'RELAYER_OK',
       orderbookStatus: [
-        { market: 'BTC/LTC', status: 'OK' },
-        { market: 'ABC/XYZ', status: 'NOT_SYNCED' }
+        { market: 'BTC/LTC', status: 'ORDERBOOK_OK' },
+        { market: 'ABC/XYZ', status: 'ORDERBOOK_NOT_SYNCED' }
       ]
     })
     instanceTableStub = { push: sinon.stub() }
@@ -69,7 +69,7 @@ describe('healthCheck', () => {
   it('adds engine statuses to the healthcheck table', async () => {
     await healthCheck(args, opts, logger)
     expect(instanceTableStub.push).to.have.been.calledWith(['BTC Engine', 'OK'.green])
-    expect(instanceTableStub.push).to.have.been.calledWith(['LTC Engine', 'NOT VALIDATED'.red])
+    expect(instanceTableStub.push).to.have.been.calledWith(['LTC Engine', 'NOT_SYNCED'.red])
   })
 
   it('adds engine error status if no engines are returned', async () => {
@@ -98,6 +98,6 @@ describe('healthCheck', () => {
   it('adds orderbook status to the healthcheck table', async () => {
     await healthCheck(args, opts, logger)
     expect(instanceTableStub.push).to.have.been.calledWith(['BTC/LTC Orderbook', 'OK'.green])
-    expect(instanceTableStub.push).to.have.been.calledWith(['ABC/XYZ Orderbook', 'NOT_SYNCED'.red])
+    expect(instanceTableStub.push).to.have.been.calledWith(['ABC/XYZ Orderbook', 'ORDERBOOK_NOT_SYNCED'.red])
   })
 })

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -69,50 +69,27 @@ enum Side {
   ASK = 1;
 }
 
-/**
- * Statuses of an engine
- */
-enum EngineStatuses {
-  // Default state of the engine
-  UNKNOWN = 0;
-  // Engine is unavailable
-  UNAVAILABLE = 1;
-  // Wallet does not exist
-  NEEDS_WALLET = 2;
-  // Wallet exists but is not locked
-  LOCKED = 3;
-  // Wallet is unlocked but the configuration of the node and chain sync status are not known
-  UNLOCKED = 4;
-  // Engine is not yet synced to chain
-  NOT_SYNCED = 5;
-  // Engine is validated and ready for use
-  VALIDATED = 6;
-}
-
-/**
- * Statuses of the relayer
- */
-enum RelayerStatuses {
-  // Relayer is available
-  OK = 0;
-  // Relayer is not available
-  UNAVAILABLE = 1;
-}
-
-/**
- * Statuses of an orderbook
- */
-enum OrderbookStatuses {
-  // Orderbook is synced
-  OK = 0;
-  // Orderbook is not synced
-  NOT_SYNCED = 1;
-}
 
 /**
  * HealthCheckResponse provides information on the health of a BrokerDaemon.
  */
 message HealthCheckResponse {
+  // Statuses of an orderbook
+  enum OrderbookStatuses {
+    // Orderbook is synced
+    OK = 0;
+    // Orderbook is not synced
+    NOT_SYNCED = 1;
+  }
+
+  // Statuses of the relayer
+  enum RelayerStatuses {
+    // Relayer is available
+    RELAYER_OK = 0;
+    // Relayer is not available
+    UNAVAILABLE = 1;
+  }
+
   // The status of every engine available on the BrokerDaemon.
   repeated EngineStatus engine_status = 1;
   // The status of the relayer this BrokerDaemon is connected to, either `'OK'` or the error message returned when connecting to it.
@@ -124,6 +101,24 @@ message HealthCheckResponse {
    * EngineStatus provides the status of an engine for a currency.
    */
   message EngineStatus {
+    // Statuses of an engine
+    enum EngineStatuses {
+      // Default state of the engine
+      UNKNOWN = 0;
+      // Engine is unavailable
+      UNAVAILABLE = 1;
+      // Wallet does not exist
+      NEEDS_WALLET = 2;
+      // Wallet exists but is not locked
+      LOCKED = 3;
+      // Wallet is unlocked but the configuration of the node and chain sync status are not known
+      UNLOCKED = 4;
+      // Engine is not yet synced to chain
+      NOT_SYNCED = 5;
+      // Engine is validated and ready for use
+      VALIDATED = 6;
+    }
+
     // The common symbol that the engine is responsible for, e.g. `BTC` or `LTC`
     string symbol = 1;
     // The status of the engine

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -77,9 +77,9 @@ message HealthCheckResponse {
   // Statuses of an orderbook
   enum OrderbookStatuses {
     // Orderbook is synced
-    OK = 0;
+    ORDERBOOK_OK = 0;
     // Orderbook is not synced
-    NOT_SYNCED = 1;
+    ORDERBOOK_NOT_SYNCED = 1;
   }
 
   // Statuses of the relayer
@@ -87,7 +87,7 @@ message HealthCheckResponse {
     // Relayer is available
     RELAYER_OK = 0;
     // Relayer is not available
-    UNAVAILABLE = 1;
+    RELAYER_UNAVAILABLE = 1;
   }
 
   // The status of every engine available on the BrokerDaemon.

--- a/broker-daemon/broker-rpc/admin-service/health-check.js
+++ b/broker-daemon/broker-rpc/admin-service/health-check.js
@@ -4,8 +4,8 @@
  * @default
  */
 const ORDERBOOK_STATUS_CODES = Object.freeze({
-  OK: 'OK',
-  NOT_SYNCED: 'NOT_SYNCED'
+  ORDERBOOK_OK: 'ORDERBOOK_OK',
+  ORDERBOOK_NOT_SYNCED: 'ORDERBOOK_NOT_SYNCED'
 })
 
 /**
@@ -15,7 +15,7 @@ const ORDERBOOK_STATUS_CODES = Object.freeze({
  */
 const RELAYER_STATUS_CODES = Object.freeze({
   RELAYER_OK: 'RELAYER_OK',
-  NOT_SYNCED: 'NOT_SYNCED'
+  RELAYER_NOT_SYNCED: 'RELAYER_NOT_SYNCED'
 })
 
 /**
@@ -32,7 +32,7 @@ async function getRelayerStatus (relayer, { logger }) {
     return RELAYER_STATUS_CODES.RELAYER_OK
   } catch (e) {
     logger.error(`Relayer error during status check: `, { error: e.stack })
-    return RELAYER_STATUS_CODES.UNAVAILABLE
+    return RELAYER_STATUS_CODES.RELAYER_UNAVAILABLE
   }
 }
 
@@ -59,7 +59,7 @@ async function healthCheck ({ relayer, logger, engines, orderbooks }, { HealthCh
   logger.debug(`Received status from relayer`, { relayerStatus })
 
   const orderbookStatus = Array.from(orderbooks).map(([ market, orderbook ]) => {
-    const status = orderbook.synced ? ORDERBOOK_STATUS_CODES.OK : ORDERBOOK_STATUS_CODES.NOT_SYNCED
+    const status = orderbook.synced ? ORDERBOOK_STATUS_CODES.ORDERBOOK_OK : ORDERBOOK_STATUS_CODES.ORDERBOOK_NOT_SYNCED
     return { market, status }
   })
 

--- a/broker-daemon/broker-rpc/admin-service/health-check.js
+++ b/broker-daemon/broker-rpc/admin-service/health-check.js
@@ -3,9 +3,18 @@
  * @type {Object}
  * @default
  */
-const STATUS_CODES = Object.freeze({
-  UNAVAILABLE: 'UNAVAILABLE',
+const ORDERBOOK_STATUS_CODES = Object.freeze({
   OK: 'OK',
+  NOT_SYNCED: 'NOT_SYNCED'
+})
+
+/**
+ * @constant
+ * @type {Object}
+ * @default
+ */
+const RELAYER_STATUS_CODES = Object.freeze({
+  RELAYER_OK: 'RELAYER_OK',
   NOT_SYNCED: 'NOT_SYNCED'
 })
 
@@ -20,10 +29,10 @@ const STATUS_CODES = Object.freeze({
 async function getRelayerStatus (relayer, { logger }) {
   try {
     await relayer.adminService.healthCheck({})
-    return STATUS_CODES.OK
+    return RELAYER_STATUS_CODES.RELAYER_OK
   } catch (e) {
     logger.error(`Relayer error during status check: `, { error: e.stack })
-    return STATUS_CODES.UNAVAILABLE
+    return RELAYER_STATUS_CODES.UNAVAILABLE
   }
 }
 
@@ -50,7 +59,7 @@ async function healthCheck ({ relayer, logger, engines, orderbooks }, { HealthCh
   logger.debug(`Received status from relayer`, { relayerStatus })
 
   const orderbookStatus = Array.from(orderbooks).map(([ market, orderbook ]) => {
-    const status = orderbook.synced ? STATUS_CODES.OK : STATUS_CODES.NOT_SYNCED
+    const status = orderbook.synced ? ORDERBOOK_STATUS_CODES.OK : ORDERBOOK_STATUS_CODES.NOT_SYNCED
     return { market, status }
   })
 

--- a/broker-daemon/broker-rpc/admin-service/health-check.spec.js
+++ b/broker-daemon/broker-rpc/admin-service/health-check.spec.js
@@ -13,7 +13,8 @@ describe('health-check', () => {
     let relayerStub
     let loggerStub
     let relayerStatusStub
-    let statusOK
+    let orderbookStatusOK
+    let relayerStatusOK
     let result
     let engineStub
     let engines
@@ -40,8 +41,9 @@ describe('health-check', () => {
         debug: sinon.stub()
       }
       HealthCheckResponse = sinon.stub()
-      statusOK = healthCheck.__get__('STATUS_CODES').OK
-      relayerStatusStub = sinon.stub().returns(statusOK)
+      orderbookStatusOK = healthCheck.__get__('ORDERBOOK_STATUS_CODES').OK
+      relayerStatusOK = healthCheck.__get__('RELAYER_STATUS_CODES').RELAYER_OK
+      relayerStatusStub = sinon.stub().returns(relayerStatusOK)
 
       reverts.push(healthCheck.__set__('getRelayerStatus', relayerStatusStub))
     })
@@ -65,12 +67,12 @@ describe('health-check', () => {
       expect(HealthCheckResponse).to.have.been.calledWith(sinon.match(
         {
           engineStatus: [
-            { symbol: 'BTC', status: statusOK },
-            { symbol: 'LTC', status: statusOK }
+            { symbol: 'BTC', status: 'OK' },
+            { symbol: 'LTC', status: 'OK' }
           ],
-          relayerStatus: statusOK,
+          relayerStatus: relayerStatusOK,
           orderbookStatus: [
-            { market: 'BTC/LTC', status: statusOK }
+            { market: 'BTC/LTC', status: orderbookStatusOK }
           ]
         }))
     })
@@ -96,13 +98,13 @@ describe('health-check', () => {
     })
 
     it('returns an OK if relayer#healthCheck is successful', async () => {
-      const { OK } = healthCheck.__get__('STATUS_CODES')
+      const { RELAYER_OK } = healthCheck.__get__('RELAYER_STATUS_CODES')
       const res = await getRelayerStatus(relayerStub, { logger })
-      expect(res).to.eql(OK)
+      expect(res).to.eql(RELAYER_OK)
     })
 
     it('returns an UNAVAILABLE status code if the call to relayer fails', async () => {
-      const { UNAVAILABLE } = healthCheck.__get__('STATUS_CODES')
+      const { UNAVAILABLE } = healthCheck.__get__('RELAYER_STATUS_CODES')
       healthCheckStub.throws()
       const res = await getRelayerStatus(relayerStub, { logger })
       expect(res).to.eql(UNAVAILABLE)

--- a/broker-daemon/broker-rpc/admin-service/health-check.spec.js
+++ b/broker-daemon/broker-rpc/admin-service/health-check.spec.js
@@ -41,7 +41,7 @@ describe('health-check', () => {
         debug: sinon.stub()
       }
       HealthCheckResponse = sinon.stub()
-      orderbookStatusOK = healthCheck.__get__('ORDERBOOK_STATUS_CODES').OK
+      orderbookStatusOK = healthCheck.__get__('ORDERBOOK_STATUS_CODES').ORDERBOOK_OK
       relayerStatusOK = healthCheck.__get__('RELAYER_STATUS_CODES').RELAYER_OK
       relayerStatusStub = sinon.stub().returns(relayerStatusOK)
 
@@ -104,10 +104,10 @@ describe('health-check', () => {
     })
 
     it('returns an UNAVAILABLE status code if the call to relayer fails', async () => {
-      const { UNAVAILABLE } = healthCheck.__get__('RELAYER_STATUS_CODES')
+      const { RELAYER_UNAVAILABLE } = healthCheck.__get__('RELAYER_STATUS_CODES')
       healthCheckStub.throws()
       const res = await getRelayerStatus(relayerStub, { logger })
-      expect(res).to.eql(UNAVAILABLE)
+      expect(res).to.eql(RELAYER_UNAVAILABLE)
     })
   })
 })

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -69,50 +69,27 @@ enum Side {
   ASK = 1;
 }
 
-/**
- * Statuses of an engine
- */
-enum EngineStatuses {
-  // Default state of the engine
-  UNKNOWN = 0;
-  // Engine is unavailable
-  UNAVAILABLE = 1;
-  // Wallet does not exist
-  NEEDS_WALLET = 2;
-  // Wallet exists but is not locked
-  LOCKED = 3;
-  // Wallet is unlocked but the configuration of the node and chain sync status are not known
-  UNLOCKED = 4;
-  // Engine is not yet synced to chain
-  NOT_SYNCED = 5;
-  // Engine is validated and ready for use
-  VALIDATED = 6;
-}
-
-/**
- * Statuses of the relayer
- */
-enum RelayerStatuses {
-  // Relayer is available
-  OK = 0;
-  // Relayer is not available
-  UNAVAILABLE = 1;
-}
-
-/**
- * Statuses of an orderbook
- */
-enum OrderbookStatuses {
-  // Orderbook is synced
-  OK = 0;
-  // Orderbook is not synced
-  NOT_SYNCED = 1;
-}
 
 /**
  * HealthCheckResponse provides information on the health of a BrokerDaemon.
  */
 message HealthCheckResponse {
+  // Statuses of an orderbook
+  enum OrderbookStatuses {
+    // Orderbook is synced
+    OK = 0;
+    // Orderbook is not synced
+    NOT_SYNCED = 1;
+  }
+
+  // Statuses of the relayer
+  enum RelayerStatuses {
+    // Relayer is available
+    RELAYER_OK = 0;
+    // Relayer is not available
+    UNAVAILABLE = 1;
+  }
+
   // The status of every engine available on the BrokerDaemon.
   repeated EngineStatus engine_status = 1;
   // The status of the relayer this BrokerDaemon is connected to, either `'OK'` or the error message returned when connecting to it.
@@ -124,6 +101,24 @@ message HealthCheckResponse {
    * EngineStatus provides the status of an engine for a currency.
    */
   message EngineStatus {
+    // Statuses of an engine
+    enum EngineStatuses {
+      // Default state of the engine
+      UNKNOWN = 0;
+      // Engine is unavailable
+      UNAVAILABLE = 1;
+      // Wallet does not exist
+      NEEDS_WALLET = 2;
+      // Wallet exists but is not locked
+      LOCKED = 3;
+      // Wallet is unlocked but the configuration of the node and chain sync status are not known
+      UNLOCKED = 4;
+      // Engine is not yet synced to chain
+      NOT_SYNCED = 5;
+      // Engine is validated and ready for use
+      VALIDATED = 6;
+    }
+
     // The common symbol that the engine is responsible for, e.g. `BTC` or `LTC`
     string symbol = 1;
     // The status of the engine

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -77,9 +77,9 @@ message HealthCheckResponse {
   // Statuses of an orderbook
   enum OrderbookStatuses {
     // Orderbook is synced
-    OK = 0;
+    ORDERBOOK_OK = 0;
     // Orderbook is not synced
-    NOT_SYNCED = 1;
+    ORDERBOOK_NOT_SYNCED = 1;
   }
 
   // Statuses of the relayer
@@ -87,7 +87,7 @@ message HealthCheckResponse {
     // Relayer is available
     RELAYER_OK = 0;
     // Relayer is not available
-    UNAVAILABLE = 1;
+    RELAYER_UNAVAILABLE = 1;
   }
 
   // The status of every engine available on the BrokerDaemon.

--- a/errors.txt
+++ b/errors.txt
@@ -1,1 +1,0 @@
-No such service: broker

--- a/errors.txt
+++ b/errors.txt
@@ -1,0 +1,1 @@
+No such service: broker


### PR DESCRIPTION
## Description
This PR modifies out broker.proto file to conform to protocol buffer spec so that users can build the broker proto file for other languages.

**Changes**
1. changed scoping of `RelayerStatuses`, `OrderbookStatuses` and `Engine Statuses`
2. changed `OK` of `RelayerStatuses` to `RELAYER_OK` to avoid conflicts with `OrderbookStatuses`

When running the original broker.proto file through protoc, we received the following errors:

```
http.proto: File not found.
google/api/annotations.proto: Import "http.proto" was not found or had errors.
google/api/annotations.proto:30:3: "HttpRule" is not defined.
broker.proto: Import "google/api/annotations.proto" was not found or had errors.
broker.proto:99:3: "UNAVAILABLE" is already defined in "broker.rpc".
broker.proto:99:3: Note that enum values use C++ scoping rules, meaning that enum values are siblings of their type, not children of it.  Therefore, "UNAVAILABLE" must be unique within "broker.rpc", not just within "RelayerStatuses".
broker.proto:107:3: "OK" is already defined in "broker.rpc".
broker.proto:107:3: Note that enum values use C++ scoping rules, meaning that enum values are siblings of their type, not children of it.  Therefore, "OK" must be unique within "broker.rpc", not just within "OrderbookStatuses".
broker.proto:109:3: "NOT_SYNCED" is already defined in "broker.rpc".
broker.proto:109:3: Note that enum values use C++ scoping rules, meaning that enum values are siblings of their type, not children of it.  Therefore, "NOT_SYNCED" must be unique within "broker.rpc", not just within "OrderbookStatuses".
```

**Protoc Usage:**
`protoc -I broker-daemon/proto -I broker-daemon/proto/google/api broker-daemon/proto/broker.proto --go_out=plugins=grpc:broker-daemon/proto`

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
