### PR TITLE
add error logging to error handler of place order

### DIFF
--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -290,6 +290,9 @@ const OrderStateMachine = StateMachine.factory({
       }
 
       const errHandler = (e) => {
+        this.logger.error('Received error when trying to place order:', { error: e, code: e.code })
+        // We handle unavailable error codes separately to add a friendly error to
+        // the order that can be viewed in it's order status
         const relayerError = e.code === grpc.status.UNAVAILABLE ? new Error(ORDER_ERROR_CODES.RELAYER_UNAVAILABLE) : e
         this.reject(relayerError)
         finish()


### PR DESCRIPTION
## Description
This PR fixes an issue where we swallow the stacktrace of an error if the `placeOrder` stream has failed to process.

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
