### PR TITLE
add DEBUG env for log levels

### DIFF
--- a/broker-daemon/utils/logger.js
+++ b/broker-daemon/utils/logger.js
@@ -50,7 +50,7 @@ function createLogger () {
   })
 
   const logger = winston.createLogger({
-    level: (process.env.NODE_ENV === 'production') ? 'info' : 'debug',
+    level: process.env.DEBUG || 'info',
     format: winston.format.combine(
       filterSensitive(),
       winston.format.timestamp(),

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -21,6 +21,7 @@ services:
       - './broker-cli/scripts:/home/app/broker-cli/scripts'
       - './broker-cli/utils:/home/app/broker-cli/utils'
     environment:
+      - DEBUG=debug
       - NODE_ENV=development
     # We use this to be able to have "hot reloading" with our application
     entrypoint: bash -c 'npm run start-sparkswapd-watch'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       # Persistent certs/keys for broker
       - '${SECURE_PATH}:/secure'
     environment:
+      - DEBUG=info
       - NODE_ENV=production
       - DATA_DIR=${DATA_DIR:-}
       - NETWORK=${NETWORK}


### PR DESCRIPTION
## Description
This PR removes the tie between `NODE_ENV` and our log levels and allows us to set the log levels of the broker daemon through the `DEBUG` environment variable.

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
