### PR TITLE
Remove nesting of enums

### DIFF
--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -70,70 +70,70 @@ enum Side {
 }
 
 
+// Statuses of the relayer
+enum RelayerStatuses {
+  // Relayer is available
+  RELAYER_OK = 0;
+  // Relayer is not available
+  RELAYER_UNAVAILABLE = 1;
+}
+
+// Statuses of an engine
+enum EngineStatuses {
+  // Default state of the engine
+  UNKNOWN = 0;
+  // Engine is unavailable
+  UNAVAILABLE = 1;
+  // Wallet does not exist
+  NEEDS_WALLET = 2;
+  // Wallet exists but is not locked
+  LOCKED = 3;
+  // Wallet is unlocked but the configuration of the node and chain sync status are not known
+  UNLOCKED = 4;
+  // Engine is not yet synced to chain
+  NOT_SYNCED = 5;
+  // Engine is validated and ready for use
+  VALIDATED = 6;
+}
+
+/**
+ * EngineStatus provides the status of an engine for a currency.
+ */
+message EngineStatus {
+  // The common symbol that the engine is responsible for, e.g. `BTC` or `LTC`
+  string symbol = 1;
+  // The status of the engine
+  EngineStatuses status = 2;
+}
+
+// Statuses of an orderbook
+enum OrderbookStatuses {
+  // Orderbook is synced
+  ORDERBOOK_OK = 0;
+  // Orderbook is not synced
+  ORDERBOOK_NOT_SYNCED = 1;
+}
+
+/**
+ * OrderbookStatus provides the status of an orderbook for a market.
+ */
+message OrderbookStatus {
+  // The market for the orderbook, e.g. `BTC/LTC`
+  string market = 1;
+  // The status of the market
+  OrderbookStatuses status = 2;
+}
+
 /**
  * HealthCheckResponse provides information on the health of a BrokerDaemon.
  */
 message HealthCheckResponse {
-  // Statuses of an orderbook
-  enum OrderbookStatuses {
-    // Orderbook is synced
-    ORDERBOOK_OK = 0;
-    // Orderbook is not synced
-    ORDERBOOK_NOT_SYNCED = 1;
-  }
-
-  // Statuses of the relayer
-  enum RelayerStatuses {
-    // Relayer is available
-    RELAYER_OK = 0;
-    // Relayer is not available
-    RELAYER_UNAVAILABLE = 1;
-  }
-
   // The status of every engine available on the BrokerDaemon.
   repeated EngineStatus engine_status = 1;
   // The status of the relayer this BrokerDaemon is connected to, either `'OK'` or the error message returned when connecting to it.
   RelayerStatuses relayer_status = 2;
   // The status of every orderbook available on the BrokerDaemon.
   repeated OrderbookStatus orderbook_status = 3;
-
-  /**
-   * EngineStatus provides the status of an engine for a currency.
-   */
-  message EngineStatus {
-    // Statuses of an engine
-    enum EngineStatuses {
-      // Default state of the engine
-      UNKNOWN = 0;
-      // Engine is unavailable
-      UNAVAILABLE = 1;
-      // Wallet does not exist
-      NEEDS_WALLET = 2;
-      // Wallet exists but is not locked
-      LOCKED = 3;
-      // Wallet is unlocked but the configuration of the node and chain sync status are not known
-      UNLOCKED = 4;
-      // Engine is not yet synced to chain
-      NOT_SYNCED = 5;
-      // Engine is validated and ready for use
-      VALIDATED = 6;
-    }
-
-    // The common symbol that the engine is responsible for, e.g. `BTC` or `LTC`
-    string symbol = 1;
-    // The status of the engine
-    EngineStatuses status = 2;
-  }
-
-  /**
-   * OrderbookStatus provides the status of an orderbook for a market.
-   */
-  message OrderbookStatus {
-    // The market for the orderbook, e.g. `BTC/LTC`
-    string market = 1;
-    // The status of the market
-    OrderbookStatuses status = 2;
-  }
 }
 
 /**

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -70,70 +70,70 @@ enum Side {
 }
 
 
+// Statuses of the relayer
+enum RelayerStatuses {
+  // Relayer is available
+  RELAYER_OK = 0;
+  // Relayer is not available
+  RELAYER_UNAVAILABLE = 1;
+}
+
+// Statuses of an engine
+enum EngineStatuses {
+  // Default state of the engine
+  UNKNOWN = 0;
+  // Engine is unavailable
+  UNAVAILABLE = 1;
+  // Wallet does not exist
+  NEEDS_WALLET = 2;
+  // Wallet exists but is not locked
+  LOCKED = 3;
+  // Wallet is unlocked but the configuration of the node and chain sync status are not known
+  UNLOCKED = 4;
+  // Engine is not yet synced to chain
+  NOT_SYNCED = 5;
+  // Engine is validated and ready for use
+  VALIDATED = 6;
+}
+
+/**
+ * EngineStatus provides the status of an engine for a currency.
+ */
+message EngineStatus {
+  // The common symbol that the engine is responsible for, e.g. `BTC` or `LTC`
+  string symbol = 1;
+  // The status of the engine
+  EngineStatuses status = 2;
+}
+
+// Statuses of an orderbook
+enum OrderbookStatuses {
+  // Orderbook is synced
+  ORDERBOOK_OK = 0;
+  // Orderbook is not synced
+  ORDERBOOK_NOT_SYNCED = 1;
+}
+
+/**
+ * OrderbookStatus provides the status of an orderbook for a market.
+ */
+message OrderbookStatus {
+  // The market for the orderbook, e.g. `BTC/LTC`
+  string market = 1;
+  // The status of the market
+  OrderbookStatuses status = 2;
+}
+
 /**
  * HealthCheckResponse provides information on the health of a BrokerDaemon.
  */
 message HealthCheckResponse {
-  // Statuses of an orderbook
-  enum OrderbookStatuses {
-    // Orderbook is synced
-    ORDERBOOK_OK = 0;
-    // Orderbook is not synced
-    ORDERBOOK_NOT_SYNCED = 1;
-  }
-
-  // Statuses of the relayer
-  enum RelayerStatuses {
-    // Relayer is available
-    RELAYER_OK = 0;
-    // Relayer is not available
-    RELAYER_UNAVAILABLE = 1;
-  }
-
   // The status of every engine available on the BrokerDaemon.
   repeated EngineStatus engine_status = 1;
   // The status of the relayer this BrokerDaemon is connected to, either `'OK'` or the error message returned when connecting to it.
   RelayerStatuses relayer_status = 2;
   // The status of every orderbook available on the BrokerDaemon.
   repeated OrderbookStatus orderbook_status = 3;
-
-  /**
-   * EngineStatus provides the status of an engine for a currency.
-   */
-  message EngineStatus {
-    // Statuses of an engine
-    enum EngineStatuses {
-      // Default state of the engine
-      UNKNOWN = 0;
-      // Engine is unavailable
-      UNAVAILABLE = 1;
-      // Wallet does not exist
-      NEEDS_WALLET = 2;
-      // Wallet exists but is not locked
-      LOCKED = 3;
-      // Wallet is unlocked but the configuration of the node and chain sync status are not known
-      UNLOCKED = 4;
-      // Engine is not yet synced to chain
-      NOT_SYNCED = 5;
-      // Engine is validated and ready for use
-      VALIDATED = 6;
-    }
-
-    // The common symbol that the engine is responsible for, e.g. `BTC` or `LTC`
-    string symbol = 1;
-    // The status of the engine
-    EngineStatuses status = 2;
-  }
-
-  /**
-   * OrderbookStatus provides the status of an orderbook for a market.
-   */
-  message OrderbookStatus {
-    // The market for the orderbook, e.g. `BTC/LTC`
-    string market = 1;
-    // The status of the market
-    OrderbookStatuses status = 2;
-  }
 }
 
 /**


### PR DESCRIPTION
## Description
`protoc`, the tool we use to generate a JSON representation of our proto file in order to render documentation does not output enums when they are too deeply nested.

This change moves the enum definitions to the top level to avoid those nesting issues.
