### PR TITLE
Use latest npm to avoid cache issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - checkout
 
+      # Make sure we are on the latest npm version
+      - run: npm i -g npm
+
       # Download and cache dependencies
       - restore_cache:
           keys:
@@ -36,6 +39,10 @@ jobs:
     working_directory: ~/broker
     steps:
       - checkout
+
+      # Make sure we are on the latest npm version
+      - run: npm i -g npm
+
       # Download and cache dependencies
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
       - checkout
 
-      # Make sure we are on the latest npm version
-      - run: npm i -g npm
+      # Make sure we are on atleast v6 npm
+      - run: npm i -g npm@6
 
       # Download and cache dependencies
       - restore_cache:
@@ -40,8 +40,8 @@ jobs:
     steps:
       - checkout
 
-      # Make sure we are on the latest npm version
-      - run: npm i -g npm
+      # Make sure we are on atleast v6 npm
+      - run: npm i -g npm@6
 
       # Download and cache dependencies
       - restore_cache:


### PR DESCRIPTION
## Description
Update our CI scripts to have npm at the latest version when we run specs or install things from cache. We are hoping this will prevent caching issues from occurring during `master` builds of the broker

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
