### PR TITLE
Feature - Lexicographic ordering for base64 encoded order IDs

### DIFF
--- a/broker-daemon/utils/base64-lex.js
+++ b/broker-daemon/utils/base64-lex.js
@@ -1,0 +1,95 @@
+/**
+ * Table that defines the conversion from a Base64 encoded character to a
+ * character that is URL safe and preserves lexicographic ordering as defined
+ * by the ASCII character code.
+ *
+ * @type {string}
+ * @constant
+ */
+const ENCODE_TABLE = {
+  'A': '-',
+  'B': '0',
+  'C': '1',
+  'D': '2',
+  'E': '3',
+  'F': '4',
+  'G': '5',
+  'H': '6',
+  'I': '7',
+  'J': '8',
+  'K': '9',
+  'L': 'A',
+  'M': 'B',
+  'N': 'C',
+  'O': 'D',
+  'P': 'E',
+  'Q': 'F',
+  'R': 'G',
+  'S': 'H',
+  'T': 'I',
+  'U': 'J',
+  'V': 'K',
+  'W': 'L',
+  'X': 'M',
+  'Y': 'N',
+  'Z': 'O',
+  'a': 'P',
+  'b': 'Q',
+  'c': 'R',
+  'd': 'S',
+  'e': 'T',
+  'f': 'U',
+  'g': 'V',
+  'h': 'W',
+  'i': 'X',
+  'j': 'Y',
+  'k': 'Z',
+  'l': '_',
+  'm': 'a',
+  'n': 'b',
+  'o': 'c',
+  'p': 'd',
+  'q': 'e',
+  'r': 'f',
+  's': 'g',
+  't': 'h',
+  'u': 'i',
+  'v': 'j',
+  'w': 'k',
+  'x': 'l',
+  'y': 'm',
+  'z': 'n',
+  '0': 'o',
+  '1': 'p',
+  '2': 'q',
+  '3': 'r',
+  '4': 's',
+  '5': 't',
+  '6': 'u',
+  '7': 'v',
+  '8': 'w',
+  '9': 'x',
+  '+': 'y',
+  '/': 'z'
+}
+
+/**
+ * Converts a Base64 encoded string and returns a URL-safe lexicographically ordered string.
+ *
+ * @param {string} base64Str - Base64 encoded string
+ * @returns {string}
+ */
+function encodeBase64Lex (base64Str) {
+  // Padding is removed since the encoded data can be reconstructed when either the data is
+  // the same size or the encoded data is never concatenated
+  const noPadding = base64Str.replace(/=/g, '')
+
+  let encoded = ''
+  for (let i = 0; i < noPadding.length; i++) {
+    encoded += ENCODE_TABLE[noPadding[i]]
+  }
+
+  return encoded
+}
+
+module.exports = encodeBase64Lex

