### PR TITLE
Trade History

### DIFF
--- a/broker-cli/commands/order/index.js
+++ b/broker-cli/commands/order/index.js
@@ -16,13 +16,15 @@ const SUPPORTED_COMMANDS = Object.freeze({
   STATUS: 'status',
   CANCEL: 'cancel',
   SUMMARY: 'summary',
-  CANCEL_ALL: 'cancel-all'
+  CANCEL_ALL: 'cancel-all',
+  TRADE_HISTORY: 'trade-history'
 })
 
 const status = require('./status')
 const cancel = require('./cancel')
 const summary = require('./summary')
 const cancelAll = require('./cancel-all')
+const tradeHistory = require('./trade-history')
 
 module.exports = (program) => {
   program
@@ -58,6 +60,9 @@ module.exports = (program) => {
         case SUPPORTED_COMMANDS.CANCEL_ALL:
           opts.market = validations.isMarketName(market)
           return cancelAll(args, opts, logger)
+
+        case SUPPORTED_COMMANDS.TRADE_HISTORY:
+          return tradeHistory(args, opts, logger)
       }
     })
     .command(`order ${SUPPORTED_COMMANDS.SUMMARY}`, 'View your orders')
@@ -73,5 +78,7 @@ module.exports = (program) => {
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING, validations.isHost)
     .command(`order ${SUPPORTED_COMMANDS.CANCEL_ALL}`, 'Cancel all block orders on market')
     .option('--market <marketName>', MARKET_NAME_HELP_STRING, validations.isMarketName, null, true)
+    .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING, validations.isHost)
+    .command(`order ${SUPPORTED_COMMANDS.TRADE_HISTORY}`, 'Cancel all block orders on market')
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING, validations.isHost)
 }

--- a/broker-cli/commands/order/index.js
+++ b/broker-cli/commands/order/index.js
@@ -79,6 +79,6 @@ module.exports = (program) => {
     .command(`order ${SUPPORTED_COMMANDS.CANCEL_ALL}`, 'Cancel all block orders on market')
     .option('--market <marketName>', MARKET_NAME_HELP_STRING, validations.isMarketName, null, true)
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING, validations.isHost)
-    .command(`order ${SUPPORTED_COMMANDS.TRADE_HISTORY}`, 'Cancel all block orders on market')
+    .command(`order ${SUPPORTED_COMMANDS.TRADE_HISTORY}`, 'Get information about completed and processing trades')
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING, validations.isHost)
 }

