### PR TITLE
remove docker override info

### DIFF
--- a/.env-mainnet-sample
+++ b/.env-mainnet-sample
@@ -60,9 +60,8 @@ LTC_RPC_PASS=sparkswapltc
 SECURE_PATH=~/.sparkswap/secure
 
 # Docker compose files
-# docker-compose by default will look for the docker-compose.yml file and apply the docker-compose.override.yml file if
-# it exists. If we specify the COMPOSE_FILE variable, all compose files joined by the COMPOSE_PATH_SEPARATOR will
-# be applied and used
+# All sparkswap compose files joined by the COMPOSE_PATH_SEPARATOR will be applied and used
+# with docker-compose
 #
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose.yml:docker-compose.bitcoind.yml:docker-compose.litecoind.yml

--- a/.env-regtest-local-sample
+++ b/.env-regtest-local-sample
@@ -66,9 +66,8 @@ LITECOIND_CONNECT_HOST=host.docker.internal
 SECURE_PATH=~/.sparkswap/secure
 
 # Docker compose files
-# docker-compose by default will look for the docker-compose.yml file and apply the docker-compose.override.yml file if
-# it exists. If we specify the COMPOSE_FILE variable, all compose files joined by the COMPOSE_PATH_SEPARATOR will
-# be applied and used
+# All sparkswap compose files joined by the COMPOSE_PATH_SEPARATOR will be applied and used
+# with docker-compose
 #
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose.yml:docker-compose.bitcoind.yml:docker-compose.litecoind.yml:docker-compose.regtest.yml:docker-compose.local.yml

--- a/.env-regtest-sample
+++ b/.env-regtest-sample
@@ -66,9 +66,8 @@ LITECOIND_CONNECT_HOST=relayer.regtest.sparkswap.com
 SECURE_PATH=~/.sparkswap/secure
 
 # Docker compose files
-# docker-compose by default will look for the docker-compose.yml file and apply the docker-compose.override.yml file if
-# it exists. If we specify the COMPOSE_FILE variable, all compose files joined by the COMPOSE_PATH_SEPARATOR will
-# be applied and used
+# All sparkswap compose files joined by the COMPOSE_PATH_SEPARATOR will be applied and used
+# with docker-compose
 #
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose.yml:docker-compose.bitcoind.yml:docker-compose.litecoind.yml:docker-compose.regtest.yml

--- a/.env-testnet-sample
+++ b/.env-testnet-sample
@@ -60,9 +60,8 @@ LTC_RPC_PASS=sparkswapltc
 SECURE_PATH=~/.sparkswap/secure
 
 # Docker compose files
-# docker-compose by default will look for the docker-compose.yml file and apply the docker-compose.override.yml file if
-# it exists. If we specify the COMPOSE_FILE variable, all compose files joined by the COMPOSE_PATH_SEPARATOR will
-# be applied and used
+# All sparkswap compose files joined by the COMPOSE_PATH_SEPARATOR will be applied and used
+# with docker-compose
 #
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose.yml:docker-compose.bitcoind.yml:docker-compose.litecoind.yml

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,3 @@ typings/
 
 # Mac
 .DS_Store
-
-# Override file which we use dynamically in the broker setup
-docker-compose.override.yml

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -206,15 +206,6 @@ if [ "$NO_DOCKER" == "false" ]; then
   docker build -t sparkswap/broker:$BROKER_VERSION -f ./docker/sparkswapd/Dockerfile ./
 fi
 
-if [ -f docker-compose.override.yml ]; then
-  # Let the user know that an override file exists which may mean that the user
-  # will have settings they do not expect
-  echo ""
-  echo "WARNING: A 'docker-compose.override.yml' file exists"
-  echo "WARNING: This may add unwanted settings to the broker that could affect how your daemon runs."
-  echo ""
-fi
-
 if [ "$LOCAL" == "true" ]; then
   echo "Downloading Local Relayer Cert..."
   # the path of this output is directly related to the SECURE_PATH that is set


### PR DESCRIPTION
## Description
This PR removes references to `docker-compose.override` because we no longer uses a setup that leverages that file. When we specify `COMPOSE_FILE` in the `.env` file, this will actually override any defaults from `docker-compose` making the comment about the override file obsolete.

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
