### PR TITLE
Feature - Add total reserved channel balance to broker balances

### DIFF
--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -54,19 +54,19 @@ const SUPPORTED_COMMANDS = Object.freeze({
  * @param {Object} args
  * @param {Object} opts
  * @param {string} [opts.rpcAddress] - broker rpc address
- * @param {boolean} [opts.commitFees] - whether total commit fees should be included
+ * @param {boolean} [opts.reserved] - whether total reserved balance should be included
  * @param {Logger} logger
  * @returns {void}
  */
 async function balance (args, opts, logger) {
-  const { rpcAddress, commitFees } = opts
+  const { rpcAddress, reserved } = opts
 
   try {
     const client = new BrokerDaemonClient(rpcAddress)
     const { balances } = await client.walletService.getBalances({})
 
-    const tableHeaders = ['', 'Committed (Pending)', 'Uncommitted (Pending)']
-    if (commitFees) { tableHeaders.push('Total Commit Fees') }
+    const commitedColumnHeader = reserved ? 'Committed (Pending) [Reserved]' : 'Committed (Pending)'
+    const tableHeaders = ['', commitedColumnHeader, 'Uncommitted (Pending)']
 
     const balancesTable = new Table({
       head: tableHeaders,
@@ -81,24 +81,26 @@ async function balance (args, opts, logger) {
         totalPendingChannelBalance,
         uncommittedBalance,
         uncommittedPendingBalance,
-        totalCommitFees
+        totalReservedChannelBalance
       } = balance
 
       totalChannelBalance = error ? 'Not Available'.yellow : totalChannelBalance.green
       uncommittedBalance = error ? 'Not Available'.yellow : uncommittedBalance
-      totalCommitFees = error ? 'Not Available'.yellow : totalCommitFees
+      totalReservedChannelBalance = error ? 'Not Available'.yellow : `[${totalReservedChannelBalance}]`.grey
 
       // We fix all pending balances to 8 decimal places due to aesthetics. Since
       // this balance should only be temporary, we do not care as much about precision
       totalPendingChannelBalance = error ? '' : `(${Big(totalPendingChannelBalance).toFixed(8)})`.grey
       uncommittedPendingBalance = error ? '' : `(${Big(uncommittedPendingBalance).toFixed(8)})`.grey
 
+      let channelBalanceCell = `${totalChannelBalance} ${totalPendingChannelBalance}`
+      if (reserved) { channelBalanceCell += ` ${totalReservedChannelBalance}`}
+
       const row = [
         symbol,
-        `${totalChannelBalance} ${totalPendingChannelBalance}`,
+        channelBalanceCell,
         `${uncommittedBalance} ${uncommittedPendingBalance}`
       ]
-      if (commitFees) { row.push(`${totalCommitFees}`) }
 
       balancesTable.push(row)
     })
@@ -539,7 +541,7 @@ module.exports = (program) => {
     // hook has been added in caporal. If the option is omitted, the subcommand will
     // not receive the variable in the `opts` object
     .option('--wallet-address [address]', 'used in sparkswap withdraw ONLY')
-    .option('--commit-fees', 'Display total commit fees')
+    .option('--reserved', 'Display total reserved balance')
     .option('--force', 'Force close all channels. This options is only used in the sparkswap release command', null, false)
     .action(async (args, opts, logger) => {
       const { command, subArguments } = args
@@ -633,7 +635,7 @@ module.exports = (program) => {
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING)
     .command(`wallet ${SUPPORTED_COMMANDS.BALANCE}`, 'Current daemon wallet balance')
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING)
-    .option('--commit-fees', 'Display total commit fees')
+    .option('--reserved', 'Display total reserved balance')
     .command(`wallet ${SUPPORTED_COMMANDS.NEW_DEPOSIT_ADDRESS}`, 'Generates a new wallet address for a daemon instance')
     .argument('<symbol>', `Supported currencies: ${SUPPORTED_SYMBOLS.join('/')}`)
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING)

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -94,7 +94,9 @@ async function balance (args, opts, logger) {
       uncommittedPendingBalance = error ? '' : `(${Big(uncommittedPendingBalance).toFixed(8)})`.grey
 
       let channelBalanceCell = `${totalChannelBalance} ${totalPendingChannelBalance}`
-      if (reserved) { channelBalanceCell += ` ${totalReservedChannelBalance}` }
+      if (reserved) {
+        channelBalanceCell += ` ${totalReservedChannelBalance}`
+      }
 
       const row = [
         symbol,

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -94,7 +94,7 @@ async function balance (args, opts, logger) {
       uncommittedPendingBalance = error ? '' : `(${Big(uncommittedPendingBalance).toFixed(8)})`.grey
 
       let channelBalanceCell = `${totalChannelBalance} ${totalPendingChannelBalance}`
-      if (reserved) { channelBalanceCell += ` ${totalReservedChannelBalance}`}
+      if (reserved) { channelBalanceCell += ` ${totalReservedChannelBalance}` }
 
       const row = [
         symbol,

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -65,7 +65,7 @@ async function balance (args, opts, logger) {
     const { balances } = await client.walletService.getBalances({})
 
     const balancesTable = new Table({
-      head: ['', 'Committed (Pending)', 'Uncommitted (Pending)', 'Commit Fees'],
+      head: ['', 'Committed (Pending)', 'Uncommitted (Pending)', 'Total Commit Fees'],
       style: { head: ['gray'] }
     })
 
@@ -77,12 +77,12 @@ async function balance (args, opts, logger) {
         totalPendingChannelBalance,
         uncommittedBalance,
         uncommittedPendingBalance,
-        commitFees
+        totalCommitFees
       } = balance
 
       totalChannelBalance = error ? 'Not Available'.yellow : totalChannelBalance.green
       uncommittedBalance = error ? 'Not Available'.yellow : uncommittedBalance
-      commitFees = error ? 'Not Available'.yellow : commitFees
+      totalCommitFees = error ? 'Not Available'.yellow : totalCommitFees
 
       // We fix all pending balances to 8 decimal places due to aesthetics. Since
       // this balance should only be temporary, we do not care as much about precision
@@ -93,7 +93,7 @@ async function balance (args, opts, logger) {
         symbol,
         `${totalChannelBalance} ${totalPendingChannelBalance}`,
         `${uncommittedBalance} ${uncommittedPendingBalance}`,
-        `${commitFees}`
+        `${totalCommitFees}`
       ])
     })
 

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -65,7 +65,7 @@ async function balance (args, opts, logger) {
     const { balances } = await client.walletService.getBalances({})
 
     const balancesTable = new Table({
-      head: ['', 'Committed (Pending)', 'Uncommitted (Pending)'],
+      head: ['', 'Committed (Pending)', 'Uncommitted (Pending)', 'Commit Fees'],
       style: { head: ['gray'] }
     })
 
@@ -76,11 +76,13 @@ async function balance (args, opts, logger) {
         totalChannelBalance,
         totalPendingChannelBalance,
         uncommittedBalance,
-        uncommittedPendingBalance
+        uncommittedPendingBalance,
+        commitFees
       } = balance
 
       totalChannelBalance = error ? 'Not Available'.yellow : totalChannelBalance.green
       uncommittedBalance = error ? 'Not Available'.yellow : uncommittedBalance
+      commitFees = error ? 'Not Available'.yellow : commitFees
 
       // We fix all pending balances to 8 decimal places due to aesthetics. Since
       // this balance should only be temporary, we do not care as much about precision
@@ -90,7 +92,8 @@ async function balance (args, opts, logger) {
       balancesTable.push([
         symbol,
         `${totalChannelBalance} ${totalPendingChannelBalance}`,
-        `${uncommittedBalance} ${uncommittedPendingBalance}`
+        `${uncommittedBalance} ${uncommittedPendingBalance}`,
+        `${commitFees}`
       ])
     })
 

--- a/broker-cli/commands/wallet.spec.js
+++ b/broker-cli/commands/wallet.spec.js
@@ -80,7 +80,7 @@ describe('cli wallet', () => {
     let daemonStub
     let walletBalanceStub
     let rpcAddress
-    let commitFees
+    let reserved
     let symbol
     let args
     let opts
@@ -97,8 +97,8 @@ describe('cli wallet', () => {
       symbol = 'BTC'
       args = { symbol }
       rpcAddress = 'test:1337'
-      commitFees = false
-      opts = { rpcAddress, commitFees }
+      reserved = false
+      opts = { rpcAddress, reserved }
       logger = { info: sinon.stub(), error: sinon.stub() }
       btcBalance = {
         symbol,
@@ -107,7 +107,7 @@ describe('cli wallet', () => {
         totalChannelBalance: '0.0000200000000000',
         totalPendingChannelBalance: '0.0000100000000000',
         uncommittedPendingBalance: '0.0000300000000000',
-        totalCommitFees: '0.0000905000000000'
+        totalReservedChannelBalance: '0.0000905000000000'
       }
       ltcBalance = {
         symbol: 'LTC',
@@ -116,7 +116,7 @@ describe('cli wallet', () => {
         totalChannelBalance: '0.0000020000000000',
         totalPendingChannelBalance: '0.0000050000000000',
         uncommittedPendingBalance: '0.0000010000000000',
-        totalCommitFees: '0.0000000000000000'
+        totalReservedChannelBalance: '0.0000000000000000'
       }
       balances = [btcBalance, ltcBalance]
 
@@ -163,9 +163,9 @@ describe('cli wallet', () => {
       })
     })
 
-    it('adds correct fees for BTC', async () => {
-      commitFees = true
-      opts = { rpcAddress, commitFees }
+    it('adds correct reserved channel balance for BTC', async () => {
+      reserved = true
+      opts = { rpcAddress, reserved }
       await balance(args, opts, logger)
       const expectedResult = ['BTC', '0.0000200000000000', '0.000100000000000', '0.0000905000000000']
 
@@ -178,9 +178,9 @@ describe('cli wallet', () => {
       })
     })
 
-    it('adds correct fees for LTC', async () => {
-      commitFees = true
-      opts = { rpcAddress, commitFees }
+    it('adds correct reserved channel balance for LTC', async () => {
+      reserved = true
+      opts = { rpcAddress, reserved }
       await balance(args, opts, logger)
       const expectedResult = ['LTC', '0.0000020000000000', '0.0000020000000000', '0.0000000000000000']
 
@@ -224,7 +224,7 @@ describe('cli wallet', () => {
           totalChannelBalance: '',
           totalPendingChannelBalance: '',
           uncommittedPendingBalance: '',
-          totalCommitFees: ''
+          totalReservedChannelBalance: ''
         }
         balances = [btcBalance, emptyLtcBalance]
 

--- a/broker-cli/commands/wallet.spec.js
+++ b/broker-cli/commands/wallet.spec.js
@@ -80,6 +80,7 @@ describe('cli wallet', () => {
     let daemonStub
     let walletBalanceStub
     let rpcAddress
+    let commitFees
     let symbol
     let args
     let opts
@@ -96,7 +97,8 @@ describe('cli wallet', () => {
       symbol = 'BTC'
       args = { symbol }
       rpcAddress = 'test:1337'
-      opts = { rpcAddress }
+      commitFees = false
+      opts = { rpcAddress, commitFees }
       logger = { info: sinon.stub(), error: sinon.stub() }
       btcBalance = {
         symbol,
@@ -104,7 +106,8 @@ describe('cli wallet', () => {
         uncommittedBalance: '0.0001000000000000',
         totalChannelBalance: '0.0000200000000000',
         totalPendingChannelBalance: '0.0000100000000000',
-        uncommittedPendingBalance: '0.0000300000000000'
+        uncommittedPendingBalance: '0.0000300000000000',
+        totalCommitFees: '0.0000905000000000'
       }
       ltcBalance = {
         symbol: 'LTC',
@@ -112,7 +115,8 @@ describe('cli wallet', () => {
         uncommittedBalance: '0.0000020000000000',
         totalChannelBalance: '0.0000020000000000',
         totalPendingChannelBalance: '0.0000050000000000',
-        uncommittedPendingBalance: '0.0000010000000000'
+        uncommittedPendingBalance: '0.0000010000000000',
+        totalCommitFees: '0.0000000000000000'
       }
       balances = [btcBalance, ltcBalance]
 
@@ -159,6 +163,36 @@ describe('cli wallet', () => {
       })
     })
 
+    it('adds correct fees for BTC', async () => {
+      commitFees = true
+      opts = { rpcAddress, commitFees }
+      await balance(args, opts, logger)
+      const expectedResult = ['BTC', '0.0000200000000000', '0.000100000000000', '0.0000905000000000']
+
+      const result = tablePushStub.args[0][0]
+
+      // Since the text in the result contains colors (non-TTY) we have to use
+      // an includes matcher instead of importing the color lib for testing.
+      result.forEach((r, i) => {
+        expect(r).to.include(expectedResult[i])
+      })
+    })
+
+    it('adds correct fees for LTC', async () => {
+      commitFees = true
+      opts = { rpcAddress, commitFees }
+      await balance(args, opts, logger)
+      const expectedResult = ['LTC', '0.0000020000000000', '0.0000020000000000', '0.0000000000000000']
+
+      const result = tablePushStub.args[1][0]
+
+      // Since the text in the result contains colors (non-TTY) we have to use
+      // an includes matcher instead of importing the color lib for testing.
+      result.forEach((r, i) => {
+        expect(r).to.include(expectedResult[i])
+      })
+    })
+
     it('adds balances to the cli table', async () => {
       await balance(args, opts, logger)
       expect(tablePushStub).to.have.been.calledTwice()
@@ -189,7 +223,8 @@ describe('cli wallet', () => {
           uncommittedBalance: '',
           totalChannelBalance: '',
           totalPendingChannelBalance: '',
-          uncommittedPendingBalance: ''
+          uncommittedPendingBalance: '',
+          totalCommitFees: ''
         }
         balances = [btcBalance, emptyLtcBalance]
 

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -1311,8 +1311,8 @@ message Balance {
   string total_pending_channel_balance = 4;
   // Balance in the listed currency that is currently in pending closing channels and unconfirmed wallet balance. This is currently in common units (e.g. 0.5 BTC)
   string uncommitted_pending_balance = 5;
-  // Total balance across all channels that are reserved as fees due to a force close. This is currently in common units (e.g. 0.5 BTC)
-  string total_commit_fees = 6;
+  // Total balance across all channels that are reserved (reasons may include fees reserved on the underlying network). This is currently in common units (e.g. 0.5 BTC)
+  string total_reserved_channel_balance = 6;
   // Error message if balances are not available
   string error = 10;
 }
@@ -1525,9 +1525,10 @@ service WalletService {
   /**
    * GetBalances retrieves the balance in all currency in wallets managed by Payment Channel Network nodes for this Broker.
    *
-   * Balances are divided into `uncommittedBalance`, i.e. everything not in a channel, `totalChannelBalance` (i.e. everything in channels opened by the Payment Channel Network nodes),
-   * `totalPendingChannelBalance`, i.e. funds in channels that have finished the funding workflow and are waiting for confirmations for the funding txn, and
-   * `uncommittedPendingBalance`, i.e funds in channels that are pending closure or unconfirmed unspent outputs under control of the wallet.
+   * Balances are divided into `uncommittedBalance` (i.e. everything not in a channel), `totalChannelBalance` (i.e. everything in channels opened by the Payment Channel Network nodes),
+   * `totalPendingChannelBalance` (i.e. funds in channels that have finished the funding workflow and are waiting for confirmations for the funding txn), `uncommittedPendingBalance`
+   * (i.e funds in channels that are pending closure or unconfirmed unspent outputs under control of the wallet), and `totalReservedChannelBalance` (i.e. funds in a channel that aren't
+   * available for the channel initiator to send).`
    *
    * NOTE: If an engine is unavailable, the balances for the particular engine will be empty `''`
    *
@@ -1552,14 +1553,16 @@ service WalletService {
    *     "uncommittedBalance": "10.0000000000000000",
    *     "totalChannelBalance": "0.1670000000000000",
    *     "totalPendingChannelBalance": "0.0001000000000000",
-   *     "uncommittedPendingBalance": "0"
+   *     "uncommittedPendingBalance": "0",
+   *     "totalReservedChannelBalance": "0.0000905000000000"
    *   },
    *   {
    *     "symbol": "LTC",
    *     "uncommittedBalance": "10.0000000000000000",
    *     "totalChannelBalance": "0.1670000000000000",
    *     "totalPendingChannelBalance": "0.0002000000000000",
-   *     "uncommittedPendingBalance": "0"
+   *     "uncommittedPendingBalance": "0",
+   *     "totalReservedChannelBalance": "0.0000905000000000"
    *   }
    * ]
    * ```
@@ -1573,6 +1576,19 @@ service WalletService {
    * ├──────────┼──────────────────────────────────┼──────────────────────────────────┤
    * │ LTC      │ 0.0000000000000000 (0.00000000)  │ 10.0000000000000000 (0.00000000) │
    * └──────────┴──────────────────────────────────┴──────────────────────────────────┘
+   * ```
+   * ```shell
+   * > sparkswap wallet balance --reserved
+   * ```
+   * Passing the optional `--reserved` flag will print
+   * ```shell
+   * ┌─────┬──────────────────────────────────────────────────────┬──────────────────────────────────┐
+   * │     │ Committed (Pending) [Reserved]                       │ Uncommitted (Pending)            │
+   * ├─────┼──────────────────────────────────────────────────────┼──────────────────────────────────┤
+   * │ BTC │ 0.1676816500000000 (0.00000000) [0.0000905000000000] │ 0.8321399800000000 (0.00000000)  │
+   * ├─────┼──────────────────────────────────────────────────────┼──────────────────────────────────┤
+   * │ LTC │ 0.0000000000000000 (0.00000000) [0.0000000000000000] │ 10.0000000000000000 (0.00000000) │
+   * └─────┴──────────────────────────────────────────────────────┴──────────────────────────────────┘
    * ```
    */
   rpc GetBalances (google.protobuf.Empty) returns (GetBalancesResponse) {

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -1311,6 +1311,8 @@ message Balance {
   string total_pending_channel_balance = 4;
   // Balance in the listed currency that is currently in pending closing channels and unconfirmed wallet balance. This is currently in common units (e.g. 0.5 BTC)
   string uncommitted_pending_balance = 5;
+  // Total balance across all channels that are reserved as fees due to a force close. This is currently in common units (e.g. 0.5 BTC)
+  string commit_fees = 6;
   // Error message if balances are not available
   string error = 10;
 }

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -1312,7 +1312,7 @@ message Balance {
   // Balance in the listed currency that is currently in pending closing channels and unconfirmed wallet balance. This is currently in common units (e.g. 0.5 BTC)
   string uncommitted_pending_balance = 5;
   // Total balance across all channels that are reserved as fees due to a force close. This is currently in common units (e.g. 0.5 BTC)
-  string commit_fees = 6;
+  string total_commit_fees = 6;
   // Error message if balances are not available
   string error = 10;
 }

--- a/broker-daemon/broker-rpc/wallet-service/get-balances.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-balances.js
@@ -23,25 +23,28 @@ const BALANCE_PRECISION = 16
 async function getEngineBalances (symbol, engine, logger) {
   const { quantumsPerCommon } = engine
 
-  let [uncommittedBalance, totalChannelBalance, totalPendingChannelBalance, uncommittedPendingBalance] = await Promise.all([
+  let [uncommittedBalance, totalChannelBalance, totalPendingChannelBalance, uncommittedPendingBalance, commitFees] = await Promise.all([
     engine.getUncommittedBalance(),
     engine.getTotalChannelBalance(),
     engine.getTotalPendingChannelBalance(),
-    engine.getUncommittedPendingBalance()
+    engine.getUncommittedPendingBalance(),
+    engine.getCommitFees()
   ])
 
-  logger.debug(`Received balances from ${symbol} engine`, { uncommittedBalance, totalChannelBalance, totalPendingChannelBalance, uncommittedPendingBalance })
+  logger.debug(`Received balances from ${symbol} engine`, { uncommittedBalance, totalChannelBalance, totalPendingChannelBalance, uncommittedPendingBalance, commitFees })
 
   totalChannelBalance = Big(totalChannelBalance).div(quantumsPerCommon).toFixed(BALANCE_PRECISION)
   totalPendingChannelBalance = Big(totalPendingChannelBalance).div(quantumsPerCommon).toFixed(BALANCE_PRECISION)
   uncommittedBalance = Big(uncommittedBalance).div(quantumsPerCommon).toFixed(BALANCE_PRECISION)
   uncommittedPendingBalance = Big(uncommittedPendingBalance).div(quantumsPerCommon).toFixed(BALANCE_PRECISION)
+  commitFees = Big(commitFees).div(quantumsPerCommon).toFixed(BALANCE_PRECISION)
 
   return {
     uncommittedBalance,
     totalChannelBalance,
     totalPendingChannelBalance,
-    uncommittedPendingBalance
+    uncommittedPendingBalance,
+    commitFees
   }
 }
 

--- a/broker-daemon/broker-rpc/wallet-service/get-balances.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-balances.js
@@ -23,28 +23,28 @@ const BALANCE_PRECISION = 16
 async function getEngineBalances (symbol, engine, logger) {
   const { quantumsPerCommon } = engine
 
-  let [uncommittedBalance, totalChannelBalance, totalPendingChannelBalance, uncommittedPendingBalance, commitFees] = await Promise.all([
+  let [uncommittedBalance, totalChannelBalance, totalPendingChannelBalance, uncommittedPendingBalance, totalCommitFees] = await Promise.all([
     engine.getUncommittedBalance(),
     engine.getTotalChannelBalance(),
     engine.getTotalPendingChannelBalance(),
     engine.getUncommittedPendingBalance(),
-    engine.getCommitFees()
+    engine.getTotalCommitFees()
   ])
 
-  logger.debug(`Received balances from ${symbol} engine`, { uncommittedBalance, totalChannelBalance, totalPendingChannelBalance, uncommittedPendingBalance, commitFees })
+  logger.debug(`Received balances from ${symbol} engine`, { uncommittedBalance, totalChannelBalance, totalPendingChannelBalance, uncommittedPendingBalance, totalCommitFees })
 
   totalChannelBalance = Big(totalChannelBalance).div(quantumsPerCommon).toFixed(BALANCE_PRECISION)
   totalPendingChannelBalance = Big(totalPendingChannelBalance).div(quantumsPerCommon).toFixed(BALANCE_PRECISION)
   uncommittedBalance = Big(uncommittedBalance).div(quantumsPerCommon).toFixed(BALANCE_PRECISION)
   uncommittedPendingBalance = Big(uncommittedPendingBalance).div(quantumsPerCommon).toFixed(BALANCE_PRECISION)
-  commitFees = Big(commitFees).div(quantumsPerCommon).toFixed(BALANCE_PRECISION)
+  totalCommitFees = Big(totalCommitFees).div(quantumsPerCommon).toFixed(BALANCE_PRECISION)
 
   return {
     uncommittedBalance,
     totalChannelBalance,
     totalPendingChannelBalance,
     uncommittedPendingBalance,
-    commitFees
+    totalCommitFees
   }
 }
 

--- a/broker-daemon/broker-rpc/wallet-service/get-balances.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-balances.js
@@ -28,7 +28,7 @@ async function getEngineBalances (symbol, engine, logger) {
     engine.getTotalChannelBalance(),
     engine.getTotalPendingChannelBalance(),
     engine.getUncommittedPendingBalance(),
-    engine.getTotalCommitFees()
+    engine.getTotalReservedChannelBalance()
   ])
 
   logger.debug(`Received balances from ${symbol} engine`, { uncommittedBalance, totalChannelBalance, totalPendingChannelBalance, uncommittedPendingBalance, totalReservedChannelBalance })

--- a/broker-daemon/broker-rpc/wallet-service/get-balances.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-balances.js
@@ -23,7 +23,7 @@ const BALANCE_PRECISION = 16
 async function getEngineBalances (symbol, engine, logger) {
   const { quantumsPerCommon } = engine
 
-  let [uncommittedBalance, totalChannelBalance, totalPendingChannelBalance, uncommittedPendingBalance, totalCommitFees] = await Promise.all([
+  let [uncommittedBalance, totalChannelBalance, totalPendingChannelBalance, uncommittedPendingBalance, totalReservedChannelBalance] = await Promise.all([
     engine.getUncommittedBalance(),
     engine.getTotalChannelBalance(),
     engine.getTotalPendingChannelBalance(),
@@ -31,20 +31,20 @@ async function getEngineBalances (symbol, engine, logger) {
     engine.getTotalCommitFees()
   ])
 
-  logger.debug(`Received balances from ${symbol} engine`, { uncommittedBalance, totalChannelBalance, totalPendingChannelBalance, uncommittedPendingBalance, totalCommitFees })
+  logger.debug(`Received balances from ${symbol} engine`, { uncommittedBalance, totalChannelBalance, totalPendingChannelBalance, uncommittedPendingBalance, totalReservedChannelBalance })
 
   totalChannelBalance = Big(totalChannelBalance).div(quantumsPerCommon).toFixed(BALANCE_PRECISION)
   totalPendingChannelBalance = Big(totalPendingChannelBalance).div(quantumsPerCommon).toFixed(BALANCE_PRECISION)
   uncommittedBalance = Big(uncommittedBalance).div(quantumsPerCommon).toFixed(BALANCE_PRECISION)
   uncommittedPendingBalance = Big(uncommittedPendingBalance).div(quantumsPerCommon).toFixed(BALANCE_PRECISION)
-  totalCommitFees = Big(totalCommitFees).div(quantumsPerCommon).toFixed(BALANCE_PRECISION)
+  totalReservedChannelBalance = Big(totalReservedChannelBalance).div(quantumsPerCommon).toFixed(BALANCE_PRECISION)
 
   return {
     uncommittedBalance,
     totalChannelBalance,
     totalPendingChannelBalance,
     uncommittedPendingBalance,
-    totalCommitFees
+    totalReservedChannelBalance
   }
 }
 

--- a/broker-daemon/broker-rpc/wallet-service/get-balances.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-balances.spec.js
@@ -27,7 +27,8 @@ describe('get-balances', () => {
         uncommittedBalance: '0.0000000000000001',
         totalChannelBalance: '0.0000000000000001',
         totalPendingChannelBalance: '0.0000000000000001',
-        uncommittedPendingBalance: '0.0000000000000001'
+        uncommittedPendingBalance: '0.0000000000000001',
+        totalCommitFees: '0.0000000000000001'
       }
       engineStub = sinon.stub()
       engines = new Map([['BTC', engineStub]])
@@ -89,6 +90,8 @@ describe('get-balances', () => {
     let uncommittedPendingBalance
     let uncommittedPendingBalanceStub
     let totalPendingBalanceStub
+    let totalCommitFees
+    let totalCommitFeesStub
 
     beforeEach(() => {
       symbol = 'BTC'
@@ -96,16 +99,19 @@ describe('get-balances', () => {
       totalChannelBalance = 10000
       totalPendingChannelBalance = 1000
       uncommittedPendingBalance = 5000
+      totalCommitFees = 1000
 
       uncommittedBalanceStub = sinon.stub().resolves(uncommittedBalance)
       totalChannelBalanceStub = sinon.stub().resolves(totalChannelBalance)
       totalPendingBalanceStub = sinon.stub().resolves(totalPendingChannelBalance)
       uncommittedPendingBalanceStub = sinon.stub().resolves(uncommittedPendingBalance)
+      totalCommitFeesStub = sinon.stub().resolves(totalCommitFees)
       engineStub = {
         getUncommittedBalance: uncommittedBalanceStub,
         getTotalChannelBalance: totalChannelBalanceStub,
         getTotalPendingChannelBalance: totalPendingBalanceStub,
         getUncommittedPendingBalance: uncommittedPendingBalanceStub,
+        getTotalCommitFees: totalCommitFeesStub,
         quantumsPerCommon: '100000000'
       }
 
@@ -122,13 +128,29 @@ describe('get-balances', () => {
       expect(totalChannelBalanceStub).to.have.been.calledOnce()
     })
 
+    it('gets the total pending channel balance of an engine', async () => {
+      await getEngineBalances(symbol, engineStub, logger)
+      expect(totalPendingBalanceStub).to.have.been.calledOnce()
+    })
+
+    it('gets the total uncommitted pending balance of an engine', async () => {
+      await getEngineBalances(symbol, engineStub, logger)
+      expect(uncommittedPendingBalanceStub).to.have.been.calledOnce()
+    })
+
+    it('gets the total commit fees of an engine', async () => {
+      await getEngineBalances(symbol, engineStub, logger)
+      expect(totalCommitFeesStub).to.have.been.calledOnce()
+    })
+
     it('returns balances for an engine', async () => {
       const res = await getEngineBalances(symbol, engineStub, logger)
       expect(res).to.eql({
         uncommittedBalance: '0.0100000000000000',
         totalChannelBalance: '0.0001000000000000',
         totalPendingChannelBalance: '0.0000100000000000',
-        uncommittedPendingBalance: '0.0000500000000000'
+        uncommittedPendingBalance: '0.0000500000000000',
+        totalCommitFees: '0.0000100000000000'
       })
     })
   })

--- a/broker-daemon/broker-rpc/wallet-service/get-balances.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-balances.spec.js
@@ -150,7 +150,7 @@ describe('get-balances', () => {
         totalChannelBalance: '0.0001000000000000',
         totalPendingChannelBalance: '0.0000100000000000',
         uncommittedPendingBalance: '0.0000500000000000',
-        totalCommitFees: '0.0000100000000000'
+        totalReservedChannelBalance: '0.0000100000000000'
       })
     })
   })

--- a/broker-daemon/broker-rpc/wallet-service/get-balances.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-balances.spec.js
@@ -28,7 +28,7 @@ describe('get-balances', () => {
         totalChannelBalance: '0.0000000000000001',
         totalPendingChannelBalance: '0.0000000000000001',
         uncommittedPendingBalance: '0.0000000000000001',
-        totalCommitFees: '0.0000000000000001'
+        totalReservedChannelBalance: '0.0000000000000001'
       }
       engineStub = sinon.stub()
       engines = new Map([['BTC', engineStub]])
@@ -90,8 +90,8 @@ describe('get-balances', () => {
     let uncommittedPendingBalance
     let uncommittedPendingBalanceStub
     let totalPendingBalanceStub
-    let totalCommitFees
-    let totalCommitFeesStub
+    let totalReservedChannelBalance
+    let totalReservedChannelBalanceStub
 
     beforeEach(() => {
       symbol = 'BTC'
@@ -99,19 +99,19 @@ describe('get-balances', () => {
       totalChannelBalance = 10000
       totalPendingChannelBalance = 1000
       uncommittedPendingBalance = 5000
-      totalCommitFees = 1000
+      totalReservedChannelBalance = 1000
 
       uncommittedBalanceStub = sinon.stub().resolves(uncommittedBalance)
       totalChannelBalanceStub = sinon.stub().resolves(totalChannelBalance)
       totalPendingBalanceStub = sinon.stub().resolves(totalPendingChannelBalance)
       uncommittedPendingBalanceStub = sinon.stub().resolves(uncommittedPendingBalance)
-      totalCommitFeesStub = sinon.stub().resolves(totalCommitFees)
+      totalReservedChannelBalanceStub = sinon.stub().resolves(totalReservedChannelBalance)
       engineStub = {
         getUncommittedBalance: uncommittedBalanceStub,
         getTotalChannelBalance: totalChannelBalanceStub,
         getTotalPendingChannelBalance: totalPendingBalanceStub,
         getUncommittedPendingBalance: uncommittedPendingBalanceStub,
-        getTotalCommitFees: totalCommitFeesStub,
+        getTotalReservedChannelBalance: totalReservedChannelBalanceStub,
         quantumsPerCommon: '100000000'
       }
 
@@ -138,9 +138,9 @@ describe('get-balances', () => {
       expect(uncommittedPendingBalanceStub).to.have.been.calledOnce()
     })
 
-    it('gets the total commit fees of an engine', async () => {
+    it('gets the total reserved channel balance of an engine', async () => {
       await getEngineBalances(symbol, engineStub, logger)
-      expect(totalCommitFeesStub).to.have.been.calledOnce()
+      expect(totalReservedChannelBalanceStub).to.have.been.calledOnce()
     })
 
     it('returns balances for an engine', async () => {

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -1311,8 +1311,8 @@ message Balance {
   string total_pending_channel_balance = 4;
   // Balance in the listed currency that is currently in pending closing channels and unconfirmed wallet balance. This is currently in common units (e.g. 0.5 BTC)
   string uncommitted_pending_balance = 5;
-  // Total balance across all channels that are reserved as fees due to a force close. This is currently in common units (e.g. 0.5 BTC)
-  string total_commit_fees = 6;
+  // Total balance across all channels that are reserved (reasons may include fees reserved on the underlying network). This is currently in common units (e.g. 0.5 BTC)
+  string total_reserved_channel_balance = 6;
   // Error message if balances are not available
   string error = 10;
 }
@@ -1525,9 +1525,10 @@ service WalletService {
   /**
    * GetBalances retrieves the balance in all currency in wallets managed by Payment Channel Network nodes for this Broker.
    *
-   * Balances are divided into `uncommittedBalance`, i.e. everything not in a channel, `totalChannelBalance` (i.e. everything in channels opened by the Payment Channel Network nodes),
-   * `totalPendingChannelBalance`, i.e. funds in channels that have finished the funding workflow and are waiting for confirmations for the funding txn, and
-   * `uncommittedPendingBalance`, i.e funds in channels that are pending closure or unconfirmed unspent outputs under control of the wallet.
+   * Balances are divided into `uncommittedBalance` (i.e. everything not in a channel), `totalChannelBalance` (i.e. everything in channels opened by the Payment Channel Network nodes),
+   * `totalPendingChannelBalance` (i.e. funds in channels that have finished the funding workflow and are waiting for confirmations for the funding txn), `uncommittedPendingBalance`
+   * (i.e funds in channels that are pending closure or unconfirmed unspent outputs under control of the wallet), and `totalReservedChannelBalance` (i.e. funds in a channel that aren't
+   * available for the channel initiator to send).`
    *
    * NOTE: If an engine is unavailable, the balances for the particular engine will be empty `''`
    *
@@ -1552,14 +1553,16 @@ service WalletService {
    *     "uncommittedBalance": "10.0000000000000000",
    *     "totalChannelBalance": "0.1670000000000000",
    *     "totalPendingChannelBalance": "0.0001000000000000",
-   *     "uncommittedPendingBalance": "0"
+   *     "uncommittedPendingBalance": "0",
+   *     "totalReservedChannelBalance": "0.0000905000000000"
    *   },
    *   {
    *     "symbol": "LTC",
    *     "uncommittedBalance": "10.0000000000000000",
    *     "totalChannelBalance": "0.1670000000000000",
    *     "totalPendingChannelBalance": "0.0002000000000000",
-   *     "uncommittedPendingBalance": "0"
+   *     "uncommittedPendingBalance": "0",
+   *     "totalReservedChannelBalance": "0.0000905000000000"
    *   }
    * ]
    * ```
@@ -1573,6 +1576,19 @@ service WalletService {
    * ├──────────┼──────────────────────────────────┼──────────────────────────────────┤
    * │ LTC      │ 0.0000000000000000 (0.00000000)  │ 10.0000000000000000 (0.00000000) │
    * └──────────┴──────────────────────────────────┴──────────────────────────────────┘
+   * ```
+   * ```shell
+   * > sparkswap wallet balance --reserved
+   * ```
+   * Passing the optional `--reserved` flag will print
+   * ```shell
+   * ┌─────┬──────────────────────────────────────────────────────┬──────────────────────────────────┐
+   * │     │ Committed (Pending) [Reserved]                       │ Uncommitted (Pending)            │
+   * ├─────┼──────────────────────────────────────────────────────┼──────────────────────────────────┤
+   * │ BTC │ 0.1676816500000000 (0.00000000) [0.0000905000000000] │ 0.8321399800000000 (0.00000000)  │
+   * ├─────┼──────────────────────────────────────────────────────┼──────────────────────────────────┤
+   * │ LTC │ 0.0000000000000000 (0.00000000) [0.0000000000000000] │ 10.0000000000000000 (0.00000000) │
+   * └─────┴──────────────────────────────────────────────────────┴──────────────────────────────────┘
    * ```
    */
   rpc GetBalances (google.protobuf.Empty) returns (GetBalancesResponse) {

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -1311,6 +1311,8 @@ message Balance {
   string total_pending_channel_balance = 4;
   // Balance in the listed currency that is currently in pending closing channels and unconfirmed wallet balance. This is currently in common units (e.g. 0.5 BTC)
   string uncommitted_pending_balance = 5;
+  // Total balance across all channels that are reserved as fees due to a force close. This is currently in common units (e.g. 0.5 BTC)
+  string commit_fees = 6;
   // Error message if balances are not available
   string error = 10;
 }

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -1312,7 +1312,7 @@ message Balance {
   // Balance in the listed currency that is currently in pending closing channels and unconfirmed wallet balance. This is currently in common units (e.g. 0.5 BTC)
   string uncommitted_pending_balance = 5;
   // Total balance across all channels that are reserved as fees due to a force close. This is currently in common units (e.g. 0.5 BTC)
-  string commit_fees = 6;
+  string total_commit_fees = 6;
   // Error message if balances are not available
   string error = 10;
 }


### PR DESCRIPTION
## Description
This PR updates the CLI so running `sparkswap wallet balance` can be passed an optional `--reserved` flag which will include total reserved balances (i.e. commit fees) for all open channels controlled by the broker.

![image](https://user-images.githubusercontent.com/11034691/55995155-9eacf500-5c68-11e9-9e5b-9b7787e9bfb8.png)

## Related PRs
https://github.com/sparkswap/lnd-engine/pull/197


## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
