### PR TITLE
FEATURE - Add `change-password` command to broker/cli

### DIFF
--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -591,10 +591,16 @@ async function changePassword (args, opts, logger) {
 
   try {
     const client = new BrokerDaemonClient(rpcAddress)
-    const currentPassword = await askQuestion(`Enter your current wallet password:`, { silent: true })
-    const newPassword = await askQuestion(`Enter your new wallet password:`, { silent: true })
+    const currentPassword = await askQuestion(`Please enter your current wallet password:`, { silent: true })
+    const newPassword = await askQuestion(`Please enter a new password:`, { silent: true })
+    const confirmNewPass = await askQuestion(`Please confirm your new password:`, { silent: true })
+
+    if (newPassword !== confirmNewPass) {
+      return logger.error('Error: Passwords did not match, please try again'.red)
+    }
+
     await client.walletService.changeWalletPassword({ symbol, currentPassword, newPassword })
-    logger.info(`Successfully Unlocked ${symbol.toUpperCase()} Wallet!`.green)
+    logger.info(`Successfully changed your ${symbol.toUpperCase()} wallet password! Your wallet is now unlocked.`.green)
   } catch (e) {
     logger.error(handleError(e))
   }
@@ -724,7 +730,7 @@ module.exports = (program) => {
     .command(`wallet ${SUPPORTED_COMMANDS.UNLOCK}`, 'Unlock a wallet')
     .argument('<symbol>', `Supported currencies: ${SUPPORTED_SYMBOLS.join('/')}`)
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING)
-    .command(`wallet ${SUPPORTED_COMMANDS.CHANGE_PASSWORD}`, 'Change an engines wallet password')
+    .command(`wallet ${SUPPORTED_COMMANDS.CHANGE_PASSWORD}`, 'Change a specific engine\'s wallet password')
     .argument('<symbol>', `Supported currencies: ${SUPPORTED_SYMBOLS.join('/')}`)
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING)
     .command(`wallet ${SUPPORTED_COMMANDS.BALANCE}`, 'Current daemon wallet balance')

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -1716,7 +1716,7 @@ message WalletHistoryResponse {
 }
 
 /**
- * Request to unlock a wallet for a specific currency
+ * Request to change a wallet password for a specific currency
  */
 message ChangeWalletPasswordRequest {
   // Currency of wallet
@@ -2173,18 +2173,17 @@ service WalletService {
   }
 
   /**
-   * UnlockWallet sends an unlock rpc command to the engine to allow funds to be used
-   * in the event that the broker has been taken offline -> online
+   * ChangeWalletPassword sends a change password rpc command to the engine which changes
+   * the wallet password for a specific currency and unlocks the engines on completion
    *
-   * This RPC will be required after every application restart, if each engine's wallet has been
-   * created. If you need to create a wallet for daemon, please refer to `CreateWallet`
+   * This RPC can only be used if the specified engine's wallet is locked.
    *
    * ```javascript
-   * await walletService.unlockWallet({ symbol: 'BTC', password: 'your-secure-password')
+   * await walletService.changeWalletPassword({ symbol: 'BTC', currentPassword: 'your-current-password', newPassword: 'your-new-secure-password')
    * ```
    *
    * ```shell
-   * > sparkswap wallet unlock BTC
+   * > sparkswap wallet change-password BTC
    * ```
    *
    * > The above command will print:
@@ -2194,7 +2193,7 @@ service WalletService {
    * ```
    *
    * ```shell
-   * Successfully Unlocked BTC Wallet!
+   * Successfully changed your BTC wallet password! Your wallet is now unlocked.
    * ```
    */
   rpc ChangeWalletPassword (ChangeWalletPasswordRequest) returns (google.protobuf.Empty) {

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -1716,6 +1716,18 @@ message WalletHistoryResponse {
 }
 
 /**
+ * Request to unlock a wallet for a specific currency
+ */
+message ChangeWalletPasswordRequest {
+  // Currency of wallet
+  string symbol = 1;
+  // Current password for the wallet
+  string current_password = 2;
+  // New password for the wallet
+  string new_password = 3;
+}
+
+/**
  * The WalletService is for interacting with the wallets managed by the Broker on behalf of the user.
  *
  * It is used primarily during set up (e.g. making deposits) of a Broker.
@@ -2157,6 +2169,38 @@ service WalletService {
   rpc WalletHistory (WalletHistoryRequest) returns (WalletHistoryResponse) {
     option (.google.api.http) = {
       get: "/v1/wallet/summary/{symbol}"
+    };
+  }
+
+  /**
+   * UnlockWallet sends an unlock rpc command to the engine to allow funds to be used
+   * in the event that the broker has been taken offline -> online
+   *
+   * This RPC will be required after every application restart, if each engine's wallet has been
+   * created. If you need to create a wallet for daemon, please refer to `CreateWallet`
+   *
+   * ```javascript
+   * await walletService.unlockWallet({ symbol: 'BTC', password: 'your-secure-password')
+   * ```
+   *
+   * ```shell
+   * > sparkswap wallet unlock BTC
+   * ```
+   *
+   * > The above command will print:
+   *
+   * ```javascript
+   * {}
+   * ```
+   *
+   * ```shell
+   * Successfully Unlocked BTC Wallet!
+   * ```
+   */
+  rpc ChangeWalletPassword (ChangeWalletPasswordRequest) returns (google.protobuf.Empty) {
+    option (.google.api.http) = {
+      post: "/v1/wallet/change-password"
+      body: "*"
     };
   }
 }

--- a/broker-daemon/broker-rpc/wallet-service/change-wallet-password.js
+++ b/broker-daemon/broker-rpc/wallet-service/change-wallet-password.js
@@ -24,7 +24,7 @@ async function changeWalletPassword ({ logger, params, engines }, { EmptyRespons
 
   if (!engine) {
     logger.error(`Could not find engine: ${symbol}`)
-    throw new Error(`Unable to unlock wallet. No engine available for ${symbol}`)
+    throw new Error(`Unable to change wallet password. No engine available for ${symbol}`)
   }
 
   if (!engine.isLocked) {

--- a/broker-daemon/broker-rpc/wallet-service/change-wallet-password.js
+++ b/broker-daemon/broker-rpc/wallet-service/change-wallet-password.js
@@ -30,7 +30,7 @@ async function changeWalletPassword ({ logger, params, engines }, { EmptyRespons
   if (!engine.isLocked) {
     logger.error(`Engine for ${symbol} is not locked. Current status: ${engine.status}`)
     throw new Error(`Unable to change your wallet password, engine for ${symbol} is currently: ${engine.status}.
-                     Your engine needs to be in status LOCKED`)
+                     Your engine needs to be in a locked status`)
   }
 
   await engine.changeWalletPassword(currentPassword, newPassword)

--- a/broker-daemon/broker-rpc/wallet-service/change-wallet-password.js
+++ b/broker-daemon/broker-rpc/wallet-service/change-wallet-password.js
@@ -1,0 +1,41 @@
+/**
+ * Change a wallet password for a specific engine
+ *
+ * @param {GrpcUnaryMethod~request} request - request object
+ * @param {Logger} request.logger
+ * @param {Object<string>} request.params
+ * @param {string} request.params.symbol - currency symbol of the wallet e.g. `BTC`
+ * @param {string} request.params.currentPassword - password for the engine's wallet
+ * @param {string} request.params.newPassword - new password for the engine's wallet
+ * @param {Map<Engine>} request.engines
+ * @param {Object} responses
+ * @param {Function} responses.EmptyResponse
+ * @throws {Error} If Engine does not exist for the given symbol
+ * @throws {Error} If Engine is not in a LOCKED state
+ * @returns {EmptyResponse}
+ */
+async function changeWalletPassword ({ logger, params, engines }, { EmptyResponse }) {
+  const {
+    symbol,
+    currentPassword,
+    newPassword
+  } = params
+  const engine = engines.get(symbol)
+
+  if (!engine) {
+    logger.error(`Could not find engine: ${symbol}`)
+    throw new Error(`Unable to unlock wallet. No engine available for ${symbol}`)
+  }
+
+  if (!engine.isLocked) {
+    logger.error(`Engine for ${symbol} is not locked. Current status: ${engine.status}`)
+    throw new Error(`Unable to change your wallet password, engine for ${symbol} is currently: ${engine.status}.
+                     Your engine needs to be in status LOCKED`)
+  }
+
+  await engine.changeWalletPassword(currentPassword, newPassword)
+
+  return new EmptyResponse({})
+}
+
+module.exports = changeWalletPassword

--- a/broker-daemon/broker-rpc/wallet-service/change-wallet-password.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/change-wallet-password.spec.js
@@ -1,0 +1,66 @@
+const path = require('path')
+const { expect, rewire, sinon } = require('test/test-helper')
+
+const changeWalletPassword = rewire(path.resolve(__dirname, 'change-wallet-password'))
+
+describe('change-wallet-password', () => {
+  let symbol
+  let currentPassword
+  let newPassword
+  let engines
+  let engine
+  let logger
+  let EmptyResponse
+  let params
+
+  beforeEach(() => {
+    currentPassword = 'current-password'
+    newPassword = 'my-password'
+    symbol = 'BTC'
+    engine = {
+      changeWalletPassword: sinon.stub(),
+      isLocked: true
+    }
+    engines = new Map([
+      ['BTC', engine]
+    ])
+    logger = {
+      error: sinon.stub()
+    }
+    params = {
+      symbol,
+      currentPassword,
+      newPassword
+    }
+    EmptyResponse = sinon.stub()
+  })
+
+  it('errors if engine could not be found', () => {
+    params.symbol = 'LTC'
+    return expect(changeWalletPassword({ logger, params, engines }, { EmptyResponse })).to.eventually.be.rejectedWith('Unable to unlock wallet')
+  })
+
+  it('logs an error if engine could not be found', async () => {
+    params.symbol = 'LTC'
+    try {
+      await changeWalletPassword({ logger, params, engines }, { EmptyResponse })
+    } catch (e) {
+      expect(logger.error).to.have.been.calledOnce()
+    }
+  })
+
+  it('errors if the wallet is not locked', () => {
+    engine.isLocked = false
+    return expect(changeWalletPassword({ logger, params, engines }, { EmptyResponse })).to.eventually.be.rejectedWith('Unable to change your wallet password')
+  })
+
+  it('changes a wallet password for a specific engine', async () => {
+    await changeWalletPassword({ logger, params, engines }, { EmptyResponse })
+    expect(engine.changeWalletPassword).to.have.been.calledWith(currentPassword, newPassword)
+  })
+
+  it('returns an empty response', async () => {
+    await changeWalletPassword({ logger, params, engines }, { EmptyResponse })
+    expect(EmptyResponse).to.have.been.calledOnce()
+  })
+})

--- a/broker-daemon/broker-rpc/wallet-service/change-wallet-password.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/change-wallet-password.spec.js
@@ -37,7 +37,7 @@ describe('change-wallet-password', () => {
 
   it('errors if engine could not be found', () => {
     params.symbol = 'LTC'
-    return expect(changeWalletPassword({ logger, params, engines }, { EmptyResponse })).to.eventually.be.rejectedWith('Unable to unlock wallet')
+    return expect(changeWalletPassword({ logger, params, engines }, { EmptyResponse })).to.eventually.be.rejectedWith('Unable to change wallet password')
   })
 
   it('logs an error if engine could not be found', async () => {

--- a/broker-daemon/broker-rpc/wallet-service/index.js
+++ b/broker-daemon/broker-rpc/wallet-service/index.js
@@ -11,6 +11,7 @@ const withdrawFunds = require('./withdraw-funds')
 const createWallet = require('./create-wallet')
 const unlockWallet = require('./unlock-wallet')
 const walletHistory = require('./wallet-history')
+const changeWalletPassword = require('./change-wallet-password')
 
 /**
  * WalletService provides interactions with an engine's crypto wallet
@@ -62,6 +63,7 @@ class WalletService {
       withdrawFunds: new GrpcUnaryMethod(withdrawFunds, this.messageId('withdrawFunds'), { logger, engines, auth }, { WithdrawFundsResponse }).register(),
       createWallet: new GrpcUnaryMethod(createWallet, this.messageId('createWallet'), { logger, engines, auth }, { CreateWalletResponse }).register(),
       unlockWallet: new GrpcUnaryMethod(unlockWallet, this.messageId('unlockWallet'), { logger, engines, auth }, { EmptyResponse }).register(),
+      changeWalletPassword: new GrpcUnaryMethod(changeWalletPassword, this.messageId('changeWalletPassword'), { logger, engines, auth }, { EmptyResponse }).register(),
       walletHistory: new GrpcUnaryMethod(walletHistory, this.messageId('walletHistory'), { logger, engines, auth }, { WalletHistoryResponse }).register()
     }
   }

--- a/broker-daemon/broker-rpc/wallet-service/index.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/index.spec.js
@@ -26,6 +26,7 @@ describe('WalletService', () => {
   let walletHistory
   let auth
   let blockOrderWorker
+  let changeWalletPassword
 
   before(() => {
     responseStub = sinon.stub()
@@ -62,6 +63,7 @@ describe('WalletService', () => {
     withdrawFunds = sinon.stub()
     createWallet = sinon.stub()
     unlockWallet = sinon.stub()
+    changeWalletPassword = sinon.stub()
     walletHistory = sinon.stub()
     balanceSpy = sinon.spy()
     commitSpy = sinon.spy()
@@ -81,6 +83,7 @@ describe('WalletService', () => {
     WalletService.__set__('withdrawFunds', withdrawFunds)
     WalletService.__set__('createWallet', createWallet)
     WalletService.__set__('unlockWallet', unlockWallet)
+    WalletService.__set__('changeWalletPassword', changeWalletPassword)
     WalletService.__set__('walletHistory', walletHistory)
 
     wallet = new WalletService(protoPath, { logger, engines, relayer, orderbooks, auth, blockOrderWorker })
@@ -188,6 +191,17 @@ describe('WalletService', () => {
 
       expect(unaryMethodStub).to.have.been.calledWith(
         unlockWallet,
+        expectedMessageId,
+        { logger, engines, auth },
+        { EmptyResponse: responseStub }
+      )
+    })
+
+    it('creates a unary method for changeWalletPassword', () => {
+      const expectedMessageId = '[WalletService:changeWalletPassword]'
+
+      expect(unaryMethodStub).to.have.been.calledWith(
+        changeWalletPassword,
         expectedMessageId,
         { logger, engines, auth },
         { EmptyResponse: responseStub }

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -1716,7 +1716,7 @@ message WalletHistoryResponse {
 }
 
 /**
- * Request to unlock a wallet for a specific currency
+ * Request to change a wallet password for a specific currency
  */
 message ChangeWalletPasswordRequest {
   // Currency of wallet
@@ -2173,18 +2173,17 @@ service WalletService {
   }
 
   /**
-   * UnlockWallet sends an unlock rpc command to the engine to allow funds to be used
-   * in the event that the broker has been taken offline -> online
+   * ChangeWalletPassword sends a change password rpc command to the engine which changes
+   * the wallet password for a specific currency and unlocks the engines on completion
    *
-   * This RPC will be required after every application restart, if each engine's wallet has been
-   * created. If you need to create a wallet for daemon, please refer to `CreateWallet`
+   * This RPC can only be used if the specified engine's wallet is locked.
    *
    * ```javascript
-   * await walletService.unlockWallet({ symbol: 'BTC', password: 'your-secure-password')
+   * await walletService.changeWalletPassword({ symbol: 'BTC', currentPassword: 'your-current-password', newPassword: 'your-new-secure-password')
    * ```
    *
    * ```shell
-   * > sparkswap wallet unlock BTC
+   * > sparkswap wallet change-password BTC
    * ```
    *
    * > The above command will print:
@@ -2194,7 +2193,7 @@ service WalletService {
    * ```
    *
    * ```shell
-   * Successfully Unlocked BTC Wallet!
+   * Successfully changed your BTC wallet password! Your wallet is now unlocked.
    * ```
    */
   rpc ChangeWalletPassword (ChangeWalletPasswordRequest) returns (google.protobuf.Empty) {

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -1716,6 +1716,18 @@ message WalletHistoryResponse {
 }
 
 /**
+ * Request to unlock a wallet for a specific currency
+ */
+message ChangeWalletPasswordRequest {
+  // Currency of wallet
+  string symbol = 1;
+  // Current password for the wallet
+  string current_password = 2;
+  // New password for the wallet
+  string new_password = 3;
+}
+
+/**
  * The WalletService is for interacting with the wallets managed by the Broker on behalf of the user.
  *
  * It is used primarily during set up (e.g. making deposits) of a Broker.
@@ -2157,6 +2169,38 @@ service WalletService {
   rpc WalletHistory (WalletHistoryRequest) returns (WalletHistoryResponse) {
     option (.google.api.http) = {
       get: "/v1/wallet/summary/{symbol}"
+    };
+  }
+
+  /**
+   * UnlockWallet sends an unlock rpc command to the engine to allow funds to be used
+   * in the event that the broker has been taken offline -> online
+   *
+   * This RPC will be required after every application restart, if each engine's wallet has been
+   * created. If you need to create a wallet for daemon, please refer to `CreateWallet`
+   *
+   * ```javascript
+   * await walletService.unlockWallet({ symbol: 'BTC', password: 'your-secure-password')
+   * ```
+   *
+   * ```shell
+   * > sparkswap wallet unlock BTC
+   * ```
+   *
+   * > The above command will print:
+   *
+   * ```javascript
+   * {}
+   * ```
+   *
+   * ```shell
+   * Successfully Unlocked BTC Wallet!
+   * ```
+   */
+  rpc ChangeWalletPassword (ChangeWalletPasswordRequest) returns (google.protobuf.Empty) {
+    option (.google.api.http) = {
+      post: "/v1/wallet/change-password"
+      body: "*"
     };
   }
 }


### PR DESCRIPTION
## Description
This PR adds a `sparkswap wallet change-password <symbol>` command to allow the user to change the passwords for a given wallet.

Related PR: https://github.com/sparkswap/lnd-engine/pull/209 (already merged and version is bumped in broker)

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