--- a/broker-daemon/utils/base64-lex.js
+++ b/broker-daemon/utils/base64-lex.js
@@ -81,6 +81,10 @@ const ENCODE_TABLE = {
  * @returns {string}
  */
 function encodeBase64Lex (buffer) {
+  if (!Buffer.isBuffer(buffer)) {
+    throw new Error(`Invalid type ${typeof buffer}. Expected type Buffer.`)
+  }
+
   const base64Encoded = buffer.toString('base64')
   // Padding is removed since the encoded data can be reconstructed when either the data is
   // the same size or the encoded data is never concatenated

--- a/broker-daemon/utils/base64-lex.js
+++ b/broker-daemon/utils/base64-lex.js
@@ -74,15 +74,17 @@ const ENCODE_TABLE = {
 }
 
 /**
- * Converts a Base64 encoded string and returns a URL-safe lexicographically ordered string.
+ * Encodes data from a buffer to a variant of Base64 encoding that preserves
+ * lexicographic order in a URL-safe string.
  *
- * @param {string} base64Str - Base64 encoded string
+ * @param {Buffer} buffer - buffer with data to encode lexicographically
  * @returns {string}
  */
-function encodeBase64Lex (base64Str) {
+function encodeBase64Lex (buffer) {
+  const base64Encoded = buffer.toString('base64')
   // Padding is removed since the encoded data can be reconstructed when either the data is
   // the same size or the encoded data is never concatenated
-  const noPadding = base64Str.replace(/=/g, '')
+  const noPadding = base64Encoded.replace(/=/g, '')
 
   let encoded = ''
   for (let i = 0; i < noPadding.length; i++) {

--- a/broker-daemon/utils/base64-lex.spec.js
+++ b/broker-daemon/utils/base64-lex.spec.js
@@ -20,8 +20,10 @@ describe('encodeBase64Lex', () => {
   it('strips off base64 padding', () => {
     // base64 encoding will have padding of only 1 or 2 '='
     // (3 bytes are represented in 4 6-bit base64 digits, i.e. encoding is mod 3)
-    expect(encodeBase64Lex('12345=')).to.be.eql('pqrst')
-    expect(encodeBase64Lex('12345==')).to.be.eql('pqrst')
+    const onePad = Buffer.from('ffff', 'hex') // base64 encoded is '//8='
+    const twoPad = Buffer.from('ff', 'hex') // base64 encoded is '/w=='
+    expect(encodeBase64Lex(onePad)).to.be.eql('zzw')
+    expect(encodeBase64Lex(twoPad)).to.be.eql('zk')
   })
 
   it('preserves lexicographic ordering for numbers vs uppercase letters', () => {
@@ -37,8 +39,8 @@ describe('encodeBase64Lex', () => {
     // ASCII character codes would incorrectly sort based on base64 for this case
     expect(base64Encodings).to.be.eql([higherBase64Encoded, lowerBase64Encoded])
 
-    lexLowerIndex = encodeBase64Lex(lowerBase64Encoded)
-    lexHigherIndex = encodeBase64Lex(higherBase64Encoded)
+    lexLowerIndex = encodeBase64Lex(base64LowerIndex)
+    lexHigherIndex = encodeBase64Lex(base64HigherIndex)
 
     lexEncodings = [lexLowerIndex, lexHigherIndex]
     lexEncodings.sort()
@@ -59,8 +61,8 @@ describe('encodeBase64Lex', () => {
     // ASCII character codes would incorrectly sort based on base64 for this case
     expect(base64Encodings).to.be.eql([higherBase64Encoded, lowerBase64Encoded])
 
-    lexLowerIndex = encodeBase64Lex(lowerBase64Encoded)
-    lexHigherIndex = encodeBase64Lex(higherBase64Encoded)
+    lexLowerIndex = encodeBase64Lex(base64LowerIndex)
+    lexHigherIndex = encodeBase64Lex(base64HigherIndex)
 
     lexEncodings = [lexLowerIndex, lexHigherIndex]
     lexEncodings.sort()
@@ -81,8 +83,8 @@ describe('encodeBase64Lex', () => {
     // ASCII character codes would incorrectly sort based on base64 for this case
     expect(base64Encodings).to.be.eql([higherBase64Encoded, lowerBase64Encoded])
 
-    lexLowerIndex = encodeBase64Lex(lowerBase64Encoded)
-    lexHigherIndex = encodeBase64Lex(higherBase64Encoded)
+    lexLowerIndex = encodeBase64Lex(base64LowerIndex)
+    lexHigherIndex = encodeBase64Lex(base64HigherIndex)
 
     lexEncodings = [lexLowerIndex, lexHigherIndex]
     lexEncodings.sort()
@@ -103,8 +105,8 @@ describe('encodeBase64Lex', () => {
     // ASCII character codes would incorrectly sort based on base64 for this case
     expect(base64Encodings).to.be.eql([higherBase64Encoded, lowerBase64Encoded])
 
-    lexLowerIndex = encodeBase64Lex(lowerBase64Encoded)
-    lexHigherIndex = encodeBase64Lex(higherBase64Encoded)
+    lexLowerIndex = encodeBase64Lex(base64LowerIndex)
+    lexHigherIndex = encodeBase64Lex(base64HigherIndex)
 
     lexEncodings = [lexLowerIndex, lexHigherIndex]
     lexEncodings.sort()
@@ -123,8 +125,8 @@ describe('encodeBase64Lex', () => {
       Buffer.from('00003f', 'hex') // base64 index for '/'
     ]
 
-    const lexIds = trickyData.map(data => {
-      return encodeBase64Lex(data.toString('base64'))
+    const lexIds = trickyData.map(buffer => {
+      return encodeBase64Lex(buffer)
     }).sort()
 
     const expected = [

--- a/broker-daemon/utils/base64-lex.spec.js
+++ b/broker-daemon/utils/base64-lex.spec.js
@@ -88,14 +88,11 @@ describe('encodeBase64Lex', () => {
     ]
 
     // Convert timestamps to base64 encoding then convert to lex ordering
-    const lexIds = []
-    timestamps.forEach(ts => {
+    const lexIds = timestamps.map(ts => {
       const id = Buffer.alloc(4)
       id.writeUInt32BE(ts / 1000)
-      lexIds.push(encodeBase64Lex(id.toString('base64')))
-    })
-
-    lexIds.sort()
+      return encodeBase64Lex(id.toString('base64'))
+    }).sort()
 
     expect(lexIds).to.be.eql(expected)
   })

--- a/broker-daemon/utils/base64-lex.spec.js
+++ b/broker-daemon/utils/base64-lex.spec.js
@@ -17,6 +17,11 @@ describe('encodeBase64Lex', () => {
   let base64Encodings
   let lexEncodings
 
+  it('throws when passed a non Buffer object', () => {
+    const nonBufferObj = {}
+    expect(() => encodeBase64Lex(nonBufferObj)).to.throw()
+  })
+
   it('strips off base64 padding', () => {
     // base64 encoding will have padding of only 1 or 2 '='
     // (3 bytes are represented in 4 6-bit base64 digits, i.e. encoding is mod 3)

--- a/broker-daemon/utils/base64-lex.spec.js
+++ b/broker-daemon/utils/base64-lex.spec.js
@@ -12,6 +12,10 @@ describe('encodeBase64Lex', () => {
   let base64HigherIndex
   let lexLowerIndex
   let lexHigherIndex
+  let lowerBase64Encoded
+  let higherBase64Encoded
+  let base64Encodings
+  let lexEncodings
 
   it('strips off base64 padding', () => {
     // base64 encoding will have padding of only 1 or 2 '='
@@ -21,78 +25,115 @@ describe('encodeBase64Lex', () => {
   })
 
   it('preserves lexicographic ordering for numbers vs uppercase letters', () => {
-    base64LowerIndex = 'A' // base64 index for 'A' is 0
-    base64HigherIndex = '0' // base64 index for '0' is 52
+    base64LowerIndex = Buffer.from('000000', 'hex') // base64 index for 0x00 is 'A'
+    base64HigherIndex = Buffer.from('000034', 'hex') // base64 index for 0x34 is '0'
+
+    lowerBase64Encoded = base64LowerIndex.toString('base64')
+    higherBase64Encoded = base64HigherIndex.toString('base64')
+
+    base64Encodings = [lowerBase64Encoded, higherBase64Encoded]
+    base64Encodings.sort()
 
     // ASCII character codes would incorrectly sort based on base64 for this case
-    expect(base64LowerIndex.charCodeAt(0)).to.be.greaterThan(base64HigherIndex.charCodeAt(0))
+    expect(base64Encodings).to.be.eql([higherBase64Encoded, lowerBase64Encoded])
 
-    lexLowerIndex = encodeBase64Lex(base64LowerIndex)
-    lexHigherIndex = encodeBase64Lex(base64HigherIndex)
+    lexLowerIndex = encodeBase64Lex(lowerBase64Encoded)
+    lexHigherIndex = encodeBase64Lex(higherBase64Encoded)
 
-    expect(lexLowerIndex.charCodeAt(0)).to.be.lessThan(lexHigherIndex.charCodeAt(0))
+    lexEncodings = [lexLowerIndex, lexHigherIndex]
+    lexEncodings.sort()
+
+    expect(lexEncodings).to.be.eql([lexLowerIndex, lexHigherIndex])
   })
 
   it('preserves lexicographic ordering for numbers vs lowercase letters', () => {
-    base64LowerIndex = 'a' // base64 index for 'a' is 26
-    base64HigherIndex = '0' // base64 index for '0' is 52
+    base64LowerIndex = Buffer.from('00001a', 'hex') // base64 index for 0x1a is 'a'
+    base64HigherIndex = Buffer.from('000034', 'hex') // base64 index for 0x34 is '0'
 
-    // ASCII character codes would incorrectly sort based on base64 in this case
-    expect(base64LowerIndex.charCodeAt(0)).to.be.greaterThan(base64HigherIndex.charCodeAt(0))
+    lowerBase64Encoded = base64LowerIndex.toString('base64')
+    higherBase64Encoded = base64HigherIndex.toString('base64')
 
-    lexLowerIndex = encodeBase64Lex(base64LowerIndex)
-    lexHigherIndex = encodeBase64Lex(base64HigherIndex)
+    base64Encodings = [lowerBase64Encoded, higherBase64Encoded]
+    base64Encodings.sort()
 
-    expect(lexLowerIndex.charCodeAt(0)).to.be.lessThan(lexHigherIndex.charCodeAt(0))
+    // ASCII character codes would incorrectly sort based on base64 for this case
+    expect(base64Encodings).to.be.eql([higherBase64Encoded, lowerBase64Encoded])
+
+    lexLowerIndex = encodeBase64Lex(lowerBase64Encoded)
+    lexHigherIndex = encodeBase64Lex(higherBase64Encoded)
+
+    lexEncodings = [lexLowerIndex, lexHigherIndex]
+    lexEncodings.sort()
+
+    expect(lexEncodings).to.be.eql([lexLowerIndex, lexHigherIndex])
   })
 
   it('preserves lexicographic ordering for `/`', () => {
-    base64LowerIndex = '0' // base64 index for '0' is 52
-    base64HigherIndex = '/' // base64 index for '/' is 63
+    base64LowerIndex = Buffer.from('000034', 'hex') // base64 index for 0x34 is '0'
+    base64HigherIndex = Buffer.from('00003f', 'hex') // base64 index for 0x3f is '/'
+
+    lowerBase64Encoded = base64LowerIndex.toString('base64')
+    higherBase64Encoded = base64HigherIndex.toString('base64')
+
+    base64Encodings = [lowerBase64Encoded, higherBase64Encoded]
+    base64Encodings.sort()
 
     // ASCII character codes would incorrectly sort based on base64 for this case
-    expect(base64LowerIndex.charCodeAt(0)).to.be.greaterThan(base64HigherIndex.charCodeAt(0))
+    expect(base64Encodings).to.be.eql([higherBase64Encoded, lowerBase64Encoded])
 
-    lexLowerIndex = encodeBase64Lex(base64LowerIndex)
-    lexHigherIndex = encodeBase64Lex(base64HigherIndex)
+    lexLowerIndex = encodeBase64Lex(lowerBase64Encoded)
+    lexHigherIndex = encodeBase64Lex(higherBase64Encoded)
 
-    expect(lexLowerIndex.charCodeAt(0)).to.be.lessThan(lexHigherIndex.charCodeAt(0))
+    lexEncodings = [lexLowerIndex, lexHigherIndex]
+    lexEncodings.sort()
+
+    expect(lexEncodings).to.be.eql([lexLowerIndex, lexHigherIndex])
   })
 
   it('preserves lexicographic ordering for `+`', () => {
-    base64LowerIndex = '0' // base64 index for '0' is 52
-    base64HigherIndex = '+' // base64 index for '+' is 62
+    base64LowerIndex = Buffer.from('000034', 'hex') // base64 index for 0x34 is '0'
+    base64HigherIndex = Buffer.from('00003e', 'hex') // base64 index for 0x3e is '+'
+
+    lowerBase64Encoded = base64LowerIndex.toString('base64')
+    higherBase64Encoded = base64HigherIndex.toString('base64')
+
+    base64Encodings = [lowerBase64Encoded, higherBase64Encoded]
+    base64Encodings.sort()
 
     // ASCII character codes would incorrectly sort based on base64 for this case
-    expect(base64LowerIndex.charCodeAt(0)).to.be.greaterThan(base64HigherIndex.charCodeAt(0))
+    expect(base64Encodings).to.be.eql([higherBase64Encoded, lowerBase64Encoded])
 
-    lexLowerIndex = encodeBase64Lex(base64LowerIndex)
-    lexHigherIndex = encodeBase64Lex(base64HigherIndex)
+    lexLowerIndex = encodeBase64Lex(lowerBase64Encoded)
+    lexHigherIndex = encodeBase64Lex(higherBase64Encoded)
 
-    expect(lexLowerIndex.charCodeAt(0)).to.be.lessThan(lexHigherIndex.charCodeAt(0))
+    lexEncodings = [lexLowerIndex, lexHigherIndex]
+    lexEncodings.sort()
+
+    expect(lexEncodings).to.be.eql([lexLowerIndex, lexHigherIndex])
   })
 
-  it('preserves lexicographic ordering for data used as order IDs', () => {
-    // When the following timestamps are base64 encoded, they lose their ordering by timestamp
-    // Using encodeBase64Lex preserves the ordering by timestamp
-    const timestamps = [
-      1554914185000,
-      1554505000000,
-      1554831515000
+  it('preserves lexicographic ordering for multiple data inputs', () => {
+    // The following hex data will not be ordered lexicographically when the base64 characters are
+    // sorted using ASCII character codes
+    const trickyData = [
+      Buffer.from('000000', 'hex'), // base64 index for 'A'
+      Buffer.from('00001a', 'hex'), // base64 index for 'a'
+      Buffer.from('000034', 'hex'), // base64 index for '0'
+      Buffer.from('00003e', 'hex'), // base64 index for '+'
+      Buffer.from('00003f', 'hex') // base64 index for '/'
     ]
+
+    const lexIds = trickyData.map(data => {
+      return encodeBase64Lex(data.toString('base64'))
+    }).sort()
 
     const expected = [
-      'M9US9-', // corresponds to 1554505000000
-      'M9nNak', // corresponds to 1554831515000
-      'M9sQXF' // corresponds to 1554914185000
+      '----', // 0x00 in base64
+      '---P', // 0x1a in base64
+      '---o', // 0x34 in base64
+      '---y', // 0x3e in base64
+      '---z' // 0x3f in base64
     ]
-
-    // Convert timestamps to base64 encoding then convert to lex ordering
-    const lexIds = timestamps.map(ts => {
-      const id = Buffer.alloc(4)
-      id.writeUInt32BE(ts / 1000)
-      return encodeBase64Lex(id.toString('base64'))
-    }).sort()
 
     expect(lexIds).to.be.eql(expected)
   })

--- a/broker-daemon/utils/base64-lex.spec.js
+++ b/broker-daemon/utils/base64-lex.spec.js
@@ -14,7 +14,10 @@ describe('encodeBase64Lex', () => {
   let lexHigherIndex
 
   it('strips off base64 padding', () => {
+    // base64 encoding will have padding of only 1 or 2 '='
+    // (3 bytes are represented in 4 6-bit base64 digits, i.e. encoding is mod 3)
     expect(encodeBase64Lex('12345=')).to.be.eql('pqrst')
+    expect(encodeBase64Lex('12345==')).to.be.eql('pqrst')
   })
 
   it('preserves lexicographic ordering for numbers vs uppercase letters', () => {
@@ -79,9 +82,9 @@ describe('encodeBase64Lex', () => {
     ]
 
     const expected = [
-      { timestamp: 1554505000000, lexId: 'M9US9-' },
-      { timestamp: 1554831515000, lexId: 'M9nNak' },
-      { timestamp: 1554914185000, lexId: 'M9sQXF' }
+      'M9US9-', // corresponds to 1554505000000
+      'M9nNak', // corresponds to 1554831515000
+      'M9sQXF' // corresponds to 1554914185000
     ]
 
     // Convert timestamps to base64 encoding then convert to lex ordering
@@ -89,21 +92,10 @@ describe('encodeBase64Lex', () => {
     timestamps.forEach(ts => {
       const id = Buffer.alloc(4)
       id.writeUInt32BE(ts / 1000)
-      lexIds.push({
-        timestamp: ts,
-        lexId: encodeBase64Lex(id.toString('base64'))
-      })
+      lexIds.push(encodeBase64Lex(id.toString('base64')))
     })
 
-    lexIds.sort((a, b) => {
-      if (a.lexId < b.lexId) {
-        return -1
-      }
-      if (a.lexId > b.lexId) {
-        return 1
-      }
-      return 0
-    })
+    lexIds.sort()
 
     expect(lexIds).to.be.eql(expected)
   })

--- a/broker-daemon/utils/base64-lex.spec.js
+++ b/broker-daemon/utils/base64-lex.spec.js
@@ -1,0 +1,110 @@
+const { expect } = require('test/test-helper')
+
+const encodeBase64Lex = require('./base64-lex')
+
+// The reason base64 doesn't preserve lexicographic order is because the index encoding
+// values for base64 do not match up with the index encoding values for ASCII characters.
+//
+// Base64 increases index using the pattern [A-Z][a-z][0-9][+][/]
+// ASCII increases index using the pattern [-][0-9][A-Z][_][a-z]
+describe('encodeBase64Lex', () => {
+  let base64LowerIndex
+  let base64HigherIndex
+  let lexLowerIndex
+  let lexHigherIndex
+
+  it('strips off base64 padding', () => {
+    expect(encodeBase64Lex('12345=')).to.be.eql('pqrst')
+  })
+
+  it('preserves lexicographic ordering for numbers vs uppercase letters', () => {
+    base64LowerIndex = 'A' // base64 index for 'A' is 0
+    base64HigherIndex = '0' // base64 index for '0' is 52
+
+    // ASCII character codes would incorrectly sort based on base64 for this case
+    expect(base64LowerIndex.charCodeAt(0)).to.be.greaterThan(base64HigherIndex.charCodeAt(0))
+
+    lexLowerIndex = encodeBase64Lex(base64LowerIndex)
+    lexHigherIndex = encodeBase64Lex(base64HigherIndex)
+
+    expect(lexLowerIndex.charCodeAt(0)).to.be.lessThan(lexHigherIndex.charCodeAt(0))
+  })
+
+  it('preserves lexicographic ordering for numbers vs lowercase letters', () => {
+    base64LowerIndex = 'a' // base64 index for 'a' is 26
+    base64HigherIndex = '0' // base64 index for '0' is 52
+
+    // ASCII character codes would incorrectly sort based on base64 in this case
+    expect(base64LowerIndex.charCodeAt(0)).to.be.greaterThan(base64HigherIndex.charCodeAt(0))
+
+    lexLowerIndex = encodeBase64Lex(base64LowerIndex)
+    lexHigherIndex = encodeBase64Lex(base64HigherIndex)
+
+    expect(lexLowerIndex.charCodeAt(0)).to.be.lessThan(lexHigherIndex.charCodeAt(0))
+  })
+
+  it('preserves lexicographic ordering for `/`', () => {
+    base64LowerIndex = '0' // base64 index for '0' is 52
+    base64HigherIndex = '/' // base64 index for '/' is 63
+
+    // ASCII character codes would incorrectly sort based on base64 for this case
+    expect(base64LowerIndex.charCodeAt(0)).to.be.greaterThan(base64HigherIndex.charCodeAt(0))
+
+    lexLowerIndex = encodeBase64Lex(base64LowerIndex)
+    lexHigherIndex = encodeBase64Lex(base64HigherIndex)
+
+    expect(lexLowerIndex.charCodeAt(0)).to.be.lessThan(lexHigherIndex.charCodeAt(0))
+  })
+
+  it('preserves lexicographic ordering for `+`', () => {
+    base64LowerIndex = '0' // base64 index for '0' is 52
+    base64HigherIndex = '+' // base64 index for '+' is 62
+
+    // ASCII character codes would incorrectly sort based on base64 for this case
+    expect(base64LowerIndex.charCodeAt(0)).to.be.greaterThan(base64HigherIndex.charCodeAt(0))
+
+    lexLowerIndex = encodeBase64Lex(base64LowerIndex)
+    lexHigherIndex = encodeBase64Lex(base64HigherIndex)
+
+    expect(lexLowerIndex.charCodeAt(0)).to.be.lessThan(lexHigherIndex.charCodeAt(0))
+  })
+
+  it('preserves lexicographic ordering for data used as order IDs', () => {
+    // When the following timestamps are base64 encoded, they lose their ordering by timestamp
+    // Using encodeBase64Lex preserves the ordering by timestamp
+    const timestamps = [
+      1554914185000,
+      1554505000000,
+      1554831515000
+    ]
+
+    const expected = [
+      { timestamp: 1554505000000, lexId: 'M9US9-' },
+      { timestamp: 1554831515000, lexId: 'M9nNak' },
+      { timestamp: 1554914185000, lexId: 'M9sQXF' }
+    ]
+
+    // Convert timestamps to base64 encoding then convert to lex ordering
+    const lexIds = []
+    timestamps.forEach(ts => {
+      const id = Buffer.alloc(4)
+      id.writeUInt32BE(ts / 1000)
+      lexIds.push({
+        timestamp: ts,
+        lexId: encodeBase64Lex(id.toString('base64'))
+      })
+    })
+
+    lexIds.sort((a, b) => {
+      if (a.lexId < b.lexId) {
+        return -1
+      }
+      if (a.lexId > b.lexId) {
+        return 1
+      }
+      return 0
+    })
+
+    expect(lexIds).to.be.eql(expected)
+  })
+})

--- a/broker-daemon/utils/generate-id.js
+++ b/broker-daemon/utils/generate-id.js
@@ -7,7 +7,7 @@ const base64Lex = require('../utils/base64-lex')
  * We start with the current timestamp so that they are automatically time ordered.
  * The randomness can be increased for particularly high-frequency brokers as nothing
  * should depend on the length of this ID.
- * @returns {string} 16 characters in [base64url encoding]{@link https://tools.ietf.org/html/rfc4648}
+ * @returns {string} 16 characters ordered by timestamp
  */
 function generateId () {
   // initialize the buffer to hold our 12 byte  ID
@@ -21,7 +21,7 @@ function generateId () {
   const rand = crypto.randomBytes(8)
   rand.copy(id, 4)
 
-  return base64Lex(id.toString('base64'))
+  return base64Lex(id)
 }
 
 module.exports = generateId

--- a/broker-daemon/utils/generate-id.js
+++ b/broker-daemon/utils/generate-id.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto')
+const base64Lex = require('../utils/base64-lex')
 
 /**
  * Generate a unique ID string
@@ -20,19 +21,7 @@ function generateId () {
   const rand = crypto.randomBytes(8)
   rand.copy(id, 4)
 
-  return urlEncode(id.toString('base64'))
-}
-
-/**
- * Convert a string from Base64 to [Base64url]{@link https://tools.ietf.org/html/rfc4648}
- * @param  {string} base64Str - Base64 encoded String
- * @returns {string}           Base64url encoded string
- */
-function urlEncode (base64Str) {
-  return base64Str
-    .replace(/=/g, '')
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
+  return base64Lex(id.toString('base64'))
 }
 
 module.exports = generateId

--- a/broker-daemon/utils/generate-id.spec.js
+++ b/broker-daemon/utils/generate-id.spec.js
@@ -4,83 +4,57 @@ const { sinon, rewire, expect, timekeeper } = require('test/test-helper')
 const generateId = rewire(path.resolve(__dirname, 'generate-id'))
 
 describe('generateId', () => {
-  describe('generateId', () => {
-    let urlEncode
-    let crypto
-    let resetUrlEncode
-    let resetCrypto
-    let randomData
-    let randomHex
-    let randomBase64
-    let randomUrlEncoded
-    let timestamp
-    let timeInSeconds
+  let base64LexStub
+  let cryptoStub
+  let resetBase64LexStub
+  let resetCryptoStub
+  let randomData
+  let randomHex
+  let randomBase64
+  let randomBase64Lex
+  let timestamp
+  let timeInSeconds
 
-    beforeEach(() => {
-      timestamp = 1532045654371
-      timeInSeconds = 1532045654
-      timekeeper.freeze(new Date(timestamp))
-      randomData = Buffer.from('deadbeefdeadbeef', 'hex')
+  beforeEach(() => {
+    timestamp = 1532045654371
+    timeInSeconds = 1532045654
+    timekeeper.freeze(new Date(timestamp))
+    randomData = Buffer.from('deadbeefdeadbeef', 'hex')
 
-      randomHex = timeInSeconds.toString(16) + 'deadbeefdeadbeef'
+    randomHex = timeInSeconds.toString(16) + 'deadbeefdeadbeef'
 
-      // the data should be the timestamp on the front, followed by
-      // our random data at the end
-      randomBase64 = Buffer.from(randomHex, 'hex').toString('base64')
-      randomUrlEncoded = 'asfdjJF09809ASDFasdf-asdf_asdf'
+    // the data should be the timestamp on the front, followed by
+    // our random data at the end
+    randomBase64 = Buffer.from(randomHex, 'hex').toString('base64')
+    randomBase64Lex = 'asfdjJF09809ASDFasdf-asdf_asdf'
 
-      urlEncode = sinon.stub().returns(randomUrlEncoded)
+    base64LexStub = sinon.stub().returns(randomBase64Lex)
 
-      crypto = {
-        randomBytes: sinon.stub().returns(randomData)
-      }
+    cryptoStub = {
+      randomBytes: sinon.stub().returns(randomData)
+    }
 
-      resetUrlEncode = generateId.__set__('urlEncode', urlEncode)
-      resetCrypto = generateId.__set__('crypto', crypto)
-    })
-
-    afterEach(() => {
-      resetUrlEncode()
-      resetCrypto()
-      timekeeper.reset()
-    })
-
-    it('creates random hex data', () => {
-      generateId()
-
-      expect(crypto.randomBytes).to.have.been.calledOnce()
-      expect(crypto.randomBytes).to.have.been.calledWith(8)
-    })
-
-    it('url encodes the data', () => {
-      expect(generateId()).to.be.eql(randomUrlEncoded)
-
-      expect(urlEncode).to.have.been.calledOnce()
-      expect(urlEncode).to.have.been.calledWith(randomBase64)
-    })
+    resetBase64LexStub = generateId.__set__('base64Lex', base64LexStub)
+    resetCryptoStub = generateId.__set__('crypto', cryptoStub)
   })
 
-  describe('urlEncode', () => {
-    let urlEncode
+  afterEach(() => {
+    resetBase64LexStub()
+    resetCryptoStub()
+    timekeeper.reset()
+  })
 
-    beforeEach(() => {
-      urlEncode = generateId.__get__('urlEncode')
-    })
+  it('creates random hex data', () => {
+    generateId()
 
-    it('strips off trailing equals signs', () => {
-      expect(urlEncode('asf8asuf98uas9f8u===')).to.be.eql('asf8asuf98uas9f8u')
-    })
+    expect(cryptoStub.randomBytes).to.have.been.calledOnce()
+    expect(cryptoStub.randomBytes).to.have.been.calledWith(8)
+  })
 
-    it('converts + to -', () => {
-      expect(urlEncode('asdf+asdf+asdf')).to.be.eql('asdf-asdf-asdf')
-    })
+  it('converts the base64 data to lexicographical order', () => {
+    expect(generateId()).to.be.eql(randomBase64Lex)
 
-    it('converts / to _', () => {
-      expect(urlEncode('asdf/asdf/asdf')).to.be.eql('asdf_asdf_asdf')
-    })
-
-    it('converts them all together', () => {
-      expect(urlEncode('asdf/asdf+asdf/asdf+asdf==')).to.be.eql('asdf_asdf-asdf_asdf-asdf')
-    })
+    expect(base64LexStub).to.have.been.calledOnce()
+    expect(base64LexStub).to.have.been.calledWith(randomBase64)
   })
 })

--- a/broker-daemon/utils/generate-id.spec.js
+++ b/broker-daemon/utils/generate-id.spec.js
@@ -25,7 +25,7 @@ describe('generateId', () => {
 
     // the data should be the timestamp on the front, followed by
     // our random data at the end
-    randomBase64 = Buffer.from(randomHex, 'hex').toString('base64')
+    randomBase64 = Buffer.from(randomHex, 'hex')
     randomBase64Lex = 'asfdjJF09809ASDFasdf-asdf_asdf'
 
     base64LexStub = sinon.stub().returns(randomBase64Lex)


### PR DESCRIPTION
## Description
This PR adds a utility function `encodeBase64Lex` which converts a base64 encoded string to an ASCII representation that preserves lexicographic ordering.

This is useful since order IDs are prepended with the UNIX timestamp they were created, so using an encoding scheme that preserves lexicographic ordering allows the user to view orders sorted by date.

## Related PRs
List related PRs if applicable


## Todos
- [x] Tests
- [x] Documentation
- [x] Link to Trello
