### PR TITLE
FEATURE - Order summary filters

### DIFF
--- a/broker-cli/commands/order/index.js
+++ b/broker-cli/commands/order/index.js
@@ -32,11 +32,28 @@ module.exports = (program) => {
     .help(`Available Commands: ${Object.values(SUPPORTED_COMMANDS).join(', ')}`)
     .argument('<command>', '', Object.values(SUPPORTED_COMMANDS), null, true)
     .argument('[sub-arguments...]')
-    .option('--market [marketName]', MARKET_NAME_HELP_STRING, validations.isMarketName)
+    .option('--market <marketName>', MARKET_NAME_HELP_STRING, validations.isMarketName, null, true)
+    .option('--limit [limit]', 'Limit of records returned from summary', program.INT)
+    .option('--active', 'Only return active records from summary', program.BOOL)
+    .option('--cancelled', 'Only return cancelled records from summary', program.BOOL)
+    .option('--completed', 'Only return completed records from summary', program.BOOL)
+    .option('--failed', 'Only return failed records from summary', program.BOOL)
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING, validations.isHost)
     .action(async (args, opts, logger) => {
-      const { command, subArguments } = args
-      const { market } = opts
+      const {
+        command,
+        subArguments
+      } = args
+
+      const {
+        market,
+        limit,
+        active,
+        cancelled,
+        completed,
+        failed
+      } = opts
+
       let blockOrderId
 
       switch (command) {
@@ -54,7 +71,14 @@ module.exports = (program) => {
           return cancel(args, opts, logger)
 
         case SUPPORTED_COMMANDS.SUMMARY:
-          opts.market = validations.isMarketName(market)
+          args.market = validations.isMarketName(market)
+          opts = {
+            limit,
+            active,
+            cancelled,
+            completed,
+            failed
+          }
           return summary(args, opts, logger)
 
         case SUPPORTED_COMMANDS.CANCEL_ALL:
@@ -67,6 +91,11 @@ module.exports = (program) => {
     })
     .command(`order ${SUPPORTED_COMMANDS.SUMMARY}`, 'View your orders')
     .option('--market <marketName>', MARKET_NAME_HELP_STRING, validations.isMarketName, null, true)
+    .option('--limit [limit]', 'Limit of records returned from summary', program.INT)
+    .option('--active [active]', 'Only return active records from summary', program.BOOL)
+    .option('--cancelled [cancelled]', 'Only return cancelled records from summary', program.BOOL)
+    .option('--completed [completed]', 'Only return completed records from summary', program.BOOL)
+    .option('--failed [failed]', 'Only return failed records from summary', program.BOOL)
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING, validations.isHost)
     .command(`order ${SUPPORTED_COMMANDS.STATUS}`, 'Get the status of a block order')
     .argument('<blockOrderId>', 'Block order to get status of', validations.isBlockOrderId)

--- a/broker-cli/commands/order/index.js
+++ b/broker-cli/commands/order/index.js
@@ -71,8 +71,8 @@ module.exports = (program) => {
           return cancel(args, opts, logger)
 
         case SUPPORTED_COMMANDS.SUMMARY:
-          args.market = validations.isMarketName(market)
           opts = {
+            market: validations.isMarketName(market),
             limit,
             active,
             cancelled,

--- a/broker-cli/commands/order/summary.js
+++ b/broker-cli/commands/order/summary.js
@@ -64,9 +64,8 @@ function createUI (market, orders) {
  * @param {Logger} logger
  */
 async function summary (args, opts, logger) {
-  const { market } = args
-
   const {
+    market,
     limit,
     active,
     cancelled,

--- a/broker-cli/commands/order/summary.js
+++ b/broker-cli/commands/order/summary.js
@@ -12,6 +12,14 @@ const {
 const BrokerDaemonClient = require('../../broker-daemon-client')
 
 /**
+ * Custom deadline for order summary at 30 seconds
+ * @constant
+ * @type {number}
+ * @default
+ */
+const ORDER_SUMMARY_RPC_DEADLINE = 30
+
+/**
  * Prints table of the users orders
  * @param {string} market
  * @param {Array<Order>} orders
@@ -81,11 +89,9 @@ async function summary (args, opts, logger) {
   try {
     const brokerDaemonClient = new BrokerDaemonClient(rpcAddress)
 
-    console.log(request)
-
     // We extend the gRPC deadline of this call because there's a possibility to return
-    // a lot of records from the endpoint
-    const orders = await brokerDaemonClient.orderService.getBlockOrders(request, { deadline: grpcDeadline(30) })
+    // a lot of records from the endpoint.
+    const orders = await brokerDaemonClient.orderService.getBlockOrders(request, { deadline: grpcDeadline(ORDER_SUMMARY_RPC_DEADLINE) })
     createUI(market, orders.blockOrders)
   } catch (e) {
     logger.error(handleError(e))

--- a/broker-cli/commands/order/summary.spec.js
+++ b/broker-cli/commands/order/summary.spec.js
@@ -29,8 +29,9 @@ describe('summary', () => {
   beforeEach(() => {
     rpcAddress = undefined
     market = 'BTC/LTC'
-    args = { market }
+    args = {}
     opts = {
+      market,
       limit: undefined,
       active: false,
       cancelled: false,
@@ -73,6 +74,7 @@ describe('summary', () => {
   it('makes a request to the broker', async () => {
     const expectedOptions = Object.assign({}, opts)
     delete expectedOptions.rpcAddress
+    delete expectedOptions.market
     await summary(args, opts, logger)
     expect(getBlockOrdersStub).to.have.been.calledWith(sinon.match({ market, options: expectedOptions }), sinon.match.object)
   })

--- a/broker-cli/commands/order/summary.spec.js
+++ b/broker-cli/commands/order/summary.spec.js
@@ -29,8 +29,15 @@ describe('summary', () => {
   beforeEach(() => {
     rpcAddress = undefined
     market = 'BTC/LTC'
-    args = {}
-    opts = { market, rpcAddress }
+    args = { market }
+    opts = {
+      limit: undefined,
+      active: false,
+      cancelled: false,
+      completed: false,
+      failed: false,
+      rpcAddress
+    }
     infoSpy = sinon.spy()
     errorSpy = sinon.spy()
     order = {
@@ -64,8 +71,10 @@ describe('summary', () => {
   })
 
   it('makes a request to the broker', async () => {
+    const expectedOptions = Object.assign({}, opts)
+    delete expectedOptions.rpcAddress
     await summary(args, opts, logger)
-    expect(getBlockOrdersStub).to.have.been.calledWith({ market })
+    expect(getBlockOrdersStub).to.have.been.calledWith(sinon.match({ market, options: expectedOptions }), sinon.match.object)
   })
 
   it('adds orders to the table', async () => {

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -589,13 +589,11 @@ message GetBlockOrdersResponse {
 
 /**
  * Request to retrieve all block orders in a given market.
- * This rpc returns a max record count of 1000 due to transport limits of grpc. Please
- * see `options`
  */
 message GetBlockOrdersRequest {
   message GetBlockOrderOptions {
-    // Limit for the amount of records that are returned. Records will be returned in
-    // ascending order
+    // Limit for the amount of records that are returned. Records will be returned by date in
+    // descending order (newest records first)
     int32 limit = 1;
     // Only return active orders
     bool active = 2;

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -832,7 +832,7 @@ service OrderService {
    *
    * ```javascript
    * const deadline = new Date().setSeconds(new Date().getSeconds() + 5)
-   * orderService.getBlockOrders({ market: 'BTC/LTC' }, { deadline }, (err, { blockOrders }) => {
+   * orderService.getBlockOrders({ market: 'BTC/LTC', options: {} }, { deadline }, (err, { blockOrders }) => {
    *   if (err) return console.error(err)
    *   console.log(blockOrders)
    * })
@@ -886,6 +886,21 @@ service OrderService {
    * │ XLEeQPNXsyJ3_MsV   │ ACTIVE   │ BID      │ 0.00010000000 │ 60.00000000000 │ GTC      │ 2019-04-12T23:24:48.621Z │
    * └────────────────────┴──────────┴──────────┴───────────────┴────────────────┴──────────┴──────────────────────────┘
    * ```
+   *
+   * Additionally, you can specify options to return a subset of records using the following:
+   *
+   * Only return the first 20 records
+   * ```
+   * sparkswap order summary --market btc/ltc --limit 20
+   * ```
+   *
+   * Only return the first 20 active records
+   * ```
+   * sparkswap order summary --market btc/ltc --limit 20 --active
+   * ```
+   *
+   * For all available options, use the command `sparkswap order summary -h`
+   *
    */
   rpc GetBlockOrders (GetBlockOrdersRequest) returns (GetBlockOrdersResponse) {
     option (.google.api.http) = {

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -589,10 +589,29 @@ message GetBlockOrdersResponse {
 
 /**
  * Request to retrieve all block orders in a given market.
+ * This rpc returns a max record count of 1000 due to transport limits of grpc. Please
+ * see `options`
  */
 message GetBlockOrdersRequest {
+  message GetBlockOrderOptions {
+    // Limit for the amount of records that are returned. Records will be returned in
+    // ascending order
+    int32 limit = 1;
+    // Only return active orders
+    bool active = 2;
+    // Only return cancelled orders
+    bool cancelled = 3;
+    // Only return completed orders
+    bool completed = 4;
+    // Only return failed orders
+    bool failed = 5;
+  }
+
   // Market for which to retrieve block orders, expressed as a string separating two common symbols with a '/', e.g. `'BTC/LTC'`
   string market = 1;
+
+  // Query options for GetBlockOrdersRequest
+  GetBlockOrderOptions options = 2;
 }
 
 /**

--- a/broker-cli/utils/index.js
+++ b/broker-cli/utils/index.js
@@ -6,6 +6,7 @@ const Big = require('./big')
 const handleError = require('./error-handler')
 const basicAuth = require('./basic-auth')
 const grpcDeadlineInterceptor = require('./grpc-deadline-interceptor')
+const grpcDeadline = require('./grpc-deadline')
 
 module.exports = {
   ENUMS,
@@ -15,5 +16,6 @@ module.exports = {
   Big,
   handleError,
   basicAuth,
-  grpcDeadlineInterceptor
+  grpcDeadlineInterceptor,
+  grpcDeadline
 }

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -441,7 +441,8 @@ class BlockOrderWorker extends EventEmitter {
     const allRecords = await getRecords(this.store, BlockOrder.fromStorage.bind(BlockOrder))
     const recordsForMarket = allRecords.filter((record) => record.marketName === market)
 
-    let result = []
+    // Set our filter types to be used when we filter the records for a particular
+    // market
     const statusFilters = []
 
     if (options.active) statusFilters.push(BlockOrder.STATUSES.ACTIVE)
@@ -449,17 +450,14 @@ class BlockOrderWorker extends EventEmitter {
     if (options.completed) statusFilters.push(BlockOrder.STATUSES.COMPLETED)
     if (options.failed) statusFilters.push(BlockOrder.STATUSES.FAILED)
 
-    // Once we have all the records for a market, we will start to filter them out into
-    // a single result
-    result.push(...recordsForMarket.filter((r) => {
-      if (statusFilters.length) {
-        return statusFilters.includes(r.status)
-      }
-
+    let result = recordsForMarket.filter((r) => {
+      if (statusFilters.length) return statusFilters.includes(r.status)
       // If there are no filters then we just return all the records into the result
       return true
-    }))
+    })
 
+    // If the limit is set and does not equal zero, then we modify the result to
+    // only return a certain amount of records
     if (options.limit) {
       result = result.slice(0, options.limit)
     }

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -2461,7 +2461,7 @@ describe('BlockOrderWorker', () => {
       await worker.getBlockOrders(market)
 
       expect(getRecords).to.have.been.calledOnce()
-      expect(getRecords).to.have.been.calledWith(store, BlockOrder.fromStorage.bind(BlockOrder))
+      expect(getRecords).to.have.been.calledWith(store, BlockOrder.fromStorage.bind(BlockOrder), { limit: -1, reverse: true })
     })
 
     it('filters the block orders by market', async () => {
@@ -2470,8 +2470,8 @@ describe('BlockOrderWorker', () => {
     })
 
     it('limits the records returned', async () => {
-      const res = await worker.getBlockOrders(market, { limit: 2 })
-      expect(res.length).to.eql(2)
+      await worker.getBlockOrders(market, { limit: 2 })
+      expect(getRecords).to.have.been.calledWith(store, BlockOrder.fromStorage.bind(BlockOrder), { limit: 2, reverse: true })
     })
 
     it('filters block orders by active status', async () => {

--- a/broker-daemon/broker-rpc/order-service/get-block-orders.js
+++ b/broker-daemon/broker-rpc/order-service/get-block-orders.js
@@ -13,26 +13,18 @@ async function getBlockOrders ({ params, logger, blockOrderWorker }, { GetBlockO
   let { options } = params
 
   // If no options are passed, then we'll make sure to default the options arg to
-  // an empty object to avoid destructuring issues
+  // an empty object to accessor issues
   if (!options) {
     options = {}
   }
 
-  const {
-    limit,
-    active,
-    cancelled,
-    completed,
-    failed
-  } = options
-
-  // We re-construct our query options to get rid of undefined values
+  // We re-construct our query options to get rid of values that we dont know about
   const queryOptions = {
-    limit,
-    active,
-    cancelled,
-    completed,
-    failed
+    limit: options.limit,
+    active: options.active,
+    cancelled: options.cancelled,
+    completed: options.completed,
+    failed: options.failed
   }
 
   try {

--- a/broker-daemon/broker-rpc/order-service/get-block-orders.js
+++ b/broker-daemon/broker-rpc/order-service/get-block-orders.js
@@ -11,8 +11,12 @@
  */
 async function getBlockOrders ({ params, logger, blockOrderWorker }, { GetBlockOrdersResponse }) {
   try {
+    logger.info(new Date())
     const orders = await blockOrderWorker.getBlockOrders(params.market)
+    logger.info(new Date())
     const blockOrders = orders.map(order => order.serializeSummary())
+    logger.info(`Block order length: ${blockOrders.length}`)
+
     // The gRPC constructor does not serialize block orders correctly, so we instead
     // return an object.
     return { blockOrders }

--- a/broker-daemon/broker-rpc/order-service/get-block-orders.js
+++ b/broker-daemon/broker-rpc/order-service/get-block-orders.js
@@ -10,10 +10,36 @@
  * @returns {GetBlockOrdersResponse}
  */
 async function getBlockOrders ({ params, logger, blockOrderWorker }, { GetBlockOrdersResponse }) {
+  let { options } = params
+
+  // If no options are passed, then we'll make sure to default the options arg to
+  // an empty object to avoid destructuring issues
+  if (!options) {
+    options = {}
+  }
+
+  const {
+    limit,
+    active,
+    cancelled,
+    completed,
+    failed
+  } = options
+
+  // We re-construct our query options to get rid of undefined values
+  const queryOptions = {
+    limit,
+    active,
+    cancelled,
+    completed,
+    failed
+  }
+
   try {
-    logger.info(new Date())
-    const orders = await blockOrderWorker.getBlockOrders(params.market)
-    logger.info(new Date())
+    logger.info('Getting all block orders', { startTime: new Date(), queryOptions })
+    const orders = await blockOrderWorker.getBlockOrders(params.market, queryOptions)
+    logger.info('Finished getting block orders', { endTime: new Date() })
+
     const blockOrders = orders.map(order => order.serializeSummary())
     logger.info(`Block order length: ${blockOrders.length}`)
 

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -589,13 +589,11 @@ message GetBlockOrdersResponse {
 
 /**
  * Request to retrieve all block orders in a given market.
- * This rpc returns a max record count of 1000 due to transport limits of grpc. Please
- * see `options`
  */
 message GetBlockOrdersRequest {
   message GetBlockOrderOptions {
-    // Limit for the amount of records that are returned. Records will be returned in
-    // ascending order
+    // Limit for the amount of records that are returned. Records will be returned by date in
+    // descending order (newest records first)
     int32 limit = 1;
     // Only return active orders
     bool active = 2;

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -832,7 +832,7 @@ service OrderService {
    *
    * ```javascript
    * const deadline = new Date().setSeconds(new Date().getSeconds() + 5)
-   * orderService.getBlockOrders({ market: 'BTC/LTC' }, { deadline }, (err, { blockOrders }) => {
+   * orderService.getBlockOrders({ market: 'BTC/LTC', options: {} }, { deadline }, (err, { blockOrders }) => {
    *   if (err) return console.error(err)
    *   console.log(blockOrders)
    * })
@@ -886,6 +886,21 @@ service OrderService {
    * │ XLEeQPNXsyJ3_MsV   │ ACTIVE   │ BID      │ 0.00010000000 │ 60.00000000000 │ GTC      │ 2019-04-12T23:24:48.621Z │
    * └────────────────────┴──────────┴──────────┴───────────────┴────────────────┴──────────┴──────────────────────────┘
    * ```
+   *
+   * Additionally, you can specify options to return a subset of records using the following:
+   *
+   * Only return the first 20 records
+   * ```
+   * sparkswap order summary --market btc/ltc --limit 20
+   * ```
+   *
+   * Only return the first 20 active records
+   * ```
+   * sparkswap order summary --market btc/ltc --limit 20 --active
+   * ```
+   *
+   * For all available options, use the command `sparkswap order summary -h`
+   *
    */
   rpc GetBlockOrders (GetBlockOrdersRequest) returns (GetBlockOrdersResponse) {
     option (.google.api.http) = {

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -589,10 +589,29 @@ message GetBlockOrdersResponse {
 
 /**
  * Request to retrieve all block orders in a given market.
+ * This rpc returns a max record count of 1000 due to transport limits of grpc. Please
+ * see `options`
  */
 message GetBlockOrdersRequest {
+  message GetBlockOrderOptions {
+    // Limit for the amount of records that are returned. Records will be returned in
+    // ascending order
+    int32 limit = 1;
+    // Only return active orders
+    bool active = 2;
+    // Only return cancelled orders
+    bool cancelled = 3;
+    // Only return completed orders
+    bool completed = 4;
+    // Only return failed orders
+    bool failed = 5;
+  }
+
   // Market for which to retrieve block orders, expressed as a string separating two common symbols with a '/', e.g. `'BTC/LTC'`
   string market = 1;
+
+  // Query options for GetBlockOrdersRequest
+  GetBlockOrderOptions options = 2;
 }
 
 /**


### PR DESCRIPTION
## Description
This PR adds the following filters to the `sparkswap order summary --market <market>` command.

- `--limit` - limit the number of records returned from the query (newest orders will be on top)
- `--active` - all active orders
- `--cancelled` - all cancelled orders
- `--completed` - all completed orders
- `--failed` - all failed orders

Additionally, this PR increases the rpc deadline from 5 seconds, to 30 seconds due to the amount of time needed if the broker is returning > 20,000 records

![Screen Shot 2019-05-14 at 11 42 25 AM](https://user-images.githubusercontent.com/5478311/57723431-733d7180-763d-11e9-846a-b632a35acf4b.png)

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
