### PR TITLE
decrease min ping interval for rpc servers

### DIFF
--- a/broker-daemon/broker-rpc/broker-rpc-server.js
+++ b/broker-daemon/broker-rpc/broker-rpc-server.js
@@ -44,10 +44,10 @@ const GRPC_SERVER_OPTIONS = {
   'grpc.keepalive_time_ms': 30000,
   // Set to true. We want to send keep-alive pings even if the stream is not in use
   'grpc.keepalive_permit_without_calls': 1,
-  // Set to 30 seconds, Minimum allowed time of a series of pings from clients. If the
-  // client tries to ping faster than this default, we will send a ENHANCE_YOUR_CALM/GO_AWAY
+  // Set to 25 seconds, Minimum allowed time of a series of pings from clients. If the
+  // CLI/client tries to ping faster than this default, we will send a ENHANCE_YOUR_CALM/GO_AWAY
   // and the stream will close
-  'grpc.http2.min_ping_interval_without_data_ms': 30000,
+  'grpc.http2.min_ping_interval_without_data_ms': 25000,
   // Set to infinity, this means the server will continually send keep-alive pings
   'grpc.http2.max_pings_without_data': 0
 }

--- a/broker-daemon/interchain-router/index.js
+++ b/broker-daemon/interchain-router/index.js
@@ -25,10 +25,10 @@ const GRPC_SERVER_OPTIONS = {
   'grpc.keepalive_time_ms': 30000,
   // Set to true. We want to send keep-alive pings even if the stream is not in use
   'grpc.keepalive_permit_without_calls': 1,
-  // Set to 30 seconds, Minimum allowed time of a series of pings from clients. If the
+  // Set to 25 seconds, Minimum allowed time of a series of pings from clients. If the
   // client tries to ping faster than this default, we will send a ENHANCE_YOUR_CALM/GO_AWAY
   // and the stream will close
-  'grpc.http2.min_ping_interval_without_data_ms': 30000,
+  'grpc.http2.min_ping_interval_without_data_ms': 25000,
   // Set to infinity, this means the server will continually send keep-alive pings
   'grpc.http2.max_pings_without_data': 0
 }


### PR DESCRIPTION
## Description
This PR decreases the minimum allowed ping interval on the interchain router and broker rpc server (serves the CLI) to make sure we are not cancelling streams due to server timing issues.

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