--- a/broker-cli/commands/order/status.js
+++ b/broker-cli/commands/order/status.js
@@ -23,7 +23,7 @@ async function status (args, opts, logger) {
   try {
     const client = new BrokerDaemonClient(rpcAddress)
     const blockOrderResult = await client.orderService.getBlockOrder(request)
-    logger.info(blockOrderResult)
+    logger.info(JSON.stringify(blockOrderResult, null, 2))
   } catch (e) {
     logger.error(handleError(e))
   }

--- a/broker-cli/commands/order/trade-history.js
+++ b/broker-cli/commands/order/trade-history.js
@@ -16,7 +16,7 @@ async function tradeHistory (args, opts, logger) {
   try {
     const client = new BrokerDaemonClient(rpcAddress)
     const tradeHistory = await client.orderService.getTradeHistory({})
-    logger.info(tradeHistory)
+    logger.info(JSON.stringify(tradeHistory, null, 2))
   } catch (e) {
     logger.error(handleError(e))
   }

--- a/broker-cli/commands/order/trade-history.js
+++ b/broker-cli/commands/order/trade-history.js
@@ -2,12 +2,11 @@ const BrokerDaemonClient = require('../../broker-daemon-client')
 const { handleError } = require('../../utils')
 
 /**
- * sparkswap order status
+ * sparkswap order trade-history
  *
- * ex: `sparkswap order status Aar_w9XuTtUqeqeaac5liIMR-Lqf1dJfKZikTkhJ'
+ * ex: `sparkswap order trade-history'
  *
  * @param {Object} args
- * @param {string} args.blockOrderId
  * @param {Object} opts
  * @param {string} opts.rpcaddress
  * @param {Logger} logger
@@ -16,8 +15,8 @@ async function tradeHistory (args, opts, logger) {
   const { rpcAddress } = opts
   try {
     const client = new BrokerDaemonClient(rpcAddress)
-    const blockOrderResult = await client.orderService.getTradeHistory({})
-    logger.info(blockOrderResult)
+    const tradeHistory = await client.orderService.getTradeHistory({})
+    logger.info(tradeHistory)
   } catch (e) {
     logger.error(handleError(e))
   }

--- a/broker-cli/commands/order/trade-history.js
+++ b/broker-cli/commands/order/trade-history.js
@@ -1,0 +1,26 @@
+const BrokerDaemonClient = require('../../broker-daemon-client')
+const { handleError } = require('../../utils')
+
+/**
+ * sparkswap order status
+ *
+ * ex: `sparkswap order status Aar_w9XuTtUqeqeaac5liIMR-Lqf1dJfKZikTkhJ'
+ *
+ * @param {Object} args
+ * @param {string} args.blockOrderId
+ * @param {Object} opts
+ * @param {string} opts.rpcaddress
+ * @param {Logger} logger
+ */
+async function tradeHistory (args, opts, logger) {
+  const { rpcAddress } = opts
+  try {
+    const client = new BrokerDaemonClient(rpcAddress)
+    const blockOrderResult = await client.orderService.getTradeHistory({})
+    logger.info(blockOrderResult)
+  } catch (e) {
+    logger.error(handleError(e))
+  }
+};
+
+module.exports = tradeHistory

--- a/broker-cli/commands/order/trade-history.spec.js
+++ b/broker-cli/commands/order/trade-history.spec.js
@@ -1,0 +1,36 @@
+const path = require('path')
+const {
+  sinon,
+  rewire,
+  expect
+} = require('test/test-helper')
+
+const tradeHistory = rewire(path.resolve(__dirname, 'trade-history'))
+
+describe('cli order trade-history', () => {
+  let args
+  let opts
+  let logger
+  let rpcAddress
+  let getTradeHistoryStub
+  let daemonStub
+
+  beforeEach(() => {
+    rpcAddress = 'test:1337'
+    opts = { rpcAddress }
+    logger = { info: sinon.stub(), error: sinon.stub() }
+
+    getTradeHistoryStub = sinon.stub()
+    daemonStub = sinon.stub()
+    daemonStub.prototype.orderService = { getTradeHistory: getTradeHistoryStub }
+
+    tradeHistory.__set__('BrokerDaemonClient', daemonStub)
+  })
+
+  it('calls broker daemon for the order tradeHistory', async () => {
+    await tradeHistory(args, opts, logger)
+
+    expect(daemonStub).to.have.been.calledWith(rpcAddress)
+    expect(getTradeHistoryStub).to.have.been.calledOnce()
+  })
+})

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -419,7 +419,7 @@ message Fill {
     FILLED = 1;
     // The swap has been executed on the Payment Channel Networks.
     EXECUTED = 2;
-    // The preimage has been returned to the Relayer by the Maker.
+    // The fill has encountered a failure.
     REJECTED = 4;
     // The fill has been cancelled.
     CANCELLED = 5;
@@ -435,7 +435,7 @@ message Fill {
     string filled = 2;
     // The date the fill has encountered a failure.
     string executed = 3;
-    // The date the preimage has been returned to the Relayer by the Maker.
+    // The date the fill has encountered a failure.
     string rejected = 5;
     // The date the fill has been cancelled.
     string cancelled = 6;

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -395,6 +395,8 @@ message Order {
   string side = 10;
   // Dates that the order has reached each status
   Date dates = 11;
+  // Amount of the order filled, expressed in a decimal string of common units for a currency (e.g. bitcoins for BTC). This can be any amount greater than zero and less than or equal to the amount in the order.
+  string fill_amount = 12;
 }
 
 /**
@@ -890,6 +892,7 @@ service OrderService {
    *         "dateRejected": "",
    *         "dateCancelled": ""
    *       }
+   *       "fillAmount": "0.0001000000000000",
    *     },
    *     {
    *       "orderId": "U6WQ8Al2lDXqHthXx7UORN0c",

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -360,6 +360,9 @@ message Order {
     CANCELLED = 6;
   }
 
+  /**
+   * Date that the order has reached each status.
+   */
   message OrderStateDates {
     // The date the order has been created on the Relayer.
     string created = 1;
@@ -422,12 +425,15 @@ message Fill {
     CANCELLED = 5;
   }
 
+  /**
+   * Date that the fill has reached each status.
+   */
   message FillStateDates {
     // The date the fill has been created on the Relayer.
     string created = 1;
     // The date the fill has been accepted as the fill for the given order.
     string filled = 2;
-    // The date the swap has been executed on the Payment Channel Networks.
+    // The date the fill has encountered a failure.
     string executed = 3;
     // The date the preimage has been returned to the Relayer by the Maker.
     string rejected = 5;
@@ -589,6 +595,9 @@ message GetBlockOrdersRequest {
   string market = 1;
 }
 
+/**
+ * Gets all completed trades for a user.
+ */
 message GetTradeHistoryResponse {
   // A list of completed and execting orders
   repeated Order orders = 1;

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -360,16 +360,41 @@ message Order {
     CANCELLED = 6;
   }
 
+  message Date {
+    // The date the order has been created on the Relayer.
+    string date_created = 1;
+    // The date the order has been placed and communicated to other marker participants.
+    string date_placed = 2;
+    // The date the swap is being executed on the Payment Channel Networks
+    string date_executing = 3;
+    // The date the swap preimage has been returned to the Relayer.
+    string date_completed = 4;
+    // The date the order has encountered a failure.
+    string date_rejected = 5;
+    // The date the order has been cancelled by the user.
+    string date_cancelled = 6;
+  }
+
   // Unique ID assigned by the Relayer for this order.
   string order_id = 1;
   // Status of the order on the Relayer.
-  OrderStatus order_status = 2;
+  OrderStatus status = 2;
   // Amount of the order expressed in a decimal string of common units for a currency (e.g. bitcoins for BTC).
   string amount = 3;
   // Price at which the order was placed, expressed as a decimal string ratio between the common units of the currencies (e.g. litecoins to bitcoins, not litoshis to satoshis). All orders on the SparkSwap Relayer have prices.
   string price = 4;
   // Any error messages related to the status of a REJECTED or FAILED order
-  string order_error = 6;
+  string error = 6;
+  // The unique ID for the block order assigned by the Broker that this order belongs to.
+  string block_order_id = 7;
+  // The base currency for the order
+  string base_symbol = 8;
+  // The counter currency for the order
+  string counter_symbol = 9;
+  // The side of the market that the order is taking.
+  string side = 10;
+  // Dates that the order has reached each status
+  Date dates = 11;
 }
 
 /**
@@ -394,18 +419,44 @@ message Fill {
     // The fill has been cancelled.
     CANCELLED = 5;
   }
+
+  message Date {
+    // The date the fill has been created on the Relayer.
+    string date_created = 1;
+    // The date the fill has been accepted as the fill for the given order.
+    string date_filled = 2;
+    // The date the swap has been executed on the Payment Channel Networks.
+    string date_executed = 3;
+    // The date the preimage has been returned to the Relayer by the Maker.
+    string date_completed = 4;
+    // The date the fill has encountered a failure.
+    string date_rejected = 5;
+    // The date the fill has been cancelled.
+    string date_cancelled = 6;
+  }
+
   // The Relayer-assigned unique ID of the order that this fill is for.
   string order_id = 1;
   // The Relayer-assignded unique ID for this fill.
   string fill_id = 2;
   // Status of the fill on the Relayer.
-  FillStatus fill_status = 3;
+  FillStatus status = 3;
   // Amount of the order to fill, expressed in a decimal string of common units for a currency (e.g. bitcoins for BTC). This can be any amount greater than zero and less than or equal to the amount in the order.
   string amount = 4;
   // Price at which the order was placed, expressed as a decimal string ratio between the common units of the currencies (e.g. litecoins to bitcoins, not litoshis to satoshis). All orders on the SparkSwap Relayer have prices.
   string price = 5;
   // Any error messages related to the status of a REJECTED or FAILED fill
-  string fill_error = 6;
+  string error = 6;
+  // The unique ID for the block order assigned by the Broker that this fill belongs to.
+  string block_order_id = 7;
+  // The base currency for the fill
+  string base_symbol = 8;
+  // The counter currency for the fill
+  string counter_symbol = 9;
+  // The side of the market that the order is taking.
+  string side = 10;
+  // Dates that the fill has reached each status
+  Date dates = 11;
 }
 
 /**
@@ -538,45 +589,11 @@ message GetBlockOrdersRequest {
   string market = 1;
 }
 
-message TradeOrder {
-  string order_id = 1;
-  string block_order_id = 2;
-  string base_symbol = 3;
-  string counter_symbol = 4;
-  string side = 5;
-  string base_amount = 6;
-  string counter_amount = 7;
-  string state = 8;
-  string date_created = 9;
-  string date_placed = 10;
-  string date_rejected = 11;
-  string date_cancelled = 12;
-  string date_executing = 13;
-  string date_completed = 14;
-}
-
-message TradeFill {
-  string fill_id = 1;
-  string order_id = 2;
-  string block_order_id = 3;
-  string base_symbol = 4;
-  string counter_symbol = 5;
-  string side = 6;
-  string base_amount = 7;
-  string counter_amount = 8;
-  string state = 9;
-  string date_created = 10;
-  string date_filled = 11;
-  string date_executed = 12;
-  string date_cancelled = 13;
-  string date_rejected = 14;
-}
-
 message GetTradeHistoryResponse {
   // A list of completed and execting orders
-  repeated TradeOrder orders = 1;
+  repeated Order orders = 1;
   // A list of accepted and executed fills
-  repeated TradeFill fills = 2;
+  repeated Fill fills = 2;
 }
 
 /**
@@ -835,7 +852,115 @@ service OrderService {
       get: "/v1/orders"
     };
   }
-
+  /**
+   * GetTradeHistory returns all completed and executing orders and all accepted and executed fills.
+   *
+   * ```javascript
+   * const deadline = new Date().setSeconds(new Date().getSeconds() + 5)
+   * const blockOrder = orderService.getTradeHistory({}, { deadline }, (err, res) => {
+   *   if (err) return console.error(err)
+   *   console.log(res)
+   * })
+   * ```
+   *
+   * ```shell
+   * > sparkswap order trade-history
+   * ```
+   *
+   * > The above command will retrieve the trades on the Broker and will print:
+   *
+   * ```javascript
+   * {
+   *   "orders": [
+   *     {
+   *       "orderId": "Ky13eTmuhZY-NIbqIng_in3D",
+   *       "orderStatus": "PLACED",
+   *       "amount": "0.0001000000000000",
+   *       "price": "0.0001000000000000",
+   *       "orderError": "",
+   *       "blockOrderId": "XLDXVDZiXxdifizQ",
+   *       "baseSymbol": "BTC",
+   *       "counterSymbol": "LTC",
+   *       "side": "ASK",
+   *       "dates": {
+   *         "dateCreated": "2019-04-12T18:22:13.111Z",
+   *         "datePlaced": "2019-04-12T18:22:13.121Z",
+   *         "dateExecuting": "",
+   *         "dateCompleted": "",
+   *         "dateRejected": "",
+   *         "dateCancelled": ""
+   *       }
+   *     },
+   *     {
+   *       "orderId": "U6WQ8Al2lDXqHthXx7UORN0c",
+   *       "orderStatus": "PLACED",
+   *       "amount": "0.0001000000000000",
+   *       "price": "0.0001000000000000",
+   *       "orderError": "",
+   *       "blockOrderId": "XLDXclazEcJjK8Po",
+   *       "baseSymbol": "BTC",
+   *       "counterSymbol": "LTC",
+   *       "side": "ASK",
+   *       "dates": {
+   *         "dateCreated": "2019-04-12T18:22:42.519Z",
+   *         "datePlaced": "2019-04-12T18:22:42.534Z",
+   *         "dateExecuting": "",
+   *         "dateCompleted": "",
+   *         "dateRejected": "",
+   *         "dateCancelled": ""
+   *       }
+   *     }
+   *   ],
+   *   "fills": []
+   * }
+   * ```
+   *
+   * ```shell
+   * {
+   *   "orders": [
+   *     {
+   *       "orderId": "Ky13eTmuhZY-NIbqIng_in3D",
+   *       "orderStatus": "PLACED",
+   *       "amount": "0.0001000000000000",
+   *       "price": "0.0001000000000000",
+   *       "orderError": "",
+   *       "blockOrderId": "XLDXVDZiXxdifizQ",
+   *       "baseSymbol": "BTC",
+   *       "counterSymbol": "LTC",
+   *       "side": "ASK",
+   *       "dates": {
+   *         "dateCreated": "2019-04-12T18:22:13.111Z",
+   *         "datePlaced": "2019-04-12T18:22:13.121Z",
+   *         "dateExecuting": "",
+   *         "dateCompleted": "",
+   *         "dateRejected": "",
+   *         "dateCancelled": ""
+   *       }
+   *     },
+   *     {
+   *       "orderId": "U6WQ8Al2lDXqHthXx7UORN0c",
+   *       "orderStatus": "PLACED",
+   *       "amount": "0.0001000000000000",
+   *       "price": "0.0001000000000000",
+   *       "orderError": "",
+   *       "blockOrderId": "XLDXclazEcJjK8Po",
+   *       "baseSymbol": "BTC",
+   *       "counterSymbol": "LTC",
+   *       "side": "ASK",
+   *       "dates": {
+   *         "dateCreated": "2019-04-12T18:22:42.519Z",
+   *         "datePlaced": "2019-04-12T18:22:42.534Z",
+   *         "dateExecuting": "",
+   *         "dateCompleted": "",
+   *         "dateRejected": "",
+   *         "dateCancelled": ""
+   *       }
+   *     }
+   *   ],
+   *   "fills": []
+   * }
+   * ```
+   */
   rpc GetTradeHistory (google.protobuf.Empty) returns (GetTradeHistoryResponse);
 }
 

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -360,25 +360,25 @@ message Order {
     CANCELLED = 6;
   }
 
-  message Date {
+  message OrderStateDates {
     // The date the order has been created on the Relayer.
-    string date_created = 1;
+    string created = 1;
     // The date the order has been placed and communicated to other marker participants.
-    string date_placed = 2;
+    string placed = 2;
     // The date the swap is being executed on the Payment Channel Networks
-    string date_executing = 3;
+    string executing = 3;
     // The date the swap preimage has been returned to the Relayer.
-    string date_completed = 4;
+    string completed = 4;
     // The date the order has encountered a failure.
-    string date_rejected = 5;
+    string rejected = 5;
     // The date the order has been cancelled by the user.
-    string date_cancelled = 6;
+    string cancelled = 6;
   }
 
   // Unique ID assigned by the Relayer for this order.
   string order_id = 1;
   // Status of the order on the Relayer.
-  OrderStatus status = 2;
+  OrderStatus order_status = 2;
   // Amount of the order expressed in a decimal string of common units for a currency (e.g. bitcoins for BTC).
   string amount = 3;
   // Price at which the order was placed, expressed as a decimal string ratio between the common units of the currencies (e.g. litecoins to bitcoins, not litoshis to satoshis). All orders on the SparkSwap Relayer have prices.
@@ -394,8 +394,10 @@ message Order {
   // The side of the market that the order is taking.
   string side = 10;
   // Dates that the order has reached each status
-  Date dates = 11;
-  // Amount of the order filled, expressed in a decimal string of common units for a currency (e.g. bitcoins for BTC). This can be any amount greater than zero and less than or equal to the amount in the order.
+  OrderStateDates dates = 11;
+  // Amount of the order filled, expressed in a decimal string of common units for a currency (e.g. bitcoins for BTC).
+  // This can be any amount greater than zero and less than or equal to the amount in the order. This will be an empty
+  // string if the order has not been filled.
   string fill_amount = 12;
 }
 
@@ -415,34 +417,30 @@ message Fill {
     // The swap has been executed on the Payment Channel Networks.
     EXECUTED = 2;
     // The preimage has been returned to the Relayer by the Maker.
-    COMPLETED = 3;
-    // The fill has encountered a failure.
     REJECTED = 4;
     // The fill has been cancelled.
     CANCELLED = 5;
   }
 
-  message Date {
+  message FillStateDates {
     // The date the fill has been created on the Relayer.
-    string date_created = 1;
+    string created = 1;
     // The date the fill has been accepted as the fill for the given order.
-    string date_filled = 2;
+    string filled = 2;
     // The date the swap has been executed on the Payment Channel Networks.
-    string date_executed = 3;
+    string executed = 3;
     // The date the preimage has been returned to the Relayer by the Maker.
-    string date_completed = 4;
-    // The date the fill has encountered a failure.
-    string date_rejected = 5;
+    string rejected = 5;
     // The date the fill has been cancelled.
-    string date_cancelled = 6;
+    string cancelled = 6;
   }
 
   // The Relayer-assigned unique ID of the order that this fill is for.
   string order_id = 1;
-  // The Relayer-assignded unique ID for this fill.
+  // The Relayer-assigned unique ID for this fill.
   string fill_id = 2;
   // Status of the fill on the Relayer.
-  FillStatus status = 3;
+  FillStatus fill_status = 3;
   // Amount of the order to fill, expressed in a decimal string of common units for a currency (e.g. bitcoins for BTC). This can be any amount greater than zero and less than or equal to the amount in the order.
   string amount = 4;
   // Price at which the order was placed, expressed as a decimal string ratio between the common units of the currencies (e.g. litecoins to bitcoins, not litoshis to satoshis). All orders on the SparkSwap Relayer have prices.
@@ -458,7 +456,7 @@ message Fill {
   // The side of the market that the order is taking.
   string side = 10;
   // Dates that the fill has reached each status
-  Date dates = 11;
+  FillStateDates dates = 11;
 }
 
 /**
@@ -875,46 +873,47 @@ service OrderService {
    * {
    *   "orders": [
    *     {
-   *       "orderId": "Ky13eTmuhZY-NIbqIng_in3D",
-   *       "orderStatus": "PLACED",
-   *       "amount": "0.0001000000000000",
-   *       "price": "0.0001000000000000",
-   *       "orderError": "",
-   *       "blockOrderId": "XLDXVDZiXxdifizQ",
+   *       "orderId": "GZnWxbVT6hK_2KM-r_hbSXp0",
+   *       "orderStatus": "COMPLETED",
+   *       "amount": "0.0040000000000000",
+   *       "price": "0.0040000000000000",
+   *       "error": "",
+   *       "blockOrderId": "XLoVOEJdJgO8JWAB",
    *       "baseSymbol": "BTC",
    *       "counterSymbol": "LTC",
    *       "side": "ASK",
    *       "dates": {
-   *         "dateCreated": "2019-04-12T18:22:13.111Z",
-   *         "datePlaced": "2019-04-12T18:22:13.121Z",
-   *         "dateExecuting": "",
-   *         "dateCompleted": "",
-   *         "dateRejected": "",
-   *         "dateCancelled": ""
-   *       }
-   *       "fillAmount": "0.0001000000000000",
-   *     },
-   *     {
-   *       "orderId": "U6WQ8Al2lDXqHthXx7UORN0c",
-   *       "orderStatus": "PLACED",
-   *       "amount": "0.0001000000000000",
-   *       "price": "0.0001000000000000",
-   *       "orderError": "",
-   *       "blockOrderId": "XLDXclazEcJjK8Po",
-   *       "baseSymbol": "BTC",
-   *       "counterSymbol": "LTC",
-   *       "side": "ASK",
-   *       "dates": {
-   *         "dateCreated": "2019-04-12T18:22:42.519Z",
-   *         "datePlaced": "2019-04-12T18:22:42.534Z",
-   *         "dateExecuting": "",
-   *         "dateCompleted": "",
-   *         "dateRejected": "",
-   *         "dateCancelled": ""
-   *       }
+   *         "created": "2019-04-19T18:36:40.809Z",
+   *         "placed": "2019-04-19T18:36:40.816Z",
+   *         "executing": "2019-04-19T18:36:52.556Z",
+   *         "completed": "2019-04-19T18:36:53.357Z",
+   *         "rejected": "",
+   *         "cancelled": ""
+   *       },
+   *       "fillAmount": "0.0010000000000000"
    *     }
    *   ],
-   *   "fills": []
+   *   "fills": [
+   *     {
+   *       "orderId": "PBt5GmSgJte9agAfDCj28j_7",
+   *       "fillId": "YQRN_XXJysf_toi73wZTTnQW",
+   *       "fillStatus": "EXECUTED",
+   *       "amount": "0.0030000000000000",
+   *       "price": "0.0030000000000000",
+   *       "error": "",
+   *       "blockOrderId": "XLoRm8Df_0Wa-A57",
+   *       "baseSymbol": "BTC",
+   *       "counterSymbol": "LTC",
+   *       "side": "BID",
+   *       "dates": {
+   *         "created": "2019-04-19T18:21:15.751Z",
+   *         "filled": "2019-04-19T18:21:15.820Z",
+   *         "executed": "2019-04-19T18:21:16.824Z",
+   *         "rejected": "",
+   *         "cancelled": ""
+   *       }
+   *     }
+   *   ]
    * }
    * ```
    *
@@ -922,45 +921,47 @@ service OrderService {
    * {
    *   "orders": [
    *     {
-   *       "orderId": "Ky13eTmuhZY-NIbqIng_in3D",
-   *       "orderStatus": "PLACED",
-   *       "amount": "0.0001000000000000",
-   *       "price": "0.0001000000000000",
-   *       "orderError": "",
-   *       "blockOrderId": "XLDXVDZiXxdifizQ",
+   *       "orderId": "GZnWxbVT6hK_2KM-r_hbSXp0",
+   *       "orderStatus": "COMPLETED",
+   *       "amount": "0.0040000000000000",
+   *       "price": "0.0040000000000000",
+   *       "error": "",
+   *       "blockOrderId": "XLoVOEJdJgO8JWAB",
    *       "baseSymbol": "BTC",
    *       "counterSymbol": "LTC",
    *       "side": "ASK",
    *       "dates": {
-   *         "dateCreated": "2019-04-12T18:22:13.111Z",
-   *         "datePlaced": "2019-04-12T18:22:13.121Z",
-   *         "dateExecuting": "",
-   *         "dateCompleted": "",
-   *         "dateRejected": "",
-   *         "dateCancelled": ""
-   *       }
-   *     },
-   *     {
-   *       "orderId": "U6WQ8Al2lDXqHthXx7UORN0c",
-   *       "orderStatus": "PLACED",
-   *       "amount": "0.0001000000000000",
-   *       "price": "0.0001000000000000",
-   *       "orderError": "",
-   *       "blockOrderId": "XLDXclazEcJjK8Po",
-   *       "baseSymbol": "BTC",
-   *       "counterSymbol": "LTC",
-   *       "side": "ASK",
-   *       "dates": {
-   *         "dateCreated": "2019-04-12T18:22:42.519Z",
-   *         "datePlaced": "2019-04-12T18:22:42.534Z",
-   *         "dateExecuting": "",
-   *         "dateCompleted": "",
-   *         "dateRejected": "",
-   *         "dateCancelled": ""
-   *       }
+   *         "created": "2019-04-19T18:36:40.809Z",
+   *         "placed": "2019-04-19T18:36:40.816Z",
+   *         "executing": "2019-04-19T18:36:52.556Z",
+   *         "completed": "2019-04-19T18:36:53.357Z",
+   *         "rejected": "",
+   *         "cancelled": ""
+   *       },
+   *       "fillAmount": "0.0010000000000000"
    *     }
    *   ],
-   *   "fills": []
+   *   "fills": [
+   *     {
+   *       "orderId": "PBt5GmSgJte9agAfDCj28j_7",
+   *       "fillId": "YQRN_XXJysf_toi73wZTTnQW",
+   *       "fillStatus": "EXECUTED",
+   *       "amount": "0.0030000000000000",
+   *       "price": "0.0030000000000000",
+   *       "error": "",
+   *       "blockOrderId": "XLoRm8Df_0Wa-A57",
+   *       "baseSymbol": "BTC",
+   *       "counterSymbol": "LTC",
+   *       "side": "BID",
+   *       "dates": {
+   *         "created": "2019-04-19T18:21:15.751Z",
+   *         "filled": "2019-04-19T18:21:15.820Z",
+   *         "executed": "2019-04-19T18:21:16.824Z",
+   *         "rejected": "",
+   *         "cancelled": ""
+   *       }
+   *     }
+   *   ]
    * }
    * ```
    */

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -538,6 +538,47 @@ message GetBlockOrdersRequest {
   string market = 1;
 }
 
+message TradeOrder {
+  string order_id = 1;
+  string block_order_id = 2;
+  string base_symbol = 3;
+  string counter_symbol = 4;
+  string side = 5;
+  string base_amount = 6;
+  string counter_amount = 7;
+  string state = 8;
+  string date_created = 9;
+  string date_placed = 10;
+  string date_rejected = 11;
+  string date_cancelled = 12;
+  string date_executing = 13;
+  string date_completed = 14;
+}
+
+message TradeFill {
+  string fill_id = 1;
+  string order_id = 2;
+  string block_order_id = 3;
+  string base_symbol = 4;
+  string counter_symbol = 5;
+  string side = 6;
+  string base_amount = 7;
+  string counter_amount = 8;
+  string state = 9;
+  string date_created = 10;
+  string date_filled = 11;
+  string date_executed = 12;
+  string date_cancelled = 13;
+  string date_rejected = 14;
+}
+
+message GetTradeHistoryResponse {
+  // A list of completed and execting orders
+  repeated TradeOrder orders = 1;
+  // A list of accepted and executed fills
+  repeated TradeFill fills = 2;
+}
+
 /**
  * The OrderService manages all trading activity on the Broker.
  * It is the primary way that users interact with the Broker on a day-to-day basis.
@@ -794,6 +835,8 @@ service OrderService {
       get: "/v1/orders"
     };
   }
+
+  rpc GetTradeHistory (google.protobuf.Empty) returns (GetTradeHistoryResponse);
 }
 
 /**

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -877,8 +877,8 @@ class BlockOrderWorker extends EventEmitter {
       fill.state === FillStateMachine.STATES.FILLED || fill.state === FillStateMachine.STATES.EXECUTED
     )
 
-    const serializedOrders = filteredOrders.map(o => Order.serialize(o))
-    const serializedFills = filteredFills.map(f => Fill.serialize(f))
+    const serializedOrders = filteredOrders.map(o => OrderStateMachine.serialize(o))
+    const serializedFills = filteredFills.map(f => FillStateMachine.serialize(f))
 
     return {
       orders: serializedOrders,

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -848,6 +848,25 @@ class BlockOrderWorker extends EventEmitter {
   }
 
   /**
+   * Get all completed trade info
+   * @returns {Object} result
+   * @returns {Array<Object>} result.orders all orders for a user
+   * @returns {Array<Object>} result.fills all fills for a user
+   */
+  async getTrades () {
+    const [
+      orders,
+      fills
+    ] = await Promise.all([
+      getRecords(this.ordersStore, Order.fromStorageWithStatus.bind(Order)),
+      getRecords(this.fillsStore, Fill.fromStorageWithStatus.bind(Fill))
+    ])
+
+    return { orders, fills }
+  }
+}
+
+  /**
    * Checks if the relayer is available by pinging the healthCheck endpoint. If available,
    * returns true. False otherwise.
    * @private

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -874,7 +874,7 @@ class BlockOrderWorker extends EventEmitter {
       order.state === OrderStateMachine.STATES.COMPLETED || order.state === OrderStateMachine.STATES.EXECUTING
     )
     const filteredFills = fills.filter(fill =>
-      fill.state === FillStateMachine.STATES.ACCEPTED || fill.state === FillStateMachine.STATES.EXECUTED
+      fill.state === FillStateMachine.STATES.FILLED || fill.state === FillStateMachine.STATES.EXECUTED
     )
 
     const serializedOrders = filteredOrders.map(o => Order.serialize(o))

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -850,8 +850,8 @@ class BlockOrderWorker extends EventEmitter {
   /**
    * Get all completed trade info
    * @returns {Object} result
-   * @returns {Array<Object>} result.orders all orders for a user
-   * @returns {Array<Object>} result.fills all fills for a user
+   * @returns {Array<Object>} result.orders all completed orders for a user
+   * @returns {Array<Object>} result.fills all completed fills for a user
    */
   async getTrades () {
     const [
@@ -870,8 +870,15 @@ class BlockOrderWorker extends EventEmitter {
         })
     ])
 
-    const serializedOrders = orders.map(o => Order.serialize(o))
-    const serializedFills = fills.map(f => Fill.serialize(f))
+    const filteredOrders = orders.filter(order =>
+      order.state === OrderStateMachine.STATES.COMPLETED || order.state === OrderStateMachine.STATES.EXECUTING
+    )
+    const filteredFills = fills.filter(fill =>
+      fill.state === FillStateMachine.STATES.ACCEPTED || fill.state === FillStateMachine.STATES.EXECUTED
+    )
+
+    const serializedOrders = filteredOrders.map(o => Order.serialize(o))
+    const serializedFills = filteredFills.map(f => Fill.serialize(f))
 
     return {
       orders: serializedOrders,

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -864,7 +864,6 @@ class BlockOrderWorker extends EventEmitter {
 
     return { orders, fills }
   }
-}
 
   /**
    * Checks if the relayer is available by pinging the healthCheck endpoint. If available,

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -858,11 +858,25 @@ class BlockOrderWorker extends EventEmitter {
       orders,
       fills
     ] = await Promise.all([
-      getRecords(this.ordersStore, Order.fromStorageWithStatus.bind(Order)),
-      getRecords(this.fillsStore, Fill.fromStorageWithStatus.bind(Fill))
+      getRecords(this.ordersStore,
+        (key, value) => {
+          const { order, state, error, dates } = JSON.parse(value)
+          return { order: Order.fromObject(key, order), state, error, dates }
+        }),
+      getRecords(this.fillsStore,
+        (key, value) => {
+          const { fill, state, error, dates } = JSON.parse(value)
+          return { fill: Fill.fromObject(key, fill), state, error, dates }
+        })
     ])
 
-    return { orders, fills }
+    const serializedOrders = orders.map(o => Order.serialize(o))
+    const serializedFills = fills.map(f => Fill.serialize(f))
+
+    return {
+      orders: serializedOrders,
+      fills: serializedFills
+    }
   }
 
   /**

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -78,7 +78,6 @@ describe('BlockOrderWorker', () => {
       NONE: 'none',
       CREATED: 'created',
       FILLED: 'filled',
-      ACCEPTED: 'accepted',
       EXECUTED: 'executed'
     }
 
@@ -2450,7 +2449,7 @@ describe('BlockOrderWorker', () => {
     let completedOrder
     let executingOrder
     let rejectedOrder
-    let acceptedFill
+    let filledFill
     let executedFill
     let rejectedFill
 
@@ -2475,9 +2474,9 @@ describe('BlockOrderWorker', () => {
         state: 'rejected'
       }
 
-      acceptedFill = {
+      filledFill = {
         fillId: 'fillId',
-        state: 'accepted'
+        state: 'filled'
       }
       executedFill = {
         fillId: 'fillId2',
@@ -2501,7 +2500,7 @@ describe('BlockOrderWorker', () => {
         fillsStore,
         sinon.match.func
       ).resolves([
-        acceptedFill,
+        filledFill,
         executedFill,
         rejectedFill
       ])
@@ -2538,7 +2537,7 @@ describe('BlockOrderWorker', () => {
           executingOrder
         ],
         fills: [
-          acceptedFill,
+          filledFill,
           executedFill
         ]
       })

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -2510,8 +2510,8 @@ describe('BlockOrderWorker', () => {
       worker = new BlockOrderWorker({ orderbooks, store, logger, relayer, engines })
       worker.ordersStore = ordersStore
       worker.fillsStore = fillsStore
-      Order.serialize = sinon.stub().returnsArg(0)
-      Fill.serialize = sinon.stub().returnsArg(0)
+      OrderStateMachine.serialize = sinon.stub().returnsArg(0)
+      FillStateMachine.serialize = sinon.stub().returnsArg(0)
     })
 
     it('retrieves all orders and fills from the store', async () => {
@@ -2546,17 +2546,17 @@ describe('BlockOrderWorker', () => {
     it('serializes the filtered orders', async () => {
       await worker.getTrades()
 
-      expect(Order.serialize).to.have.been.calledWith(completedOrder)
-      expect(Order.serialize).to.have.been.calledWith(executingOrder)
-      expect(Order.serialize).to.not.have.been.calledWith(rejectedOrder)
+      expect(OrderStateMachine.serialize).to.have.been.calledWith(completedOrder)
+      expect(OrderStateMachine.serialize).to.have.been.calledWith(executingOrder)
+      expect(OrderStateMachine.serialize).to.not.have.been.calledWith(rejectedOrder)
     })
 
     it('serializes the filtered fills', async () => {
       await worker.getTrades()
 
-      expect(Fill.serialize).to.have.been.calledWith(filledFill)
-      expect(Fill.serialize).to.have.been.calledWith(executedFill)
-      expect(Fill.serialize).to.not.have.been.calledWith(rejectedFill)
+      expect(FillStateMachine.serialize).to.have.been.calledWith(filledFill)
+      expect(FillStateMachine.serialize).to.have.been.calledWith(executedFill)
+      expect(FillStateMachine.serialize).to.not.have.been.calledWith(rejectedFill)
     })
   })
 })

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -2542,5 +2542,21 @@ describe('BlockOrderWorker', () => {
         ]
       })
     })
+
+    it('serializes the filtered orders', async () => {
+      await worker.getTrades()
+
+      expect(Order.serialize).to.have.been.calledWith(completedOrder)
+      expect(Order.serialize).to.have.been.calledWith(executingOrder)
+      expect(Order.serialize).to.not.have.been.calledWith(rejectedOrder)
+    })
+
+    it('serializes the filtered fills', async () => {
+      await worker.getTrades()
+
+      expect(Fill.serialize).to.have.been.calledWith(filledFill)
+      expect(Fill.serialize).to.have.been.calledWith(executedFill)
+      expect(Fill.serialize).to.not.have.been.calledWith(rejectedFill)
+    })
   })
 })

--- a/broker-daemon/broker-rpc/order-service/get-trade-history.js
+++ b/broker-daemon/broker-rpc/order-service/get-trade-history.js
@@ -1,0 +1,48 @@
+const { MarketEvent } = require('../../models')
+const { Big } = require('../../utils')
+
+/**
+ * Default limit for number of records returned per call
+ * @type {Integer}
+ * @constant
+ */
+const DEFAULT_LIMIT = Big(50)
+
+/**
+ * Retrieve information about trades (filled orders) since a specified date.
+ *
+ * @param {GrpcUnaryMethod~request} request - request object
+ * @param {Object} request.params - Request parameters from the client
+ * @param {String} request.params.market - market symbol e.g. BTC/LTC
+ * @param {String} request.params.since - ISO8601 millisecond timestamp
+ * @param {String} request.params.limit
+ * @param {Object} request.logger
+ * @param  {Map<String, Orderbook>} request.orderbooks Collection of all active Orderbooks
+ * @param {Object} responses
+ * @param {function} responses.GetTradesResponse - constructor for GetTradesResponse messages
+ * @return {responses.GetTradesResponse}
+ */
+
+async function getTradeHistory ({ params, logger, blockOrderWorker }, { GetTradesResponse }) {
+  try {
+    const { orders, fills } = await blockOrderWorker.getTrades()
+    const completedOrders = orders.filter(order => order.state === 'placed')
+    const executingOrders = orders.filter(order => order.state === 'executing')
+    const acceptedFills = fills.filter(fill => fill.state === 'accepted')
+    const executedFills = fills.filter(fill => fill.state === 'executed')
+
+    return new GetTradesResponse({
+      completedOrders,
+      executingOrders,
+      acceptedFills,
+      executedFills
+    })
+
+  } catch (err) {
+    logger.error('Received error when grabbing trades', { error: err.stack })
+    throw new Error(err.message)
+  }
+
+}
+
+module.exports = getTradeHistory

--- a/broker-daemon/broker-rpc/order-service/get-trade-history.js
+++ b/broker-daemon/broker-rpc/order-service/get-trade-history.js
@@ -13,8 +13,8 @@ async function getTradeHistory ({ logger, blockOrderWorker }, { GetTradeHistoryR
   try {
     const { orders, fills } = await blockOrderWorker.getTrades()
 
-    const filteredOrders = orders.filter(order => order.state === 'completed' || order.state === 'executing')
-    const filteredFills = fills.filter(fill => fill.state === 'accepted' || fill.state === 'executed')
+    const filteredOrders = orders.filter(order => order.status === 'COMPLETED' || order.status === 'EXECUTING')
+    const filteredFills = fills.filter(fill => fill.status === 'ACCEPTED' || fill.status === 'EXECUTED')
 
     return new GetTradeHistoryResponse({
       orders: filteredOrders,

--- a/broker-daemon/broker-rpc/order-service/get-trade-history.js
+++ b/broker-daemon/broker-rpc/order-service/get-trade-history.js
@@ -1,13 +1,3 @@
-const { MarketEvent } = require('../../models')
-const { Big } = require('../../utils')
-
-/**
- * Default limit for number of records returned per call
- * @type {Integer}
- * @constant
- */
-const DEFAULT_LIMIT = Big(50)
-
 /**
  * Retrieve information about trades (filled orders) since a specified date.
  *
@@ -26,23 +16,17 @@ const DEFAULT_LIMIT = Big(50)
 async function getTradeHistory ({ params, logger, blockOrderWorker }, { GetTradesResponse }) {
   try {
     const { orders, fills } = await blockOrderWorker.getTrades()
-    const completedOrders = orders.filter(order => order.state === 'placed')
-    const executingOrders = orders.filter(order => order.state === 'executing')
-    const acceptedFills = fills.filter(fill => fill.state === 'accepted')
-    const executedFills = fills.filter(fill => fill.state === 'executed')
+    const filteredOrders = orders.filter(order => order.state === 'completed' || order.state === 'executing')
+    const filteredFills = fills.filter(fill => fill.state === 'accepted' || fill.state === 'executed')
 
     return new GetTradesResponse({
-      completedOrders,
-      executingOrders,
-      acceptedFills,
-      executedFills
+      orders: filteredOrders,
+      fills: filteredFills
     })
-
   } catch (err) {
     logger.error('Received error when grabbing trades', { error: err.stack })
     throw new Error(err.message)
   }
-
 }
 
 module.exports = getTradeHistory

--- a/broker-daemon/broker-rpc/order-service/get-trade-history.js
+++ b/broker-daemon/broker-rpc/order-service/get-trade-history.js
@@ -13,12 +13,9 @@ async function getTradeHistory ({ logger, blockOrderWorker }, { GetTradeHistoryR
   try {
     const { orders, fills } = await blockOrderWorker.getTrades()
 
-    const filteredOrders = orders.filter(order => order.status === 'COMPLETED' || order.status === 'EXECUTING')
-    const filteredFills = fills.filter(fill => fill.status === 'ACCEPTED' || fill.status === 'EXECUTED')
-
     return new GetTradeHistoryResponse({
-      orders: filteredOrders,
-      fills: filteredFills
+      orders,
+      fills
     })
   } catch (err) {
     logger.error('Received error when grabbing trades', { error: err.stack })

--- a/broker-daemon/broker-rpc/order-service/get-trade-history.js
+++ b/broker-daemon/broker-rpc/order-service/get-trade-history.js
@@ -1,25 +1,22 @@
 /**
- * Retrieve information about trades (filled orders) since a specified date.
+ * Retrieve information about completed trades
  *
  * @param {GrpcUnaryMethod~request} request - request object
- * @param {Object} request.params - Request parameters from the client
- * @param {String} request.params.market - market symbol e.g. BTC/LTC
- * @param {String} request.params.since - ISO8601 millisecond timestamp
- * @param {String} request.params.limit
  * @param {Object} request.logger
- * @param  {Map<String, Orderbook>} request.orderbooks Collection of all active Orderbooks
+ * @param {BlockOrderWorker} request.blockOrderWorker
  * @param {Object} responses
- * @param {function} responses.GetTradesResponse - constructor for GetTradesResponse messages
- * @return {responses.GetTradesResponse}
+ * @param {function} responses.GetTradeHistoryResponse - constructor for GetTradeHistoryResponse messages
+ * @return {responses.GetTradeHistoryResponse}
  */
 
-async function getTradeHistory ({ params, logger, blockOrderWorker }, { GetTradesResponse }) {
+async function getTradeHistory ({ logger, blockOrderWorker }, { GetTradeHistoryResponse }) {
   try {
     const { orders, fills } = await blockOrderWorker.getTrades()
+
     const filteredOrders = orders.filter(order => order.state === 'completed' || order.state === 'executing')
     const filteredFills = fills.filter(fill => fill.state === 'accepted' || fill.state === 'executed')
 
-    return new GetTradesResponse({
+    return new GetTradeHistoryResponse({
       orders: filteredOrders,
       fills: filteredFills
     })

--- a/broker-daemon/broker-rpc/order-service/get-trade-history.spec.js
+++ b/broker-daemon/broker-rpc/order-service/get-trade-history.spec.js
@@ -25,7 +25,7 @@ describe('getTradeHistory', () => {
     fills = [
       {
         fillId: 'fillId',
-        status: 'ACCEPTED'
+        status: 'FILLED'
       },
       {
         fillId: 'fillId2',

--- a/broker-daemon/broker-rpc/order-service/get-trade-history.spec.js
+++ b/broker-daemon/broker-rpc/order-service/get-trade-history.spec.js
@@ -19,28 +19,28 @@ describe('getTradeHistory', () => {
     GetTradeHistoryResponse = sinon.stub()
     completedOrder = {
       orderId: 'orderId',
-      state: 'completed'
+      status: 'COMPLETED'
     }
     executingOrder = {
       orderId: 'orderId2',
-      state: 'executing'
+      status: 'EXECUTING'
     }
     rejectedOrder = {
       orderId: 'orderId3',
-      state: 'rejected'
+      status: 'REJECTED'
     }
 
     acceptedFill = {
       fillId: 'fillId',
-      state: 'accepted'
+      status: 'ACCEPTED'
     }
     executedFill = {
       fillId: 'fillId2',
-      state: 'executed'
+      status: 'EXECUTED'
     }
     rejectedFill = {
       fillId: 'fillId3',
-      state: 'rejected'
+      status: 'REJECTED'
     }
     orders = [
       completedOrder,

--- a/broker-daemon/broker-rpc/order-service/get-trade-history.spec.js
+++ b/broker-daemon/broker-rpc/order-service/get-trade-history.spec.js
@@ -8,49 +8,29 @@ describe('getTradeHistory', () => {
   let blockOrderWorker
   let orders
   let fills
-  let completedOrder
-  let executingOrder
-  let rejectedOrder
-  let acceptedFill
-  let executedFill
-  let rejectedFill
 
   beforeEach(() => {
     GetTradeHistoryResponse = sinon.stub()
-    completedOrder = {
-      orderId: 'orderId',
-      status: 'COMPLETED'
-    }
-    executingOrder = {
-      orderId: 'orderId2',
-      status: 'EXECUTING'
-    }
-    rejectedOrder = {
-      orderId: 'orderId3',
-      status: 'REJECTED'
-    }
-
-    acceptedFill = {
-      fillId: 'fillId',
-      status: 'ACCEPTED'
-    }
-    executedFill = {
-      fillId: 'fillId2',
-      status: 'EXECUTED'
-    }
-    rejectedFill = {
-      fillId: 'fillId3',
-      status: 'REJECTED'
-    }
     orders = [
-      completedOrder,
-      executingOrder,
-      rejectedOrder
+      {
+        orderId: 'orderId',
+        status: 'COMPLETED'
+      },
+      {
+        orderId: 'orderId2',
+        status: 'EXECUTING'
+      }
     ]
+
     fills = [
-      acceptedFill,
-      executedFill,
-      rejectedFill
+      {
+        fillId: 'fillId',
+        status: 'ACCEPTED'
+      },
+      {
+        fillId: 'fillId2',
+        status: 'EXECUTED'
+      }
     ]
 
     blockOrderWorker = {
@@ -73,20 +53,14 @@ describe('getTradeHistory', () => {
     expect(blockOrderWorker.getTrades).to.have.been.calledOnce()
   })
 
-  it('returns filtered trades', async () => {
+  it('returns trades', async () => {
     const res = await getTradeHistory({ blockOrderWorker }, { GetTradeHistoryResponse })
 
     expect(GetTradeHistoryResponse).to.have.been.calledOnce()
     expect(GetTradeHistoryResponse).to.have.been.calledWithNew()
     expect(GetTradeHistoryResponse).to.have.been.calledWith({
-      orders: [
-        completedOrder,
-        executingOrder
-      ],
-      fills: [
-        acceptedFill,
-        executedFill
-      ]
+      orders,
+      fills
     })
     expect(res).to.be.instanceOf(GetTradeHistoryResponse)
   })

--- a/broker-daemon/broker-rpc/order-service/get-trade-history.spec.js
+++ b/broker-daemon/broker-rpc/order-service/get-trade-history.spec.js
@@ -1,0 +1,93 @@
+const path = require('path')
+const { expect, rewire, sinon } = require('test/test-helper')
+
+const getTradeHistory = rewire(path.resolve(__dirname, 'get-trade-history'))
+
+describe('getTradeHistory', () => {
+  let GetTradeHistoryResponse
+  let blockOrderWorker
+  let orders
+  let fills
+  let completedOrder
+  let executingOrder
+  let rejectedOrder
+  let acceptedFill
+  let executedFill
+  let rejectedFill
+
+  beforeEach(() => {
+    GetTradeHistoryResponse = sinon.stub()
+    completedOrder = {
+      orderId: 'orderId',
+      state: 'completed'
+    }
+    executingOrder = {
+      orderId: 'orderId2',
+      state: 'executing'
+    }
+    rejectedOrder = {
+      orderId: 'orderId3',
+      state: 'rejected'
+    }
+
+    acceptedFill = {
+      fillId: 'fillId',
+      state: 'accepted'
+    }
+    executedFill = {
+      fillId: 'fillId2',
+      state: 'executed'
+    }
+    rejectedFill = {
+      fillId: 'fillId3',
+      state: 'rejected'
+    }
+    orders = [
+      completedOrder,
+      executingOrder,
+      rejectedOrder
+    ]
+    fills = [
+      acceptedFill,
+      executedFill,
+      rejectedFill
+    ]
+
+    blockOrderWorker = {
+      getTrades: sinon.stub().resolves({
+        orders,
+        fills
+      })
+    }
+  })
+
+  it('throws an Error if retreiving trades fails', () => {
+    blockOrderWorker.getTrades.rejects(new Error('error'))
+
+    return expect(getTradeHistory({ blockOrderWorker }, { GetTradeHistoryResponse })).to.eventually.be.rejectedWith(Error, 'error')
+  })
+
+  it('retrieves the trades', async () => {
+    await getTradeHistory({ blockOrderWorker }, { GetTradeHistoryResponse })
+
+    expect(blockOrderWorker.getTrades).to.have.been.calledOnce()
+  })
+
+  it('returns filtered trades', async () => {
+    const res = await getTradeHistory({ blockOrderWorker }, { GetTradeHistoryResponse })
+
+    expect(GetTradeHistoryResponse).to.have.been.calledOnce()
+    expect(GetTradeHistoryResponse).to.have.been.calledWithNew()
+    expect(GetTradeHistoryResponse).to.have.been.calledWith({
+      orders: [
+        completedOrder,
+        executingOrder
+      ],
+      fills: [
+        acceptedFill,
+        executedFill
+      ]
+    })
+    expect(res).to.be.instanceOf(GetTradeHistoryResponse)
+  })
+})

--- a/broker-daemon/broker-rpc/order-service/index.js
+++ b/broker-daemon/broker-rpc/order-service/index.js
@@ -6,6 +6,7 @@ const getBlockOrder = require('./get-block-order')
 const cancelBlockOrder = require('./cancel-block-order')
 const getBlockOrders = require('./get-block-orders')
 const cancelAllBlockOrders = require('./cancel-all-block-orders')
+const getTradeHistory = require('./get-trade-history')
 
 class OrderService {
   /**
@@ -28,7 +29,8 @@ class OrderService {
       TimeInForce,
       GetBlockOrderResponse,
       GetBlockOrdersResponse,
-      CancelAllBlockOrdersResponse
+      CancelAllBlockOrdersResponse,
+      GetTradeHistoryResponse
     } = this.proto.broker.rpc
 
     this.implementation = {
@@ -36,7 +38,8 @@ class OrderService {
       getBlockOrder: new GrpcUnaryMethod(getBlockOrder, this.messageId('getBlockOrder'), { logger, blockOrderWorker, auth }, { GetBlockOrderResponse }).register(),
       cancelBlockOrder: new GrpcUnaryMethod(cancelBlockOrder, this.messageId('cancelBlockOrder'), { logger, blockOrderWorker, auth }).register(),
       getBlockOrders: new GrpcUnaryMethod(getBlockOrders, this.messageId('getBlockOrders'), { logger, blockOrderWorker, auth }, { GetBlockOrdersResponse }).register(),
-      cancelAllBlockOrders: new GrpcUnaryMethod(cancelAllBlockOrders, this.messageId('cancelAllBlockOrders'), { logger, blockOrderWorker, auth }, { CancelAllBlockOrdersResponse }).register()
+      cancelAllBlockOrders: new GrpcUnaryMethod(cancelAllBlockOrders, this.messageId('cancelAllBlockOrders'), { logger, blockOrderWorker, auth }, { CancelAllBlockOrdersResponse }).register(),
+      getTradeHistory: new GrpcUnaryMethod(getTradeHistory, this.messageId('getTradeHistory'), { logger, blockOrderWorker, auth }, { GetTradeHistoryResponse }).register()
     }
   }
 

--- a/broker-daemon/broker-rpc/order-service/index.spec.js
+++ b/broker-daemon/broker-rpc/order-service/index.spec.js
@@ -9,6 +9,7 @@ describe('OrderService', () => {
   let cancelBlockOrderStub
   let getBlockOrdersStub
   let cancelAllBlockOrdersStub
+  let getTradeHistoryStub
 
   let GrpcMethod
   let register
@@ -36,6 +37,7 @@ describe('OrderService', () => {
           GetBlockOrderResponse: sinon.stub(),
           GetBlockOrdersResponse: sinon.stub(),
           CancelAllBlockOrdersResponse: sinon.stub(),
+          GetTradeHistoryResponse: sinon.stub(),
           TimeInForce: {
             GTC: 0
           }
@@ -72,6 +74,9 @@ describe('OrderService', () => {
 
     cancelAllBlockOrdersStub = sinon.stub()
     OrderService.__set__('cancelAllBlockOrders', cancelAllBlockOrdersStub)
+
+    getTradeHistoryStub = sinon.stub()
+    OrderService.__set__('getTradeHistory', getTradeHistoryStub)
   })
 
   beforeEach(() => {
@@ -346,6 +351,53 @@ describe('OrderService', () => {
     it('passes in the response', () => {
       expect(callArgs[3]).to.be.an('object')
       expect(callArgs[3]).to.have.property('CancelAllBlockOrdersResponse', proto.broker.rpc.CancelAllBlockOrdersResponse)
+    })
+  })
+
+  describe('#getTradeHistory', () => {
+    let callOrder = 5
+    let callArgs
+
+    beforeEach(() => {
+      callArgs = GrpcMethod.args[callOrder]
+    })
+
+    it('exposes an implementation', () => {
+      expect(server.implementation).to.have.property('getTradeHistory')
+      expect(server.implementation.getTradeHistory).to.be.a('function')
+    })
+
+    it('creates a GrpcMethod', () => {
+      expect(GrpcMethod).to.have.been.called()
+      expect(GrpcMethod).to.have.been.calledWithNew()
+      expect(server.implementation.getTradeHistory).to.be.equal(fakeRegistered)
+    })
+
+    it('provides the method', () => {
+      expect(callArgs[0]).to.be.equal(getTradeHistoryStub)
+    })
+
+    it('provides a message id', () => {
+      expect(callArgs[1]).to.be.equal('[OrderService:getTradeHistory]')
+    })
+
+    describe('request options', () => {
+      it('passes in the logger', () => {
+        expect(callArgs[2]).to.have.property('logger', logger)
+      })
+
+      it('block order worker', () => {
+        expect(callArgs[2]).to.have.property('blockOrderWorker', blockOrderWorker)
+      })
+
+      it('passes in auth', () => {
+        expect(callArgs[2]).to.have.property('auth', auth)
+      })
+    })
+
+    it('passes in the response', () => {
+      expect(callArgs[3]).to.be.an('object')
+      expect(callArgs[3]).to.have.property('GetTradeHistoryResponse', proto.broker.rpc.GetTradeHistoryResponse)
     })
   })
 })

--- a/broker-daemon/models/block-order.js
+++ b/broker-daemon/models/block-order.js
@@ -373,11 +373,11 @@ class BlockOrder {
    */
   serialize () {
     const orders = this.orders.map((orderObject) => {
-      return Order.serialize(orderObject)
+      return OrderStateMachine.serialize(orderObject)
     })
 
     const fills = this.fills.map((fillObject) => {
-      return Fill.serialize(fillObject)
+      return FillStateMachine.serialize(fillObject)
     })
 
     const serialized = {

--- a/broker-daemon/models/block-order.js
+++ b/broker-daemon/models/block-order.js
@@ -338,8 +338,8 @@ class BlockOrder {
     const orders = await getRecords(
       store,
       (key, value) => {
-        const { order, state, error } = JSON.parse(value)
-        return { order: Order.fromObject(key, order), state, error }
+        const { order, state, error, dates } = JSON.parse(value)
+        return { order: Order.fromObject(key, order), state, error, dates }
       },
       // limit the orders we retrieve to those that belong to this blockOrder, i.e. those that are in
       // its prefix range.
@@ -357,8 +357,8 @@ class BlockOrder {
     const fills = await getRecords(
       store,
       (key, value) => {
-        const { fill, state, error } = JSON.parse(value)
-        return { fill: Fill.fromObject(key, fill), state, error }
+        const { fill, state, error, dates } = JSON.parse(value)
+        return { fill: Fill.fromObject(key, fill), state, error, dates }
       },
       // limit the fills we retrieve to those that belong to this blockOrder, i.e. those that are in
       // its prefix range.
@@ -372,34 +372,12 @@ class BlockOrder {
    * @returns {Object} Object to be serialized into a GRPC message
    */
   serialize () {
-    const baseAmountFactor = this.baseCurrencyConfig.quantumsPerCommon
-    const counterAmountFactor = this.counterCurrencyConfig.quantumsPerCommon
-
-    const orders = this.orders.map(({ order, state, error }) => {
-      const baseCommonAmount = Big(order.baseAmount).div(baseAmountFactor)
-      const counterCommonAmount = Big(order.counterAmount).div(counterAmountFactor)
-
-      return {
-        orderId: order.orderId,
-        amount: baseCommonAmount.toFixed(16),
-        price: counterCommonAmount.div(baseCommonAmount).toFixed(16),
-        orderStatus: state.toUpperCase(),
-        orderError: error ? error.toString() : undefined
-      }
+    const orders = this.orders.map((orderObject) => {
+      return Order.serialize(orderObject)
     })
 
-    const fills = this.fills.map(({ fill, state, error }) => {
-      const baseCommonAmount = Big(fill.fillAmount).div(baseAmountFactor)
-      const counterCommonAmount = Big(fill.counterFillAmount).div(counterAmountFactor)
-
-      return {
-        orderId: fill.order.orderId,
-        fillId: fill.fillId,
-        amount: baseCommonAmount.toFixed(16),
-        price: counterCommonAmount.div(baseCommonAmount).toFixed(16),
-        fillStatus: state.toUpperCase(),
-        fillError: error ? error.toString() : undefined
-      }
+    const fills = this.fills.map((fillObject) => {
+      return Fill.serialize(fillObject)
     })
 
     const serialized = {
@@ -411,7 +389,7 @@ class BlockOrder {
       timestamp: this.timestamp,
       datetime: this.datetime,
       orders,
-      fills: fills
+      fills
     }
 
     if (this.price) {

--- a/broker-daemon/models/block-order.spec.js
+++ b/broker-daemon/models/block-order.spec.js
@@ -450,7 +450,7 @@ describe('BlockOrder', () => {
 
           const serialized = blockOrder.serialize()
 
-          expect(serialized.orders[0]).to.have.property('orderStatus', 'CREATED')
+          expect(serialized.orders[0]).to.have.property('status', 'CREATED')
         })
 
         it('returns an undefined value for orderError for a successful order', () => {

--- a/broker-daemon/models/block-order.spec.js
+++ b/broker-daemon/models/block-order.spec.js
@@ -253,6 +253,8 @@ describe('BlockOrder', () => {
     let timestamp
     let Order
     let Fill
+    let OrderStateMachine
+    let FillStateMachine
 
     let reverts = []
 
@@ -288,20 +290,46 @@ describe('BlockOrder', () => {
       Order = {
         fromObject: sinon.stub(),
         fromStorage: sinon.stub(),
-        rangeForBlockOrder: sinon.stub(),
-        serialize: sinon.stub()
+        rangeForBlockOrder: sinon.stub()
       }
+      OrderStateMachine = {
+        serialize: sinon.stub(),
+        STATES: {
+          NONE: 'none',
+          CREATED: 'created',
+          PLACED: 'placed',
+          CANCELLED: 'cancelled',
+          EXECUTING: 'executing',
+          COMPLETED: 'completed',
+          REJECTED: 'rejected'
+        }
+      }
+
+      FillStateMachine = {
+        serialize: sinon.stub(),
+        STATES: {
+          NONE: 'none',
+          CREATED: 'created',
+          FILLED: 'filled',
+          EXECUTED: 'executed',
+          CANCELLED: 'cancelled',
+          REJECTED: 'rejected'
+        }
+      }
+
       BlockOrder.__set__('Order', Order)
 
       Fill = {
         fromObject: sinon.stub(),
-        rangeForBlockOrder: sinon.stub(),
-        serialize: sinon.stub()
+        rangeForBlockOrder: sinon.stub()
       }
+
       BlockOrder.__set__('Fill', Fill)
 
       reverts.push(BlockOrder.__set__('CONFIG', CONFIG))
       reverts.push(BlockOrder.__set__('nanoToDatetime', nanoToDatetimeStub))
+      reverts.push(BlockOrder.__set__('OrderStateMachine', OrderStateMachine))
+      reverts.push(BlockOrder.__set__('FillStateMachine', FillStateMachine))
 
       blockOrder = new BlockOrder(params)
     })
@@ -416,7 +444,7 @@ describe('BlockOrder', () => {
 
         it('serializes all of the orders', () => {
           blockOrder.orders = [ osm ]
-          Order.serialize.returns([ osm ])
+          OrderStateMachine.serialize.returns([ osm ])
 
           const serialized = blockOrder.serialize()
 
@@ -458,7 +486,7 @@ describe('BlockOrder', () => {
 
         it('serializes all of the fills', () => {
           blockOrder.fills = [ fsm ]
-          Fill.serialize.returns([ fsm ])
+          FillStateMachine.serialize.returns([ fsm ])
 
           const serialized = blockOrder.serialize()
 

--- a/broker-daemon/models/block-order.spec.js
+++ b/broker-daemon/models/block-order.spec.js
@@ -288,13 +288,15 @@ describe('BlockOrder', () => {
       Order = {
         fromObject: sinon.stub(),
         fromStorage: sinon.stub(),
-        rangeForBlockOrder: sinon.stub()
+        rangeForBlockOrder: sinon.stub(),
+        serialize: sinon.stub()
       }
       BlockOrder.__set__('Order', Order)
 
       Fill = {
         fromObject: sinon.stub(),
-        rangeForBlockOrder: sinon.stub()
+        rangeForBlockOrder: sinon.stub(),
+        serialize: sinon.stub()
       }
       BlockOrder.__set__('Fill', Fill)
 
@@ -414,51 +416,11 @@ describe('BlockOrder', () => {
 
         it('serializes all of the orders', () => {
           blockOrder.orders = [ osm ]
+          Order.serialize.returns([ osm ])
 
           const serialized = blockOrder.serialize()
 
           expect(serialized.orders).to.have.lengthOf(1)
-        })
-
-        it('serializes the order id', () => {
-          blockOrder.orders = [ osm ]
-
-          const serialized = blockOrder.serialize()
-
-          expect(serialized.orders[0]).to.have.property('orderId', 'mykey')
-        })
-
-        it('serializes the amount into common units', () => {
-          blockOrder.orders = [ osm ]
-
-          const serialized = blockOrder.serialize()
-
-          expect(serialized.orders[0]).to.have.property('amount', '0.0000100000000000')
-        })
-
-        it('converts the price', () => {
-          blockOrder.orders = [ osm ]
-
-          const serialized = blockOrder.serialize()
-
-          expect(serialized.orders[0]).to.have.property('price')
-          expect(serialized.orders[0].price).to.be.eql('10.0000000000000000')
-        })
-
-        it('serializes the state of the order', () => {
-          blockOrder.orders = [ osm ]
-
-          const serialized = blockOrder.serialize()
-
-          expect(serialized.orders[0]).to.have.property('status', 'CREATED')
-        })
-
-        it('returns an undefined value for orderError for a successful order', () => {
-          blockOrder.orders = [ osm ]
-
-          const serialized = blockOrder.serialize()
-
-          expect(serialized.orders[0]).to.have.property('orderError', undefined)
         })
       })
 
@@ -496,59 +458,11 @@ describe('BlockOrder', () => {
 
         it('serializes all of the fills', () => {
           blockOrder.fills = [ fsm ]
+          Fill.serialize.returns([ fsm ])
 
           const serialized = blockOrder.serialize()
 
           expect(serialized.fills).to.have.lengthOf(1)
-        })
-
-        it('serializes the fill id', () => {
-          blockOrder.fills = [ fsm ]
-
-          const serialized = blockOrder.serialize()
-
-          expect(serialized.fills[0]).to.have.property('fillId', 'mykey')
-        })
-
-        it('serializes the order id', () => {
-          blockOrder.fills = [ fsm ]
-
-          const serialized = blockOrder.serialize()
-
-          expect(serialized.fills[0]).to.have.property('orderId', 'otherkey')
-        })
-
-        it('serializes the amount', () => {
-          blockOrder.fills = [ fsm ]
-
-          const serialized = blockOrder.serialize()
-
-          expect(serialized.fills[0]).to.have.property('amount', '0.0000090000000000')
-        })
-
-        it('converts the price', () => {
-          blockOrder.fills = [ fsm ]
-
-          const serialized = blockOrder.serialize()
-
-          expect(serialized.fills[0]).to.have.property('price')
-          expect(serialized.fills[0].price).to.be.eql('10.0000000000000000')
-        })
-
-        it('serializes the state of the fill', () => {
-          blockOrder.fills = [ fsm ]
-
-          const serialized = blockOrder.serialize()
-
-          expect(serialized.fills[0]).to.have.property('fillStatus', 'CREATED')
-        })
-
-        it('returns an undefined value for fillError for a successful order', () => {
-          blockOrder.fills = [ fsm ]
-
-          const serialized = blockOrder.serialize()
-
-          expect(serialized.fills[0]).to.have.property('fillError', undefined)
         })
       })
     })

--- a/broker-daemon/models/fill.js
+++ b/broker-daemon/models/fill.js
@@ -401,7 +401,7 @@ class Fill {
   /**
    * Create an object with fill information
    * @param {string} key - Unique key for the fill, i.e. its `blockOrderId` and `fillId`
-   * @param {Object} orderStateMachineRecord - Stringified representation of the fill state machine record
+   * @param {Object} fillStateMachineRecord - Stringified representation of the fill state machine record
    * @returns {Object} - contains information about the fill and it's state
    */
   static fromStorageWithStatus (key, fillStateMachineRecord) {
@@ -412,8 +412,18 @@ class Fill {
     const [ blockOrderId, fillId ] = key.split(DELIMITER)
 
     const {
+      fill: {
+        order: {
+          orderId,
+          baseSymbol,
+          counterSymbol,
+          side,
+          baseAmount,
+          counterAmount
+        },
+        fillAmount
+      },
       state,
-      order,
       dates
     } = valueObject
 

--- a/broker-daemon/models/fill.js
+++ b/broker-daemon/models/fill.js
@@ -423,7 +423,7 @@ class Fill {
       counterSymbol: order.counterSymbol,
       price: counterCommonAmount.div(baseCommonAmount).toFixed(16),
       fillAmount: fill.fillAmount,
-      status: state.toUpperCase(),
+      fillStatus: state.toUpperCase(),
       error: error ? error.toString() : undefined,
       dates
     }

--- a/broker-daemon/models/fill.js
+++ b/broker-daemon/models/fill.js
@@ -338,7 +338,7 @@ class Fill {
    * @returns {Fill}              Inflated fill object
    */
   static fromObject (key, valueObject) {
-    // keys are the unique id for the object (orderId) prefixed by the object they belong to (blockOrderId)
+    // keys are the unique id for the object (fillId) prefixed by the object they belong to (blockOrderId)
     // and are separated by the delimiter (:)
     const [ blockOrderId, fillId ] = key.split(DELIMITER)
 
@@ -396,6 +396,42 @@ class Fill {
     })
 
     return fill
+  }
+
+  /**
+   * Create an object with fill information
+   * @param {string} key - Unique key for the fill, i.e. its `blockOrderId` and `fillId`
+   * @param {Object} orderStateMachineRecord - Stringified representation of the fill state machine record
+   * @returns {Object} - contains information about the fill and it's state
+   */
+  static fromStorageWithStatus (key, fillStateMachineRecord) {
+    const valueObject = JSON.parse(fillStateMachineRecord)
+
+    // keys are the unique id for the object (fillId) prefixed by the object they belong to (blockOrderId)
+    // and are separated by the delimiter (:)
+    const [ blockOrderId, fillId ] = key.split(DELIMITER)
+
+    const {
+      state,
+      order,
+      dates
+    } = valueObject
+
+    const formattedFill = {
+      fillId,
+      orderId,
+      blockOrderId,
+      baseSymbol,
+      counterSymbol,
+      side,
+      baseAmount,
+      counterAmount,
+      fillAmount,
+      state,
+      ...dates
+    }
+
+    return formattedFill
   }
 
   /**

--- a/broker-daemon/models/fill.js
+++ b/broker-daemon/models/fill.js
@@ -417,12 +417,12 @@ class Fill {
     return {
       fillId: fill.fillId,
       orderId: order.orderId,
-      blockOrderId: order.blockOrderId,
+      blockOrderId: fill.blockOrderId,
       side: order.side,
       baseSymbol: order.baseSymbol,
       counterSymbol: order.counterSymbol,
       price: counterCommonAmount.div(baseCommonAmount).toFixed(16),
-      fillAmount: fill.fillAmount,
+      amount: Big(fill.fillAmount).div(baseAmountFactor).toFixed(16),
       fillStatus: state.toUpperCase(),
       error: error ? error.toString() : undefined,
       dates

--- a/broker-daemon/models/fill.js
+++ b/broker-daemon/models/fill.js
@@ -409,10 +409,10 @@ class Fill {
 
     const { order } = fill
 
-    const baseAmountFactor = CONFIG.currencies.find(({ symbol }) => symbol === fill.baseSymbol).quantumsPerCommon
-    const counterAmountFactor = CONFIG.currencies.find(({ symbol }) => symbol === fill.counterSymbol).quantumsPerCommon
-    const baseCommonAmount = Big(fill.fillAmount).div(baseAmountFactor)
-    const counterCommonAmount = Big(fill.counterFillAmount).div(counterAmountFactor)
+    const baseAmountFactor = CONFIG.currencies.find(({ symbol }) => symbol === order.baseSymbol).quantumsPerCommon
+    const counterAmountFactor = CONFIG.currencies.find(({ symbol }) => symbol === order.counterSymbol).quantumsPerCommon
+    const baseCommonAmount = Big(order.baseAmount).div(baseAmountFactor)
+    const counterCommonAmount = Big(order.counterAmount).div(counterAmountFactor)
 
     return {
       fillId: fill.fillId,
@@ -421,7 +421,6 @@ class Fill {
       side: order.side,
       baseSymbol: order.baseSymbol,
       counterSymbol: order.counterSymbol,
-      amount: baseCommonAmount.toFixed(16),
       price: counterCommonAmount.div(baseCommonAmount).toFixed(16),
       fillAmount: fill.fillAmount,
       status: state.toUpperCase(),

--- a/broker-daemon/models/fill.js
+++ b/broker-daemon/models/fill.js
@@ -102,6 +102,28 @@ class Fill {
   }
 
   /**
+   * serialize an fill for transmission via grpc
+   * @returns {Object} Object to be serialized into a GRPC message
+   */
+  serialize () {
+    const baseAmountFactor = CONFIG.currencies.find(({ symbol }) => symbol === this.order.baseSymbol).quantumsPerCommon
+    const counterAmountFactor = CONFIG.currencies.find(({ symbol }) => symbol === this.order.counterSymbol).quantumsPerCommon
+    const baseCommonAmount = Big(this.order.baseAmount).div(baseAmountFactor)
+    const counterCommonAmount = Big(this.order.counterAmount).div(counterAmountFactor)
+
+    return {
+      fillId: this.fillId,
+      orderId: this.order.orderId,
+      blockOrderId: this.blockOrderId,
+      side: this.order.side,
+      baseSymbol: this.order.baseSymbol,
+      counterSymbol: this.order.counterSymbol,
+      price: counterCommonAmount.div(baseCommonAmount).toFixed(16),
+      amount: Big(this.fillAmount).div(baseAmountFactor).toFixed(16)
+    }
+  }
+
+  /**
    * Params required to create an order on the relayer
    * @returns {Object} Object of parameters the relayer expects
    */
@@ -397,41 +419,6 @@ class Fill {
     })
 
     return fill
-  }
-
-  /**
-   * serialize an fill for transmission via grpc
-   * @param {Object} fillObject - Plain object representation of the fill, state, dates
-   * @returns {Object} Object to be serialized into a GRPC message
-   */
-  static serialize (fillObject) {
-    const {
-      fill,
-      state,
-      error,
-      dates
-    } = fillObject
-
-    const { order } = fill
-
-    const baseAmountFactor = CONFIG.currencies.find(({ symbol }) => symbol === order.baseSymbol).quantumsPerCommon
-    const counterAmountFactor = CONFIG.currencies.find(({ symbol }) => symbol === order.counterSymbol).quantumsPerCommon
-    const baseCommonAmount = Big(order.baseAmount).div(baseAmountFactor)
-    const counterCommonAmount = Big(order.counterAmount).div(counterAmountFactor)
-
-    return {
-      fillId: fill.fillId,
-      orderId: order.orderId,
-      blockOrderId: fill.blockOrderId,
-      side: order.side,
-      baseSymbol: order.baseSymbol,
-      counterSymbol: order.counterSymbol,
-      price: counterCommonAmount.div(baseCommonAmount).toFixed(16),
-      amount: Big(fill.fillAmount).div(baseAmountFactor).toFixed(16),
-      fillStatus: state.toUpperCase(),
-      error: error ? error.toString() : undefined,
-      dates
-    }
   }
 
   /**

--- a/broker-daemon/models/fill.js
+++ b/broker-daemon/models/fill.js
@@ -399,6 +399,12 @@ class Fill {
     return fill
   }
 
+
+  /**
+   * serialize an fukk for transmission via grpc
+   * @param {Object} fukkObject - Plain object representation of the fukk, state, dates
+   * @returns {Object} Object to be serialized into a GRPC message
+   */
   static serialize (fillObject) {
     const {
       fill,

--- a/broker-daemon/models/fill.js
+++ b/broker-daemon/models/fill.js
@@ -399,10 +399,9 @@ class Fill {
     return fill
   }
 
-
   /**
-   * serialize an fukk for transmission via grpc
-   * @param {Object} fukkObject - Plain object representation of the fukk, state, dates
+   * serialize an fill for transmission via grpc
+   * @param {Object} fillObject - Plain object representation of the fill, state, dates
    * @returns {Object} Object to be serialized into a GRPC message
    */
   static serialize (fillObject) {

--- a/broker-daemon/models/fill.spec.js
+++ b/broker-daemon/models/fill.spec.js
@@ -88,6 +88,48 @@ describe('Fill', () => {
     })
   })
 
+  describe('::fromStorageWithStatus', () => {
+    it('defines a static method for creating fills from storage with status', () => {
+      expect(Fill).itself.to.respondTo('fromStorageWithStatus')
+    })
+
+    it('creates orders from a key and value', () => {
+      const params = {
+        state: 'accepted',
+        dates: {
+          dateAccepted: '2019-04-15T17:22:26.672Z'
+        },
+        fill: {
+          order: {
+            orderId: 'fakeID',
+            baseSymbol: 'BTC',
+            counterSymbol: 'LTC',
+            side: 'BID',
+            baseAmount: '10000',
+            counterAmount: '100000'
+          },
+          fillAmount: '9000'
+        }
+      }
+      const blockOrderId = 'blockid'
+      const fillId = 'myid'
+      const key = `${blockOrderId}:${fillId}`
+
+      const fill = Fill.fromStorageWithStatus(key, JSON.stringify(params))
+
+      expect(fill).to.have.property('blockOrderId', blockOrderId)
+      expect(fill).to.have.property('fillId', fillId)
+      expect(fill).to.have.property('fillAmount', params.fill.fillAmount)
+      expect(fill).to.have.property('baseSymbol', params.fill.order.baseSymbol)
+      expect(fill).to.have.property('counterSymbol', params.fill.order.counterSymbol)
+      expect(fill).to.have.property('side', params.fill.order.side)
+      expect(fill).to.have.property('baseAmount', params.fill.order.baseAmount)
+      expect(fill).to.have.property('counterAmount', params.fill.order.counterAmount)
+      expect(fill).to.have.property('state', params.state)
+      expect(fill).to.have.property('dateAccepted', params.dates.dateAccepted)
+    })
+  })
+
   describe('::fromObject', () => {
     it('defines a static method for creating orders from a plain object', () => {
       expect(Fill).itself.to.respondTo('fromObject')

--- a/broker-daemon/models/fill.spec.js
+++ b/broker-daemon/models/fill.spec.js
@@ -5,6 +5,7 @@ const Fill = rewire(path.resolve(__dirname, 'fill'))
 
 describe('Fill', () => {
   let Order
+  let CONFIG
 
   beforeEach(() => {
     Order = {
@@ -14,6 +15,24 @@ describe('Fill', () => {
       }
     }
 
+    CONFIG = {
+      currencies: [
+        {
+          symbol: 'BTC',
+          quantumsPerCommon: '100000000'
+        },
+        {
+          symbol: 'XYZ',
+          quantumsPerCommon: '10000'
+        },
+        {
+          symbol: 'LTC',
+          quantumsPerCommon: '100000000'
+        }
+      ]
+    }
+
+    Fill.__set__('CONFIG', CONFIG)
     Fill.__set__('Order', Order)
   })
 
@@ -88,19 +107,20 @@ describe('Fill', () => {
     })
   })
 
-  describe('::fromStorageWithStatus', () => {
-    it('defines a static method for creating fills from storage with status', () => {
-      expect(Fill).itself.to.respondTo('fromStorageWithStatus')
+  describe('::serialize', () => {
+    it('defines a static method for serialize a fillObject', () => {
+      expect(Fill).itself.to.respondTo('serialize')
     })
 
-    it('creates orders from a key and value', () => {
+    it('returns a serialized version of the fill', () => {
       const params = {
-        state: 'accepted',
+        state: 'ACCEPTED',
         dates: {
           dateAccepted: '2019-04-15T17:22:26.672Z'
         },
         fill: {
           order: {
+            blockOrderId: 'asdfasdf',
             orderId: 'fakeID',
             baseSymbol: 'BTC',
             counterSymbol: 'LTC',
@@ -108,25 +128,22 @@ describe('Fill', () => {
             baseAmount: '10000',
             counterAmount: '100000'
           },
+          fillId: 'asdf',
           fillAmount: '9000'
         }
       }
-      const blockOrderId = 'blockid'
-      const fillId = 'myid'
-      const key = `${blockOrderId}:${fillId}`
 
-      const fill = Fill.fromStorageWithStatus(key, JSON.stringify(params))
+      const fill = Fill.serialize(params)
 
-      expect(fill).to.have.property('blockOrderId', blockOrderId)
-      expect(fill).to.have.property('fillId', fillId)
+      expect(fill).to.have.property('blockOrderId', params.fill.order.blockOrderId)
+      expect(fill).to.have.property('fillId', params.fill.fillId)
       expect(fill).to.have.property('fillAmount', params.fill.fillAmount)
       expect(fill).to.have.property('baseSymbol', params.fill.order.baseSymbol)
       expect(fill).to.have.property('counterSymbol', params.fill.order.counterSymbol)
       expect(fill).to.have.property('side', params.fill.order.side)
-      expect(fill).to.have.property('baseAmount', params.fill.order.baseAmount)
-      expect(fill).to.have.property('counterAmount', params.fill.order.counterAmount)
-      expect(fill).to.have.property('state', params.state)
-      expect(fill).to.have.property('dateAccepted', params.dates.dateAccepted)
+      expect(fill).to.have.property('price', '10.0000000000000000')
+      expect(fill).to.have.property('status', params.state.toUpperCase())
+      expect(fill).to.have.property('dates', params.dates)
     })
   })
 

--- a/broker-daemon/models/fill.spec.js
+++ b/broker-daemon/models/fill.spec.js
@@ -142,7 +142,7 @@ describe('Fill', () => {
       expect(fill).to.have.property('counterSymbol', params.fill.order.counterSymbol)
       expect(fill).to.have.property('side', params.fill.order.side)
       expect(fill).to.have.property('price', '10.0000000000000000')
-      expect(fill).to.have.property('status', params.state.toUpperCase())
+      expect(fill).to.have.property('fillStatus', params.state.toUpperCase())
       expect(fill).to.have.property('dates', params.dates)
     })
   })

--- a/broker-daemon/models/fill.spec.js
+++ b/broker-daemon/models/fill.spec.js
@@ -107,46 +107,6 @@ describe('Fill', () => {
     })
   })
 
-  describe('::serialize', () => {
-    it('defines a static method for serialize a fillObject', () => {
-      expect(Fill).itself.to.respondTo('serialize')
-    })
-
-    it('returns a serialized version of the fill', () => {
-      const params = {
-        state: 'FILLED',
-        dates: {
-          filled: '2019-04-15T17:22:26.672Z'
-        },
-        fill: {
-          blockOrderId: 'asdfasdf',
-          order: {
-            orderId: 'fakeID',
-            baseSymbol: 'BTC',
-            counterSymbol: 'LTC',
-            side: 'BID',
-            baseAmount: '10000',
-            counterAmount: '100000'
-          },
-          fillId: 'asdf',
-          fillAmount: '9000'
-        }
-      }
-
-      const fill = Fill.serialize(params)
-
-      expect(fill).to.have.property('blockOrderId', params.fill.blockOrderId)
-      expect(fill).to.have.property('fillId', params.fill.fillId)
-      expect(fill).to.have.property('amount', '0.0000900000000000')
-      expect(fill).to.have.property('baseSymbol', params.fill.order.baseSymbol)
-      expect(fill).to.have.property('counterSymbol', params.fill.order.counterSymbol)
-      expect(fill).to.have.property('side', params.fill.order.side)
-      expect(fill).to.have.property('price', '10.0000000000000000')
-      expect(fill).to.have.property('fillStatus', params.state.toUpperCase())
-      expect(fill).to.have.property('dates', params.dates)
-    })
-  })
-
   describe('::fromObject', () => {
     it('defines a static method for creating orders from a plain object', () => {
       expect(Fill).itself.to.respondTo('fromObject')
@@ -471,6 +431,20 @@ describe('Fill', () => {
         fill.setExecuteParams(executeParams)
 
         expect(fill.value).to.include(`"makerAddress":"${executeParams.makerAddress}"`)
+      })
+    })
+
+    describe('serialize', () => {
+      it('returns a serialized version of the fill', () => {
+        const serializedFill = fill.serialize()
+
+        expect(serializedFill).to.have.property('blockOrderId', fill.blockOrderId)
+        expect(serializedFill).to.have.property('fillId', fill.fillId)
+        expect(serializedFill).to.have.property('amount', '0.0000900000000000')
+        expect(serializedFill).to.have.property('baseSymbol', fill.order.baseSymbol)
+        expect(serializedFill).to.have.property('counterSymbol', fill.order.counterSymbol)
+        expect(serializedFill).to.have.property('side', fill.order.side)
+        expect(serializedFill).to.have.property('price', '10.0000000000000000')
       })
     })
   })

--- a/broker-daemon/models/fill.spec.js
+++ b/broker-daemon/models/fill.spec.js
@@ -114,13 +114,13 @@ describe('Fill', () => {
 
     it('returns a serialized version of the fill', () => {
       const params = {
-        state: 'ACCEPTED',
+        state: 'FILLED',
         dates: {
-          dateAccepted: '2019-04-15T17:22:26.672Z'
+          filled: '2019-04-15T17:22:26.672Z'
         },
         fill: {
+          blockOrderId: 'asdfasdf',
           order: {
-            blockOrderId: 'asdfasdf',
             orderId: 'fakeID',
             baseSymbol: 'BTC',
             counterSymbol: 'LTC',
@@ -135,9 +135,9 @@ describe('Fill', () => {
 
       const fill = Fill.serialize(params)
 
-      expect(fill).to.have.property('blockOrderId', params.fill.order.blockOrderId)
+      expect(fill).to.have.property('blockOrderId', params.fill.blockOrderId)
       expect(fill).to.have.property('fillId', params.fill.fillId)
-      expect(fill).to.have.property('fillAmount', params.fill.fillAmount)
+      expect(fill).to.have.property('amount', '0.0000900000000000')
       expect(fill).to.have.property('baseSymbol', params.fill.order.baseSymbol)
       expect(fill).to.have.property('counterSymbol', params.fill.order.counterSymbol)
       expect(fill).to.have.property('side', params.fill.order.side)

--- a/broker-daemon/models/order.js
+++ b/broker-daemon/models/order.js
@@ -434,6 +434,11 @@ class Order {
     return order
   }
 
+  /**
+   * serialize an order for transmission via grpc
+   * @param {Object} orderObject - Plain object representation of the order, state, dates
+   * @returns {Object} Object to be serialized into a GRPC message
+   */
   static serialize (orderObject) {
     const {
       order,

--- a/broker-daemon/models/order.js
+++ b/broker-daemon/models/order.js
@@ -456,7 +456,7 @@ class Order {
       amount: baseCommonAmount.toFixed(16),
       price: counterCommonAmount.div(baseCommonAmount).toFixed(16),
       fillAmount: order.fillAmount,
-      status: state.toUpperCase(),
+      orderStatus: state.toUpperCase(),
       error: error ? error.toString() : undefined,
       dates
     }

--- a/broker-daemon/models/order.js
+++ b/broker-daemon/models/order.js
@@ -438,7 +438,7 @@ class Order {
    * Create an object with order information
    * @param {string} key - Unique key for the order, i.e. its `blockOrderId` and `orderId`
    * @param {Object} orderStateMachineRecord - Stringified representation of the order state machine record
-   * @returns {Object} - contains information about the order and it's state          
+   * @returns {Object} - contains information about the order and it's state
    */
   static fromStorageWithStatus (key, orderStateMachineRecord) {
     const valueObject = JSON.parse(orderStateMachineRecord)

--- a/broker-daemon/models/order.js
+++ b/broker-daemon/models/order.js
@@ -435,6 +435,47 @@ class Order {
   }
 
   /**
+   * Create an object with order information
+   * @param {string} key - Unique key for the order, i.e. its `blockOrderId` and `orderId`
+   * @param {Object} orderStateMachineRecord - Stringified representation of the order state machine record
+   * @returns {Object} - contains information about the order and it's state          
+   */
+  static fromStorageWithStatus (key, orderStateMachineRecord) {
+    const valueObject = JSON.parse(orderStateMachineRecord)
+    // keys are the unique id for the object (orderId) prefixed by the object they belong to (blockOrderId)
+    // and are separated by the delimiter (:)
+    const [ blockOrderId, orderId ] = key.split(DELIMITER)
+
+    const {
+      state,
+      order,
+      dates
+    } = valueObject
+
+    const {
+      baseSymbol,
+      counterSymbol,
+      side,
+      baseAmount,
+      counterAmount
+    } = order
+
+    const formattedOrder = {
+      orderId,
+      blockOrderId,
+      baseSymbol,
+      counterSymbol,
+      side,
+      baseAmount,
+      counterAmount,
+      state,
+      ...dates
+    }
+
+    return formattedOrder
+  }
+
+  /**
    * Create a set of options that can be passed to a LevelUP `createReadStream` call
    * that limits the set to orders that belong to the given blockOrderid.
    * This works because all orders are prefixed with their blockOrderId and the Delimiter.

--- a/broker-daemon/models/order.js
+++ b/broker-daemon/models/order.js
@@ -446,6 +446,7 @@ class Order {
     const counterAmountFactor = CONFIG.currencies.find(({ symbol }) => symbol === order.counterSymbol).quantumsPerCommon
     const baseCommonAmount = Big(order.baseAmount).div(baseAmountFactor)
     const counterCommonAmount = Big(order.counterAmount).div(counterAmountFactor)
+    const fillCommonAmount = order.fillAmount ? Big(order.fillAmount).div(baseAmountFactor).toFixed(16) : order.fillAmount
 
     return {
       orderId: order.orderId,
@@ -455,7 +456,7 @@ class Order {
       counterSymbol: order.counterSymbol,
       amount: baseCommonAmount.toFixed(16),
       price: counterCommonAmount.div(baseCommonAmount).toFixed(16),
-      fillAmount: order.fillAmount,
+      fillAmount: fillCommonAmount,
       orderStatus: state.toUpperCase(),
       error: error ? error.toString() : undefined,
       dates

--- a/broker-daemon/models/order.spec.js
+++ b/broker-daemon/models/order.spec.js
@@ -85,45 +85,6 @@ describe('Order', () => {
     })
   })
 
-  describe('::serialize', () => {
-    it('defines a static method for creating orders from storage with status', () => {
-      expect(Order).itself.to.respondTo('serialize')
-    })
-
-    it('creates orders from a key and value', () => {
-      const params = {
-        dates: {
-          created: '2019-04-15T17:22:26.672Z',
-          placed: '2019-04-15T17:22:26.672Z'
-        },
-        state: 'placed',
-        order: {
-          orderId: 'asdf',
-          blockOrderid: 'asdfasdf',
-          baseSymbol: 'BTC',
-          counterSymbol: 'LTC',
-          side: 'BID',
-          baseAmount: '1000',
-          counterAmount: '10000',
-          makerBaseAddress: 'bolt:123019230jasofdij',
-          makerCounterAddress: 'bolt:65433455asdfasdf'
-        }
-      }
-
-      const order = Order.serialize(params)
-
-      expect(order).to.have.property('blockOrderId', params.order.blockOrderId)
-      expect(order).to.have.property('orderId', params.order.orderId)
-      expect(order).to.have.property('baseSymbol', params.order.baseSymbol)
-      expect(order).to.have.property('counterSymbol', params.order.counterSymbol)
-      expect(order).to.have.property('side', params.order.side)
-      expect(order).to.have.property('amount', '0.0000100000000000')
-      expect(order).to.have.property('price', '10.0000000000000000')
-      expect(order).to.have.property('orderStatus', params.state.toUpperCase())
-      expect(order).to.have.property('dates', params.dates)
-    })
-  })
-
   describe('::fromObject', () => {
     it('defines a static method for creating orders from a plain object', () => {
       expect(Order).itself.to.respondTo('fromObject')
@@ -503,6 +464,20 @@ describe('Order', () => {
         expect(order.value).to.include(`"swapHash":"${filledParams.swapHash}"`)
         expect(order.value).to.include(`"fillAmount":"${filledParams.fillAmount}"`)
         expect(order.value).to.include(`"takerAddress":"${filledParams.takerAddress}"`)
+      })
+    })
+
+    describe('serialize', () => {
+      it('serializes the order for grpc transfer', () => {
+        const serializedOrder = order.serialize()
+
+        expect(serializedOrder).to.have.property('blockOrderId', order.blockOrderId)
+        expect(serializedOrder).to.have.property('orderId', order.orderId)
+        expect(serializedOrder).to.have.property('baseSymbol', order.baseSymbol)
+        expect(serializedOrder).to.have.property('counterSymbol', order.counterSymbol)
+        expect(serializedOrder).to.have.property('side', order.side)
+        expect(serializedOrder).to.have.property('amount', '0.0001000000000000')
+        expect(serializedOrder).to.have.property('price', '10.0000000000000000')
       })
     })
   })

--- a/broker-daemon/models/order.spec.js
+++ b/broker-daemon/models/order.spec.js
@@ -85,9 +85,9 @@ describe('Order', () => {
     })
   })
 
-  describe('::fromStorageWithStatus', () => {
+  describe('::serialize', () => {
     it('defines a static method for creating orders from storage with status', () => {
-      expect(Order).itself.to.respondTo('fromStorageWithStatus')
+      expect(Order).itself.to.respondTo('serialize')
     })
 
     it('creates orders from a key and value', () => {
@@ -98,31 +98,29 @@ describe('Order', () => {
         },
         state: 'placed',
         order: {
+          orderId: 'asdf',
+          blockOrderid: 'asdfasdf',
           baseSymbol: 'BTC',
           counterSymbol: 'LTC',
           side: 'BID',
-          baseAmount: '10000',
-          counterAmount: '100000',
+          baseAmount: '1000',
+          counterAmount: '10000',
           makerBaseAddress: 'bolt:123019230jasofdij',
           makerCounterAddress: 'bolt:65433455asdfasdf'
         }
       }
-      const blockOrderId = 'blockid'
-      const orderId = 'myid'
-      const key = `${blockOrderId}:${orderId}`
 
-      const order = Order.fromStorageWithStatus(key, JSON.stringify(params))
+      const order = Order.serialize(params)
 
-      expect(order).to.have.property('blockOrderId', blockOrderId)
-      expect(order).to.have.property('orderId', orderId)
+      expect(order).to.have.property('blockOrderId', params.order.blockOrderId)
+      expect(order).to.have.property('orderId', params.order.orderId)
       expect(order).to.have.property('baseSymbol', params.order.baseSymbol)
       expect(order).to.have.property('counterSymbol', params.order.counterSymbol)
       expect(order).to.have.property('side', params.order.side)
-      expect(order).to.have.property('baseAmount', params.order.baseAmount)
-      expect(order).to.have.property('counterAmount', params.order.counterAmount)
-      expect(order).to.have.property('state', params.state)
-      expect(order).to.have.property('dateCreated', params.dates.dateCreated)
-      expect(order).to.have.property('datePlaced', params.dates.datePlaced)
+      expect(order).to.have.property('amount', '0.0000100000000000')
+      expect(order).to.have.property('price', '10.0000000000000000')
+      expect(order).to.have.property('status', params.state.toUpperCase())
+      expect(order).to.have.property('dates', params.dates)
     })
   })
 

--- a/broker-daemon/models/order.spec.js
+++ b/broker-daemon/models/order.spec.js
@@ -93,8 +93,8 @@ describe('Order', () => {
     it('creates orders from a key and value', () => {
       const params = {
         dates: {
-          dateCreated: '2019-04-15T17:22:26.672Z',
-          datePlaced: '2019-04-15T17:22:26.672Z'
+          created: '2019-04-15T17:22:26.672Z',
+          placed: '2019-04-15T17:22:26.672Z'
         },
         state: 'placed',
         order: {
@@ -119,7 +119,7 @@ describe('Order', () => {
       expect(order).to.have.property('side', params.order.side)
       expect(order).to.have.property('amount', '0.0000100000000000')
       expect(order).to.have.property('price', '10.0000000000000000')
-      expect(order).to.have.property('status', params.state.toUpperCase())
+      expect(order).to.have.property('orderStatus', params.state.toUpperCase())
       expect(order).to.have.property('dates', params.dates)
     })
   })

--- a/broker-daemon/models/order.spec.js
+++ b/broker-daemon/models/order.spec.js
@@ -25,7 +25,7 @@ describe('Order', () => {
   })
 
   describe('::fromStorage', () => {
-    it('defines a static method for creating orderss from storage', () => {
+    it('defines a static method for creating orders from storage', () => {
       expect(Order).itself.to.respondTo('fromStorage')
     })
 
@@ -82,6 +82,47 @@ describe('Order', () => {
       expect(order).to.have.property('orderId', orderId)
       expect(order).to.have.property('feePaymentRequest', params.order.feePaymentRequest)
       expect(order).to.have.property('depositPaymentRequest', params.order.depositPaymentRequest)
+    })
+  })
+
+  describe('::fromStorageWithStatus', () => {
+    it('defines a static method for creating orders from storage with status', () => {
+      expect(Order).itself.to.respondTo('fromStorageWithStatus')
+    })
+
+    it('creates orders from a key and value', () => {
+      const params = {
+        dates: {
+          dateCreated: '2019-04-15T17:22:26.672Z',
+          datePlaced: '2019-04-15T17:22:26.672Z'
+        },
+        state: 'placed',
+        order: {
+          baseSymbol: 'BTC',
+          counterSymbol: 'LTC',
+          side: 'BID',
+          baseAmount: '10000',
+          counterAmount: '100000',
+          makerBaseAddress: 'bolt:123019230jasofdij',
+          makerCounterAddress: 'bolt:65433455asdfasdf'
+        }
+      }
+      const blockOrderId = 'blockid'
+      const orderId = 'myid'
+      const key = `${blockOrderId}:${orderId}`
+
+      const order = Order.fromStorageWithStatus(key, JSON.stringify(params))
+
+      expect(order).to.have.property('blockOrderId', blockOrderId)
+      expect(order).to.have.property('orderId', orderId)
+      expect(order).to.have.property('baseSymbol', params.order.baseSymbol)
+      expect(order).to.have.property('counterSymbol', params.order.counterSymbol)
+      expect(order).to.have.property('side', params.order.side)
+      expect(order).to.have.property('baseAmount', params.order.baseAmount)
+      expect(order).to.have.property('counterAmount', params.order.counterAmount)
+      expect(order).to.have.property('state', params.state)
+      expect(order).to.have.property('dateCreated', params.dates.dateCreated)
+      expect(order).to.have.property('datePlaced', params.dates.datePlaced)
     })
   })
 

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -419,7 +419,7 @@ message Fill {
     FILLED = 1;
     // The swap has been executed on the Payment Channel Networks.
     EXECUTED = 2;
-    // The preimage has been returned to the Relayer by the Maker.
+    // The fill has encountered a failure.
     REJECTED = 4;
     // The fill has been cancelled.
     CANCELLED = 5;
@@ -435,7 +435,7 @@ message Fill {
     string filled = 2;
     // The date the fill has encountered a failure.
     string executed = 3;
-    // The date the preimage has been returned to the Relayer by the Maker.
+    // The date the fill has encountered a failure.
     string rejected = 5;
     // The date the fill has been cancelled.
     string cancelled = 6;

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -395,6 +395,8 @@ message Order {
   string side = 10;
   // Dates that the order has reached each status
   Date dates = 11;
+  // Amount of the order filled, expressed in a decimal string of common units for a currency (e.g. bitcoins for BTC). This can be any amount greater than zero and less than or equal to the amount in the order.
+  string fill_amount = 12;
 }
 
 /**
@@ -890,6 +892,7 @@ service OrderService {
    *         "dateRejected": "",
    *         "dateCancelled": ""
    *       }
+   *       "fillAmount": "0.0001000000000000",
    *     },
    *     {
    *       "orderId": "U6WQ8Al2lDXqHthXx7UORN0c",

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -417,8 +417,6 @@ message Fill {
     // The swap has been executed on the Payment Channel Networks.
     EXECUTED = 2;
     // The preimage has been returned to the Relayer by the Maker.
-    COMPLETED = 3;
-    // The fill has encountered a failure.
     REJECTED = 4;
     // The fill has been cancelled.
     CANCELLED = 5;
@@ -432,8 +430,6 @@ message Fill {
     // The date the swap has been executed on the Payment Channel Networks.
     string executed = 3;
     // The date the preimage has been returned to the Relayer by the Maker.
-    string completed = 4;
-    // The date the fill has encountered a failure.
     string rejected = 5;
     // The date the fill has been cancelled.
     string cancelled = 6;
@@ -877,46 +873,47 @@ service OrderService {
    * {
    *   "orders": [
    *     {
-   *       "orderId": "Ky13eTmuhZY-NIbqIng_in3D",
-   *       "orderStatus": "EXECUTING",
-   *       "amount": "0.0001000000000000",
-   *       "price": "0.0001000000000000",
-   *       "orderError": "",
-   *       "blockOrderId": "XLDXVDZiXxdifizQ",
+   *       "orderId": "GZnWxbVT6hK_2KM-r_hbSXp0",
+   *       "orderStatus": "COMPLETED",
+   *       "amount": "0.0040000000000000",
+   *       "price": "0.0040000000000000",
+   *       "error": "",
+   *       "blockOrderId": "XLoVOEJdJgO8JWAB",
    *       "baseSymbol": "BTC",
    *       "counterSymbol": "LTC",
    *       "side": "ASK",
    *       "dates": {
-   *         "created": "2019-04-12T18:22:13.111Z",
-   *         "placed": "2019-04-12T18:22:13.121Z",
-   *         "executing": "2019-04-12T18:22:20.121Z",
-   *         "completed": "",
+   *         "created": "2019-04-19T18:36:40.809Z",
+   *         "placed": "2019-04-19T18:36:40.816Z",
+   *         "executing": "2019-04-19T18:36:52.556Z",
+   *         "completed": "2019-04-19T18:36:53.357Z",
    *         "rejected": "",
    *         "cancelled": ""
-   *       }
-   *       "fillAmount": "0.0001000000000000",
-   *     },
+   *       },
+   *       "fillAmount": "0.0010000000000000"
+   *     }
+   *   ],
+   *   "fills": [
    *     {
-   *       "orderId": "U6WQ8Al2lDXqHthXx7UORN0c",
-   *       "orderStatus": "COMPLETED",
-   *       "amount": "0.0001000000000000",
-   *       "price": "0.0001000000000000",
-   *       "orderError": "",
-   *       "blockOrderId": "XLDXclazEcJjK8Po",
+   *       "orderId": "PBt5GmSgJte9agAfDCj28j_7",
+   *       "fillId": "YQRN_XXJysf_toi73wZTTnQW",
+   *       "fillStatus": "EXECUTED",
+   *       "amount": "0.0030000000000000",
+   *       "price": "0.0030000000000000",
+   *       "error": "",
+   *       "blockOrderId": "XLoRm8Df_0Wa-A57",
    *       "baseSymbol": "BTC",
    *       "counterSymbol": "LTC",
-   *       "side": "ASK",
+   *       "side": "BID",
    *       "dates": {
-   *         "created": "2019-04-12T18:22:42.519Z",
-   *         "placed": "2019-04-12T18:22:42.534Z",
-   *         "executing": "2019-04-12T18:22:44.534Z",
-   *         "completed": "2019-04-12T18:25:44.121Z",
+   *         "created": "2019-04-19T18:21:15.751Z",
+   *         "filled": "2019-04-19T18:21:15.820Z",
+   *         "executed": "2019-04-19T18:21:16.824Z",
    *         "rejected": "",
    *         "cancelled": ""
    *       }
    *     }
-   *   ],
-   *   "fills": []
+   *   ]
    * }
    * ```
    *
@@ -924,45 +921,47 @@ service OrderService {
    * {
    *   "orders": [
    *     {
-   *       "orderId": "Ky13eTmuhZY-NIbqIng_in3D",
-   *       "orderStatus": "PLACED",
-   *       "amount": "0.0001000000000000",
-   *       "price": "0.0001000000000000",
-   *       "orderError": "",
-   *       "blockOrderId": "XLDXVDZiXxdifizQ",
+   *       "orderId": "GZnWxbVT6hK_2KM-r_hbSXp0",
+   *       "orderStatus": "COMPLETED",
+   *       "amount": "0.0040000000000000",
+   *       "price": "0.0040000000000000",
+   *       "error": "",
+   *       "blockOrderId": "XLoVOEJdJgO8JWAB",
    *       "baseSymbol": "BTC",
    *       "counterSymbol": "LTC",
    *       "side": "ASK",
    *       "dates": {
-   *         "dateCreated": "2019-04-12T18:22:13.111Z",
-   *         "datePlaced": "2019-04-12T18:22:13.121Z",
-   *         "dateExecuting": "",
-   *         "dateCompleted": "",
-   *         "dateRejected": "",
-   *         "dateCancelled": ""
-   *       }
-   *     },
-   *     {
-   *       "orderId": "U6WQ8Al2lDXqHthXx7UORN0c",
-   *       "orderStatus": "PLACED",
-   *       "amount": "0.0001000000000000",
-   *       "price": "0.0001000000000000",
-   *       "orderError": "",
-   *       "blockOrderId": "XLDXclazEcJjK8Po",
-   *       "baseSymbol": "BTC",
-   *       "counterSymbol": "LTC",
-   *       "side": "ASK",
-   *       "dates": {
-   *         "dateCreated": "2019-04-12T18:22:42.519Z",
-   *         "datePlaced": "2019-04-12T18:22:42.534Z",
-   *         "dateExecuting": "",
-   *         "dateCompleted": "",
-   *         "dateRejected": "",
-   *         "dateCancelled": ""
-   *       }
+   *         "created": "2019-04-19T18:36:40.809Z",
+   *         "placed": "2019-04-19T18:36:40.816Z",
+   *         "executing": "2019-04-19T18:36:52.556Z",
+   *         "completed": "2019-04-19T18:36:53.357Z",
+   *         "rejected": "",
+   *         "cancelled": ""
+   *       },
+   *       "fillAmount": "0.0010000000000000"
    *     }
    *   ],
-   *   "fills": []
+   *   "fills": [
+   *     {
+   *       "orderId": "PBt5GmSgJte9agAfDCj28j_7",
+   *       "fillId": "YQRN_XXJysf_toi73wZTTnQW",
+   *       "fillStatus": "EXECUTED",
+   *       "amount": "0.0030000000000000",
+   *       "price": "0.0030000000000000",
+   *       "error": "",
+   *       "blockOrderId": "XLoRm8Df_0Wa-A57",
+   *       "baseSymbol": "BTC",
+   *       "counterSymbol": "LTC",
+   *       "side": "BID",
+   *       "dates": {
+   *         "created": "2019-04-19T18:21:15.751Z",
+   *         "filled": "2019-04-19T18:21:15.820Z",
+   *         "executed": "2019-04-19T18:21:16.824Z",
+   *         "rejected": "",
+   *         "cancelled": ""
+   *       }
+   *     }
+   *   ]
    * }
    * ```
    */

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -360,6 +360,9 @@ message Order {
     CANCELLED = 6;
   }
 
+  /**
+   * Date that the order has reached each status.
+   */
   message OrderStateDates {
     // The date the order has been created on the Relayer.
     string created = 1;
@@ -422,12 +425,15 @@ message Fill {
     CANCELLED = 5;
   }
 
+  /**
+   * Date that the fill has reached each status.
+   */
   message FillStateDates {
     // The date the fill has been created on the Relayer.
     string created = 1;
     // The date the fill has been accepted as the fill for the given order.
     string filled = 2;
-    // The date the swap has been executed on the Payment Channel Networks.
+    // The date the fill has encountered a failure.
     string executed = 3;
     // The date the preimage has been returned to the Relayer by the Maker.
     string rejected = 5;
@@ -589,6 +595,9 @@ message GetBlockOrdersRequest {
   string market = 1;
 }
 
+/**
+ * Gets all completed trades for a user.
+ */
 message GetTradeHistoryResponse {
   // A list of completed and execting orders
   repeated Order orders = 1;

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -360,25 +360,25 @@ message Order {
     CANCELLED = 6;
   }
 
-  message Date {
+  message OrderStateDates {
     // The date the order has been created on the Relayer.
-    string date_created = 1;
+    string created = 1;
     // The date the order has been placed and communicated to other marker participants.
-    string date_placed = 2;
+    string placed = 2;
     // The date the swap is being executed on the Payment Channel Networks
-    string date_executing = 3;
+    string executing = 3;
     // The date the swap preimage has been returned to the Relayer.
-    string date_completed = 4;
+    string completed = 4;
     // The date the order has encountered a failure.
-    string date_rejected = 5;
+    string rejected = 5;
     // The date the order has been cancelled by the user.
-    string date_cancelled = 6;
+    string cancelled = 6;
   }
 
   // Unique ID assigned by the Relayer for this order.
   string order_id = 1;
   // Status of the order on the Relayer.
-  OrderStatus status = 2;
+  OrderStatus order_status = 2;
   // Amount of the order expressed in a decimal string of common units for a currency (e.g. bitcoins for BTC).
   string amount = 3;
   // Price at which the order was placed, expressed as a decimal string ratio between the common units of the currencies (e.g. litecoins to bitcoins, not litoshis to satoshis). All orders on the SparkSwap Relayer have prices.
@@ -394,8 +394,10 @@ message Order {
   // The side of the market that the order is taking.
   string side = 10;
   // Dates that the order has reached each status
-  Date dates = 11;
-  // Amount of the order filled, expressed in a decimal string of common units for a currency (e.g. bitcoins for BTC). This can be any amount greater than zero and less than or equal to the amount in the order.
+  OrderStateDates dates = 11;
+  // Amount of the order filled, expressed in a decimal string of common units for a currency (e.g. bitcoins for BTC).
+  // This can be any amount greater than zero and less than or equal to the amount in the order. This will be an empty
+  // string if the order has not been filled.
   string fill_amount = 12;
 }
 
@@ -422,27 +424,27 @@ message Fill {
     CANCELLED = 5;
   }
 
-  message Date {
+  message FillStateDates {
     // The date the fill has been created on the Relayer.
-    string date_created = 1;
+    string created = 1;
     // The date the fill has been accepted as the fill for the given order.
-    string date_filled = 2;
+    string filled = 2;
     // The date the swap has been executed on the Payment Channel Networks.
-    string date_executed = 3;
+    string executed = 3;
     // The date the preimage has been returned to the Relayer by the Maker.
-    string date_completed = 4;
+    string completed = 4;
     // The date the fill has encountered a failure.
-    string date_rejected = 5;
+    string rejected = 5;
     // The date the fill has been cancelled.
-    string date_cancelled = 6;
+    string cancelled = 6;
   }
 
   // The Relayer-assigned unique ID of the order that this fill is for.
   string order_id = 1;
-  // The Relayer-assignded unique ID for this fill.
+  // The Relayer-assigned unique ID for this fill.
   string fill_id = 2;
   // Status of the fill on the Relayer.
-  FillStatus status = 3;
+  FillStatus fill_status = 3;
   // Amount of the order to fill, expressed in a decimal string of common units for a currency (e.g. bitcoins for BTC). This can be any amount greater than zero and less than or equal to the amount in the order.
   string amount = 4;
   // Price at which the order was placed, expressed as a decimal string ratio between the common units of the currencies (e.g. litecoins to bitcoins, not litoshis to satoshis). All orders on the SparkSwap Relayer have prices.
@@ -458,7 +460,7 @@ message Fill {
   // The side of the market that the order is taking.
   string side = 10;
   // Dates that the fill has reached each status
-  Date dates = 11;
+  FillStateDates dates = 11;
 }
 
 /**
@@ -876,7 +878,7 @@ service OrderService {
    *   "orders": [
    *     {
    *       "orderId": "Ky13eTmuhZY-NIbqIng_in3D",
-   *       "orderStatus": "PLACED",
+   *       "orderStatus": "EXECUTING",
    *       "amount": "0.0001000000000000",
    *       "price": "0.0001000000000000",
    *       "orderError": "",
@@ -885,18 +887,18 @@ service OrderService {
    *       "counterSymbol": "LTC",
    *       "side": "ASK",
    *       "dates": {
-   *         "dateCreated": "2019-04-12T18:22:13.111Z",
-   *         "datePlaced": "2019-04-12T18:22:13.121Z",
-   *         "dateExecuting": "",
-   *         "dateCompleted": "",
-   *         "dateRejected": "",
-   *         "dateCancelled": ""
+   *         "created": "2019-04-12T18:22:13.111Z",
+   *         "placed": "2019-04-12T18:22:13.121Z",
+   *         "executing": "2019-04-12T18:22:20.121Z",
+   *         "completed": "",
+   *         "rejected": "",
+   *         "cancelled": ""
    *       }
    *       "fillAmount": "0.0001000000000000",
    *     },
    *     {
    *       "orderId": "U6WQ8Al2lDXqHthXx7UORN0c",
-   *       "orderStatus": "PLACED",
+   *       "orderStatus": "COMPLETED",
    *       "amount": "0.0001000000000000",
    *       "price": "0.0001000000000000",
    *       "orderError": "",
@@ -905,12 +907,12 @@ service OrderService {
    *       "counterSymbol": "LTC",
    *       "side": "ASK",
    *       "dates": {
-   *         "dateCreated": "2019-04-12T18:22:42.519Z",
-   *         "datePlaced": "2019-04-12T18:22:42.534Z",
-   *         "dateExecuting": "",
-   *         "dateCompleted": "",
-   *         "dateRejected": "",
-   *         "dateCancelled": ""
+   *         "created": "2019-04-12T18:22:42.519Z",
+   *         "placed": "2019-04-12T18:22:42.534Z",
+   *         "executing": "2019-04-12T18:22:44.534Z",
+   *         "completed": "2019-04-12T18:25:44.121Z",
+   *         "rejected": "",
+   *         "cancelled": ""
    *       }
    *     }
    *   ],

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -360,16 +360,41 @@ message Order {
     CANCELLED = 6;
   }
 
+  message Date {
+    // The date the order has been created on the Relayer.
+    string date_created = 1;
+    // The date the order has been placed and communicated to other marker participants.
+    string date_placed = 2;
+    // The date the swap is being executed on the Payment Channel Networks
+    string date_executing = 3;
+    // The date the swap preimage has been returned to the Relayer.
+    string date_completed = 4;
+    // The date the order has encountered a failure.
+    string date_rejected = 5;
+    // The date the order has been cancelled by the user.
+    string date_cancelled = 6;
+  }
+
   // Unique ID assigned by the Relayer for this order.
   string order_id = 1;
   // Status of the order on the Relayer.
-  OrderStatus order_status = 2;
+  OrderStatus status = 2;
   // Amount of the order expressed in a decimal string of common units for a currency (e.g. bitcoins for BTC).
   string amount = 3;
   // Price at which the order was placed, expressed as a decimal string ratio between the common units of the currencies (e.g. litecoins to bitcoins, not litoshis to satoshis). All orders on the SparkSwap Relayer have prices.
   string price = 4;
   // Any error messages related to the status of a REJECTED or FAILED order
-  string order_error = 6;
+  string error = 6;
+  // The unique ID for the block order assigned by the Broker that this order belongs to.
+  string block_order_id = 7;
+  // The base currency for the order
+  string base_symbol = 8;
+  // The counter currency for the order
+  string counter_symbol = 9;
+  // The side of the market that the order is taking.
+  string side = 10;
+  // Dates that the order has reached each status
+  Date dates = 11;
 }
 
 /**
@@ -394,18 +419,44 @@ message Fill {
     // The fill has been cancelled.
     CANCELLED = 5;
   }
+
+  message Date {
+    // The date the fill has been created on the Relayer.
+    string date_created = 1;
+    // The date the fill has been accepted as the fill for the given order.
+    string date_filled = 2;
+    // The date the swap has been executed on the Payment Channel Networks.
+    string date_executed = 3;
+    // The date the preimage has been returned to the Relayer by the Maker.
+    string date_completed = 4;
+    // The date the fill has encountered a failure.
+    string date_rejected = 5;
+    // The date the fill has been cancelled.
+    string date_cancelled = 6;
+  }
+
   // The Relayer-assigned unique ID of the order that this fill is for.
   string order_id = 1;
   // The Relayer-assignded unique ID for this fill.
   string fill_id = 2;
   // Status of the fill on the Relayer.
-  FillStatus fill_status = 3;
+  FillStatus status = 3;
   // Amount of the order to fill, expressed in a decimal string of common units for a currency (e.g. bitcoins for BTC). This can be any amount greater than zero and less than or equal to the amount in the order.
   string amount = 4;
   // Price at which the order was placed, expressed as a decimal string ratio between the common units of the currencies (e.g. litecoins to bitcoins, not litoshis to satoshis). All orders on the SparkSwap Relayer have prices.
   string price = 5;
   // Any error messages related to the status of a REJECTED or FAILED fill
-  string fill_error = 6;
+  string error = 6;
+  // The unique ID for the block order assigned by the Broker that this fill belongs to.
+  string block_order_id = 7;
+  // The base currency for the fill
+  string base_symbol = 8;
+  // The counter currency for the fill
+  string counter_symbol = 9;
+  // The side of the market that the order is taking.
+  string side = 10;
+  // Dates that the fill has reached each status
+  Date dates = 11;
 }
 
 /**
@@ -538,45 +589,11 @@ message GetBlockOrdersRequest {
   string market = 1;
 }
 
-message TradeOrder {
-  string order_id = 1;
-  string block_order_id = 2;
-  string base_symbol = 3;
-  string counter_symbol = 4;
-  string side = 5;
-  string base_amount = 6;
-  string counter_amount = 7;
-  string state = 8;
-  string date_created = 9;
-  string date_placed = 10;
-  string date_rejected = 11;
-  string date_cancelled = 12;
-  string date_executing = 13;
-  string date_completed = 14;
-}
-
-message TradeFill {
-  string fill_id = 1;
-  string order_id = 2;
-  string block_order_id = 3;
-  string base_symbol = 4;
-  string counter_symbol = 5;
-  string side = 6;
-  string base_amount = 7;
-  string counter_amount = 8;
-  string state = 9;
-  string date_created = 10;
-  string date_filled = 11;
-  string date_executed = 12;
-  string date_cancelled = 13;
-  string date_rejected = 14;
-}
-
 message GetTradeHistoryResponse {
   // A list of completed and execting orders
-  repeated TradeOrder orders = 1;
+  repeated Order orders = 1;
   // A list of accepted and executed fills
-  repeated TradeFill fills = 2;
+  repeated Fill fills = 2;
 }
 
 /**
@@ -835,7 +852,115 @@ service OrderService {
       get: "/v1/orders"
     };
   }
-
+  /**
+   * GetTradeHistory returns all completed and executing orders and all accepted and executed fills.
+   *
+   * ```javascript
+   * const deadline = new Date().setSeconds(new Date().getSeconds() + 5)
+   * const blockOrder = orderService.getTradeHistory({}, { deadline }, (err, res) => {
+   *   if (err) return console.error(err)
+   *   console.log(res)
+   * })
+   * ```
+   *
+   * ```shell
+   * > sparkswap order trade-history
+   * ```
+   *
+   * > The above command will retrieve the trades on the Broker and will print:
+   *
+   * ```javascript
+   * {
+   *   "orders": [
+   *     {
+   *       "orderId": "Ky13eTmuhZY-NIbqIng_in3D",
+   *       "orderStatus": "PLACED",
+   *       "amount": "0.0001000000000000",
+   *       "price": "0.0001000000000000",
+   *       "orderError": "",
+   *       "blockOrderId": "XLDXVDZiXxdifizQ",
+   *       "baseSymbol": "BTC",
+   *       "counterSymbol": "LTC",
+   *       "side": "ASK",
+   *       "dates": {
+   *         "dateCreated": "2019-04-12T18:22:13.111Z",
+   *         "datePlaced": "2019-04-12T18:22:13.121Z",
+   *         "dateExecuting": "",
+   *         "dateCompleted": "",
+   *         "dateRejected": "",
+   *         "dateCancelled": ""
+   *       }
+   *     },
+   *     {
+   *       "orderId": "U6WQ8Al2lDXqHthXx7UORN0c",
+   *       "orderStatus": "PLACED",
+   *       "amount": "0.0001000000000000",
+   *       "price": "0.0001000000000000",
+   *       "orderError": "",
+   *       "blockOrderId": "XLDXclazEcJjK8Po",
+   *       "baseSymbol": "BTC",
+   *       "counterSymbol": "LTC",
+   *       "side": "ASK",
+   *       "dates": {
+   *         "dateCreated": "2019-04-12T18:22:42.519Z",
+   *         "datePlaced": "2019-04-12T18:22:42.534Z",
+   *         "dateExecuting": "",
+   *         "dateCompleted": "",
+   *         "dateRejected": "",
+   *         "dateCancelled": ""
+   *       }
+   *     }
+   *   ],
+   *   "fills": []
+   * }
+   * ```
+   *
+   * ```shell
+   * {
+   *   "orders": [
+   *     {
+   *       "orderId": "Ky13eTmuhZY-NIbqIng_in3D",
+   *       "orderStatus": "PLACED",
+   *       "amount": "0.0001000000000000",
+   *       "price": "0.0001000000000000",
+   *       "orderError": "",
+   *       "blockOrderId": "XLDXVDZiXxdifizQ",
+   *       "baseSymbol": "BTC",
+   *       "counterSymbol": "LTC",
+   *       "side": "ASK",
+   *       "dates": {
+   *         "dateCreated": "2019-04-12T18:22:13.111Z",
+   *         "datePlaced": "2019-04-12T18:22:13.121Z",
+   *         "dateExecuting": "",
+   *         "dateCompleted": "",
+   *         "dateRejected": "",
+   *         "dateCancelled": ""
+   *       }
+   *     },
+   *     {
+   *       "orderId": "U6WQ8Al2lDXqHthXx7UORN0c",
+   *       "orderStatus": "PLACED",
+   *       "amount": "0.0001000000000000",
+   *       "price": "0.0001000000000000",
+   *       "orderError": "",
+   *       "blockOrderId": "XLDXclazEcJjK8Po",
+   *       "baseSymbol": "BTC",
+   *       "counterSymbol": "LTC",
+   *       "side": "ASK",
+   *       "dates": {
+   *         "dateCreated": "2019-04-12T18:22:42.519Z",
+   *         "datePlaced": "2019-04-12T18:22:42.534Z",
+   *         "dateExecuting": "",
+   *         "dateCompleted": "",
+   *         "dateRejected": "",
+   *         "dateCancelled": ""
+   *       }
+   *     }
+   *   ],
+   *   "fills": []
+   * }
+   * ```
+   */
   rpc GetTradeHistory (google.protobuf.Empty) returns (GetTradeHistoryResponse);
 }
 

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -538,6 +538,47 @@ message GetBlockOrdersRequest {
   string market = 1;
 }
 
+message TradeOrder {
+  string order_id = 1;
+  string block_order_id = 2;
+  string base_symbol = 3;
+  string counter_symbol = 4;
+  string side = 5;
+  string base_amount = 6;
+  string counter_amount = 7;
+  string state = 8;
+  string date_created = 9;
+  string date_placed = 10;
+  string date_rejected = 11;
+  string date_cancelled = 12;
+  string date_executing = 13;
+  string date_completed = 14;
+}
+
+message TradeFill {
+  string fill_id = 1;
+  string order_id = 2;
+  string block_order_id = 3;
+  string base_symbol = 4;
+  string counter_symbol = 5;
+  string side = 6;
+  string base_amount = 7;
+  string counter_amount = 8;
+  string state = 9;
+  string date_created = 10;
+  string date_filled = 11;
+  string date_executed = 12;
+  string date_cancelled = 13;
+  string date_rejected = 14;
+}
+
+message GetTradeHistoryResponse {
+  // A list of completed and execting orders
+  repeated TradeOrder orders = 1;
+  // A list of accepted and executed fills
+  repeated TradeFill fills = 2;
+}
+
 /**
  * The OrderService manages all trading activity on the Broker.
  * It is the primary way that users interact with the Broker on a day-to-day basis.
@@ -794,6 +835,8 @@ service OrderService {
       get: "/v1/orders"
     };
   }
+
+  rpc GetTradeHistory (google.protobuf.Empty) returns (GetTradeHistoryResponse);
 }
 
 /**

--- a/broker-daemon/state-machines/fill-state-machine.js
+++ b/broker-daemon/state-machines/fill-state-machine.js
@@ -43,6 +43,8 @@ const FillStateMachine = StateMachine.factory({
     new StateMachineLogging({
       skipTransitions: [ 'goto' ]
     }),
+    // StateMachineDates plugin needs to be instantiated before StateMachinePersistence plugin
+    // because the first date onEnterState needs to be set before we persist
     new StateMachineDates({
       skipTransitions: [ 'goto' ]
     }),

--- a/broker-daemon/state-machines/fill-state-machine.js
+++ b/broker-daemon/state-machines/fill-state-machine.js
@@ -425,6 +425,30 @@ const FillStateMachine = StateMachine.factory({
 })
 
 /**
+ * serialize an fill for transmission via grpc
+ * @param {Object} fillObject - Plain object representation of the fill, state, dates
+ * @returns {Object} Object to be serialized into a GRPC message
+ */
+FillStateMachine.serialize = function (fillObject) {
+  const {
+    fill,
+    state,
+    error,
+    dates
+  } = fillObject
+
+  const serializedFill = fill.serialize()
+
+  Object.assign(serializedFill, {
+    fillStatus: state.toUpperCase(),
+    error: error ? error.toString() : undefined,
+    dates
+  })
+
+  return serializedFill
+}
+
+/**
  * Instantiate and create a fill
  * This method is a pure pass through to the state machine, so any parameter checking should happen in
  * `data` and `onBeforeCreate`, respectively.

--- a/broker-daemon/state-machines/fill-state-machine.js
+++ b/broker-daemon/state-machines/fill-state-machine.js
@@ -439,13 +439,12 @@ FillStateMachine.serialize = function (fillObject) {
 
   const serializedFill = fill.serialize()
 
-  Object.assign(serializedFill, {
+  return {
     fillStatus: state.toUpperCase(),
     error: error ? error.toString() : undefined,
-    dates
-  })
-
-  return serializedFill
+    dates,
+    ...serializedFill
+  }
 }
 
 /**

--- a/broker-daemon/state-machines/fill-state-machine.js
+++ b/broker-daemon/state-machines/fill-state-machine.js
@@ -156,7 +156,7 @@ const FillStateMachine = StateMachine.factory({
    * @returns {Object} Data to attach to the state machine
    */
   data: function ({ store, logger, relayer, engines }) {
-    return { store, logger, relayer, engines, fill: {}, dates: {} }
+    return { store, logger, relayer, engines, fill: {} }
   },
   methods: {
     /**

--- a/broker-daemon/state-machines/fill-state-machine.js
+++ b/broker-daemon/state-machines/fill-state-machine.js
@@ -9,7 +9,8 @@ const {
   StateMachinePersistence,
   StateMachineRejection,
   StateMachineLogging,
-  StateMachineEvents
+  StateMachineEvents,
+  StateMachineDates
 } = require('./plugins')
 
 /**
@@ -40,6 +41,9 @@ const FillStateMachine = StateMachine.factory({
     new StateMachineRejection(),
     new StateMachineEvents(),
     new StateMachineLogging({
+      skipTransitions: [ 'goto' ]
+    }),
+    new StateMachineDates({
       skipTransitions: [ 'goto' ]
     }),
     new StateMachinePersistence({
@@ -94,6 +98,18 @@ const FillStateMachine = StateMachine.factory({
           if (this.error) {
             return this.error.message
           }
+        },
+        /**
+         * @type {StateMachinePersistence~FieldAccessor}
+         * @param {Object}   dates - Stored plain object of dates for the states that have been entered on the State machine
+         * @returns {Object} dates - Plain object of dates for the states that have been entered on the State machine
+         */
+        dates: function (dates) {
+          if (dates) {
+            this.dates = dates
+          }
+
+          return this.dates
         }
       }
     })
@@ -140,7 +156,7 @@ const FillStateMachine = StateMachine.factory({
    * @returns {Object} Data to attach to the state machine
    */
   data: function ({ store, logger, relayer, engines }) {
-    return { store, logger, relayer, engines, fill: {} }
+    return { store, logger, relayer, engines, fill: {}, dates: {} }
   },
   methods: {
     /**

--- a/broker-daemon/state-machines/fill-state-machine.spec.js
+++ b/broker-daemon/state-machines/fill-state-machine.spec.js
@@ -909,4 +909,36 @@ describe('FillStateMachine', () => {
       expect(fsm.fill).to.be.equal(myObject)
     })
   })
+
+  describe('::serialize', () => {
+    let fillObject
+
+    beforeEach(() => {
+      fillObject = {
+        fill: {
+          serialize: sinon.stub().returns({})
+        },
+        state: 'EXECUTED',
+        dates: {
+          'created': '2019-04-19T18:21:15.751Z',
+          'filled': '2019-04-19T18:21:15.820Z',
+          'executed': '2019-04-19T18:21:16.824Z'
+        }
+      }
+    })
+
+    it('serializes the fill', async () => {
+      await FillStateMachine.serialize(fillObject)
+
+      expect(fillObject.fill.serialize).to.have.been.called()
+    })
+
+    it('returns the serialized fill with state and dates', async () => {
+      const serializedFill = await FillStateMachine.serialize(fillObject)
+
+      expect(serializedFill).to.have.property('fillStatus', fillObject.state.toUpperCase())
+      expect(serializedFill).to.have.property('dates', fillObject.dates)
+      expect(serializedFill).to.have.property('error', undefined)
+    })
+  })
 })

--- a/broker-daemon/state-machines/fill-state-machine.spec.js
+++ b/broker-daemon/state-machines/fill-state-machine.spec.js
@@ -130,7 +130,7 @@ describe('FillStateMachine', () => {
     it('saves state machine data in the database', async () => {
       await fsm.persist(key)
 
-      expect(store.put).to.have.been.calledWith(sinon.match.any, sinon.match('{"state":"none","fill":{"my":"fill"},"history":[]}'))
+      expect(store.put).to.have.been.calledWith(sinon.match.any, sinon.match('{"state":"none","fill":{"my":"fill"},"history":[],"dates":{}}'))
     })
 
     it('saves the fill to the database', async () => {

--- a/broker-daemon/state-machines/fill-state-machine.spec.js
+++ b/broker-daemon/state-machines/fill-state-machine.spec.js
@@ -130,7 +130,7 @@ describe('FillStateMachine', () => {
     it('saves state machine data in the database', async () => {
       await fsm.persist(key)
 
-      expect(store.put).to.have.been.calledWith(sinon.match.any, sinon.match('{"state":"none","fill":{"my":"fill"},"history":[],"dates":{}}'))
+      expect(store.put).to.have.been.calledWith(sinon.match.any, sinon.match('{"state":"none","fill":{"my":"fill"},"history":[]}'))
     })
 
     it('saves the fill to the database', async () => {

--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -164,7 +164,7 @@ const OrderStateMachine = StateMachine.factory({
    * @returns {Object}                                  Data to attach to the state machine
    */
   data: function ({ store, logger, relayer, engines }) {
-    return { store, logger, relayer, engines, order: {}, dates: {} }
+    return { store, logger, relayer, engines, order: {} }
   },
   methods: {
     /**

--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -467,13 +467,12 @@ OrderStateMachine.serialize = function (orderObject) {
 
   const serializedOrder = order.serialize()
 
-  Object.assign(serializedOrder, {
+  return {
     orderStatus: state.toUpperCase(),
     error: error ? error.toString() : undefined,
-    dates
-  })
-
-  return serializedOrder
+    dates,
+    ...serializedOrder
+  }
 }
 
 /**

--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -188,7 +188,7 @@ const OrderStateMachine = StateMachine.factory({
 
     onBeforeCreate: async function (lifecycle, blockOrderId, { side, baseSymbol, counterSymbol, baseAmount, counterAmount }) {
       this.order = new Order(blockOrderId, { baseSymbol, counterSymbol, side, baseAmount, counterAmount })
-      // TODO: figure out a way to cache the maker address instead of making a request
+
       const baseEngine = this.engines.get(this.order.baseSymbol)
       if (!baseEngine) {
         throw new Error(`No engine available for ${this.order.baseSymbol}`)
@@ -198,6 +198,8 @@ const OrderStateMachine = StateMachine.factory({
       if (!counterEngine) {
         throw new Error(`No engine available for ${this.order.counterSymbol}`)
       }
+
+      // TODO: figure out a way to cache the maker address instead of making a request
       this.order.makerBaseAddress = await baseEngine.getPaymentChannelNetworkAddress()
       this.order.makerCounterAddress = await counterEngine.getPaymentChannelNetworkAddress()
 

--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -453,6 +453,30 @@ const OrderStateMachine = StateMachine.factory({
 })
 
 /**
+ * serialize an order, its state and dates for transmission via grpc
+ * @param {Object} orderObject - Plain object representation of the order, state, dates
+ * @returns {Object} Object (order) to be serialized into a GRPC message
+ */
+OrderStateMachine.serialize = function (orderObject) {
+  const {
+    order,
+    state,
+    error,
+    dates
+  } = orderObject
+
+  const serializedOrder = order.serialize()
+
+  Object.assign(serializedOrder, {
+    orderStatus: state.toUpperCase(),
+    error: error ? error.toString() : undefined,
+    dates
+  })
+
+  return serializedOrder
+}
+
+/**
  * Instantiate and create an order
  * This method is a pure pass through to the state machine, so any parameter checking should happen in
  * `data` and `onBeforeCreate`, respectively.

--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -84,6 +84,19 @@ const OrderStateMachine = StateMachine.factory({
         },
         /**
          * @type {StateMachinePersistence~FieldAccessor}
+         * @param {Object}   orderObject - Stored plain object description of the Order associated with the State machine
+         * @param {string}   key         - Unique key for the order/state machine
+         * @returns {Object}             Plain object description of the Order associated with the State machine
+         */
+        dates: function (dates) {
+          if (dates) {
+            this.dates = dates
+          }
+
+          return this.dates
+        },
+        /**
+         * @type {StateMachinePersistence~FieldAccessor}
          * @param {string}   errorMessage - Stored error message for a state machine in an errored state
          * @returns {string}              Error message for a state machine in an errored state
          */
@@ -169,6 +182,7 @@ const OrderStateMachine = StateMachine.factory({
      */
 
     onBeforeCreate: async function (lifecycle, blockOrderId, { side, baseSymbol, counterSymbol, baseAmount, counterAmount }) {
+      this.dates = {}
       this.order = new Order(blockOrderId, { baseSymbol, counterSymbol, side, baseAmount, counterAmount })
       // TODO: figure out a way to cache the maker address instead of making a request
       const baseEngine = this.engines.get(this.order.baseSymbol)

--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -43,6 +43,8 @@ const OrderStateMachine = StateMachine.factory({
     new StateMachineLogging({
       skipTransitions: [ 'goto' ]
     }),
+    // StateMachineDates plugin needs to be instantiated before StateMachinePersistence plugin
+    // because the first date onEnterState needs to be set before we persist
     new StateMachineDates({
       skipTransitions: [ 'goto' ]
     }),

--- a/broker-daemon/state-machines/order-state-machine.js
+++ b/broker-daemon/state-machines/order-state-machine.js
@@ -11,7 +11,7 @@ const {
   StateMachineRejection,
   StateMachineLogging,
   StateMachineEvents,
-  StateMachineDateHistory
+  StateMachineDates
 } = require('./plugins')
 
 /**
@@ -43,7 +43,7 @@ const OrderStateMachine = StateMachine.factory({
     new StateMachineLogging({
       skipTransitions: [ 'goto' ]
     }),
-    new StateMachineDateHistory({
+    new StateMachineDates({
       skipTransitions: [ 'goto' ]
     }),
     new StateMachineEvents(),

--- a/broker-daemon/state-machines/order-state-machine.spec.js
+++ b/broker-daemon/state-machines/order-state-machine.spec.js
@@ -1014,4 +1014,37 @@ describe('OrderStateMachine', () => {
       expect(osm.order).to.be.equal(myObject)
     })
   })
+
+  describe('::serialize', () => {
+    let orderObject
+
+    beforeEach(() => {
+      orderObject = {
+        order: {
+          serialize: sinon.stub().returns({})
+        },
+        state: 'COMPLETED',
+        dates: {
+          'created': '2019-04-19T22:35:12.049Z',
+          'placed': '2019-04-19T22:35:12.054Z',
+          'executing': '2019-04-19T22:35:44.941Z',
+          'completed': '2019-04-19T22:35:45.780Z'
+        }
+      }
+    })
+
+    it('serializes the order', async () => {
+      await OrderStateMachine.serialize(orderObject)
+
+      expect(orderObject.order.serialize).to.have.been.called()
+    })
+
+    it('returns the serialized order with state and dates', async () => {
+      const serializedOrder = await OrderStateMachine.serialize(orderObject)
+
+      expect(serializedOrder).to.have.property('orderStatus', orderObject.state.toUpperCase())
+      expect(serializedOrder).to.have.property('dates', orderObject.dates)
+      expect(serializedOrder).to.have.property('error', undefined)
+    })
+  })
 })

--- a/broker-daemon/state-machines/order-state-machine.spec.js
+++ b/broker-daemon/state-machines/order-state-machine.spec.js
@@ -170,7 +170,7 @@ describe('OrderStateMachine', () => {
     it('saves state machine data in the database', async () => {
       await osm.persist(key)
 
-      expect(store.put).to.have.been.calledWith(sinon.match.any, sinon.match('{"state":"none","order":{"my":"order"},"history":[]}'))
+      expect(store.put).to.have.been.calledWith(sinon.match.any, sinon.match('{"state":"none","order":{"my":"order"},"history":[],"dates":{}}'))
     })
 
     it('saves the order to the database', async () => {

--- a/broker-daemon/state-machines/order-state-machine.spec.js
+++ b/broker-daemon/state-machines/order-state-machine.spec.js
@@ -170,7 +170,7 @@ describe('OrderStateMachine', () => {
     it('saves state machine data in the database', async () => {
       await osm.persist(key)
 
-      expect(store.put).to.have.been.calledWith(sinon.match.any, sinon.match('{"state":"none","order":{"my":"order"},"history":[],"dates":{}}'))
+      expect(store.put).to.have.been.calledWith(sinon.match.any, sinon.match('{"state":"none","order":{"my":"order"},"history":[]}'))
     })
 
     it('saves the order to the database', async () => {

--- a/broker-daemon/state-machines/plugins/index.js
+++ b/broker-daemon/state-machines/plugins/index.js
@@ -2,10 +2,12 @@ const StateMachinePersistence = require('./persistence')
 const StateMachineRejection = require('./rejection')
 const StateMachineLogging = require('./logging')
 const StateMachineEvents = require('./state-machine-events')
+const StateMachineDateHistory = require('./state-history')
 
 module.exports = {
   StateMachinePersistence,
   StateMachineRejection,
   StateMachineLogging,
-  StateMachineEvents
+  StateMachineEvents,
+  StateMachineDateHistory
 }

--- a/broker-daemon/state-machines/plugins/index.js
+++ b/broker-daemon/state-machines/plugins/index.js
@@ -2,12 +2,12 @@ const StateMachinePersistence = require('./persistence')
 const StateMachineRejection = require('./rejection')
 const StateMachineLogging = require('./logging')
 const StateMachineEvents = require('./state-machine-events')
-const StateMachineDateHistory = require('./state-history')
+const StateMachineDates = require('./state-machine-dates')
 
 module.exports = {
   StateMachinePersistence,
   StateMachineRejection,
   StateMachineLogging,
   StateMachineEvents,
-  StateMachineDateHistory
+  StateMachineDates
 }

--- a/broker-daemon/state-machines/plugins/persistence.js
+++ b/broker-daemon/state-machines/plugins/persistence.js
@@ -163,8 +163,6 @@ class StateMachinePersistence extends StateMachinePlugin {
           data[name] = getter.call(this)
         })
 
-        data['dates'][`date${this.state.charAt(0).toUpperCase()}${this.state.slice(1)}`] = new Date()
-
         plugin.hook(this, 'persist', [key, data])
 
         // somehow spit an error if this fails?

--- a/broker-daemon/state-machines/plugins/persistence.js
+++ b/broker-daemon/state-machines/plugins/persistence.js
@@ -163,6 +163,8 @@ class StateMachinePersistence extends StateMachinePlugin {
           data[name] = getter.call(this)
         })
 
+        data['dates'][`date${this.state.charAt(0).toUpperCase()}${this.state.slice(1)}`] = new Date()
+
         plugin.hook(this, 'persist', [key, data])
 
         // somehow spit an error if this fails?

--- a/broker-daemon/state-machines/plugins/state-machine-dates.js
+++ b/broker-daemon/state-machines/plugins/state-machine-dates.js
@@ -7,7 +7,6 @@ class StateMachineDates extends StateMachinePlugin {
   /**
    * Set up configuration for the dates plugin, controlling which properties on the host object to use
    * @param {Object} options
-   * @param {string} [options.loggerName='logger'] - Property of the host state machine that holds the logger
    * @param {Array<string>} [options.skipTransitions=[]] - Array of transition names to be ignored
    */
   constructor ({ skipTransitions = [] } = {}) {
@@ -34,4 +33,4 @@ class StateMachineDates extends StateMachinePlugin {
   }
 }
 
-module.exports = StateMachineDateHistory
+module.exports = StateMachineDates

--- a/broker-daemon/state-machines/plugins/state-machine-dates.js
+++ b/broker-daemon/state-machines/plugins/state-machine-dates.js
@@ -1,0 +1,37 @@
+const StateMachinePlugin = require('./abstract')
+
+/**
+ * @class Store dates when states changed
+ */
+class StateMachineDates extends StateMachinePlugin {
+  /**
+   * Set up configuration for the dates plugin, controlling which properties on the host object to use
+   * @param {Object} options
+   * @param {string} [options.loggerName='logger'] - Property of the host state machine that holds the logger
+   * @param {Array<string>} [options.skipTransitions=[]] - Array of transition names to be ignored
+   */
+  constructor ({ skipTransitions = [] } = {}) {
+    super()
+    this.skipTransitions = skipTransitions
+  }
+
+  /**
+   * Observers object to add additional lifecycle observers
+   * Adds our lifecycle observers to add a date to StateMachine when a new state is entered
+   * @returns {Object} Key value of observers
+   */
+  get observers () {
+    const plugin = this
+
+    return {
+      onEnterState: function (lifecycle) {
+        if (!plugin.skipTransitions.includes(lifecycle.transition)) {
+          // set the date the state was entered, for example, 'dateCreated'
+          this.dates[`date${this.state.charAt(0).toUpperCase()}${this.state.slice(1)}`] = new Date()
+        }
+      }
+    }
+  }
+}
+
+module.exports = StateMachineDateHistory

--- a/broker-daemon/state-machines/plugins/state-machine-dates.js
+++ b/broker-daemon/state-machines/plugins/state-machine-dates.js
@@ -25,8 +25,11 @@ class StateMachineDates extends StateMachinePlugin {
     return {
       onEnterState: function (lifecycle) {
         if (!plugin.skipTransitions.includes(lifecycle.transition)) {
-          // set the date the state was entered, for example, 'dateCreated'
-          this.dates[`date${this.state.charAt(0).toUpperCase()}${this.state.slice(1)}`] = new Date()
+          if (this.dates === undefined) {
+            this.dates = {}
+          }
+          // set the date the state was entered, for example, 'created'
+          this.dates[this.state] = new Date()
         }
       }
     }

--- a/broker-daemon/state-machines/plugins/state-machine-dates.spec.js
+++ b/broker-daemon/state-machines/plugins/state-machine-dates.spec.js
@@ -45,7 +45,7 @@ describe('StateMachineLogging', () => {
       stateMachine.create()
 
       expect(stateMachine.dates).to.eql({
-        dateCreated: now
+        created: now
       })
     })
 
@@ -59,8 +59,8 @@ describe('StateMachineLogging', () => {
       stateMachine.place()
 
       expect(stateMachine.dates).to.eql({
-        dateCreated: now,
-        datePlaced: now
+        created: now,
+        placed: now
       })
     })
   })

--- a/broker-daemon/state-machines/plugins/state-machine-dates.spec.js
+++ b/broker-daemon/state-machines/plugins/state-machine-dates.spec.js
@@ -1,0 +1,67 @@
+const { expect, timekeeper } = require('test/test-helper')
+
+const StateMachineDates = require('./state-machine-dates')
+const StateMachine = require('../state-machine')
+
+describe('StateMachineLogging', () => {
+  describe('observers', () => {
+    let stateMachineDates
+    let Machine
+    let stateMachine
+    let skipTransitions
+    let now
+
+    beforeEach(() => {
+      skipTransitions = ['goto']
+      now = new Date()
+      timekeeper.freeze(now)
+      stateMachineDates = new StateMachineDates({ skipTransitions })
+      Machine = StateMachine.factory({
+        plugins: [
+          stateMachineDates
+        ],
+        transitions: [
+          { name: 'create', from: 'none', to: 'created' },
+          { name: 'place', from: 'created', to: 'placed' },
+          { name: 'goto', from: '*', to: (s) => s }
+        ],
+        data: function () {
+          return { dates: {} }
+        }
+      })
+
+      stateMachine = new Machine({})
+    })
+
+    afterEach(() => {
+      timekeeper.reset()
+    })
+
+    it('should have property onEnterState', () => {
+      expect(stateMachineDates.observers).to.have.property('onEnterState')
+    })
+
+    it('should log onEnterState if transition should not be skipped', () => {
+      stateMachine.create()
+
+      expect(stateMachine.dates).to.eql({
+        dateCreated: now
+      })
+    })
+
+    it('should not log the onEnterState if the transition should be skipped', () => {
+      stateMachine.goto('create')
+      expect(stateMachine.dates).to.eql({})
+    })
+
+    it('should add multiple dates if it goes through multiple transitions', () => {
+      stateMachine.create()
+      stateMachine.place()
+
+      expect(stateMachine.dates).to.eql({
+        dateCreated: now,
+        datePlaced: now
+      })
+    })
+  })
+})

--- a/broker-daemon/state-machines/plugins/state-machine-dates.spec.js
+++ b/broker-daemon/state-machines/plugins/state-machine-dates.spec.js
@@ -41,7 +41,7 @@ describe('StateMachineLogging', () => {
       expect(stateMachineDates.observers).to.have.property('onEnterState')
     })
 
-    it('should log onEnterState if transition should not be skipped', () => {
+    it('should add state date if transition should not be skipped', () => {
       stateMachine.create()
 
       expect(stateMachine.dates).to.eql({
@@ -49,12 +49,12 @@ describe('StateMachineLogging', () => {
       })
     })
 
-    it('should not log the onEnterState if the transition should be skipped', () => {
+    it('should not add state date if transition should be skipped', () => {
       stateMachine.goto('create')
       expect(stateMachine.dates).to.eql({})
     })
 
-    it('should add multiple dates if it goes through multiple transitions', () => {
+    it('should add multiple state dates if transitions should not be skipped', () => {
       stateMachine.create()
       stateMachine.place()
 

--- a/broker-daemon/state-machines/plugins/state-machine-dates.spec.js
+++ b/broker-daemon/state-machines/plugins/state-machine-dates.spec.js
@@ -3,7 +3,7 @@ const { expect, timekeeper } = require('test/test-helper')
 const StateMachineDates = require('./state-machine-dates')
 const StateMachine = require('../state-machine')
 
-describe('StateMachineLogging', () => {
+describe('StateMachineDates', () => {
   describe('observers', () => {
     let stateMachineDates
     let Machine


### PR DESCRIPTION
## Description
We want a command to get us history of a users trades. In order to do this, we need to get all orders and fills from the respective stores and filter based on their statuses (completed, executing for orders and accepted, executed for fills).

We also wanted to add dates that each status for an order/fill has been reached, so I added a state machine plugin to document this information when persisting the record.

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
