### PR TITLE
add friendly error to supported markets

### DIFF
--- a/broker-daemon/broker-rpc/orderbook-service/get-supported-markets.js
+++ b/broker-daemon/broker-rpc/orderbook-service/get-supported-markets.js
@@ -12,10 +12,17 @@
  * @returns {GetSupportedMarketsResponse}
  */
 async function getSupportedMarkets ({ params, relayer, logger, engines, orderbooks }, { GetSupportedMarketsResponse }) {
-  const { markets } = await relayer.adminService.getMarkets({})
+  try {
+    var { markets } = await relayer.adminService.getMarkets({})
+  } catch (e) {
+    throw new Error('Failed to get markets from relayer')
+  }
 
   const supportedMarkets = markets.reduce((acc, market) => {
-    if (!orderbooks.get(market)) return acc
+    if (!orderbooks.get(market)) {
+      return acc
+    }
+
     const [base, counter] = market.split('/')
     const marketInfo = {
       id: market,
@@ -27,6 +34,7 @@ async function getSupportedMarkets ({ params, relayer, logger, engines, orderboo
     acc.push(marketInfo)
     return acc
   }, [])
+
   return new GetSupportedMarketsResponse({ supportedMarkets })
 }
 

--- a/broker-daemon/broker-rpc/orderbook-service/get-supported-markets.spec.js
+++ b/broker-daemon/broker-rpc/orderbook-service/get-supported-markets.spec.js
@@ -28,6 +28,11 @@ describe('getSupportedMarkets', () => {
     }
   })
 
+  it('throws an error if the relayer is unresponsive', () => {
+    relayer.adminService.getMarkets.rejects()
+    return expect(getSupportedMarkets({ logger, engines, relayer, orderbooks }, { GetSupportedMarketsResponse })).to.eventually.be.rejectedWith('Failed to get markets')
+  })
+
   it('gets the balances from a particular engine', async () => {
     await getSupportedMarkets({ logger, engines, relayer, orderbooks }, { GetSupportedMarketsResponse })
     expect(relayer.adminService.getMarkets).to.have.been.calledOnce()


### PR DESCRIPTION
## Description
While investigating work that needed to be done for our CCXT implementation, I started receiving generic error messages from the Relayer. This PR makes the user aware that the relayer connection is down if we cannot make the call to `getMarkets`

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
