### PR TITLE
Feature - JSON exports for accounting features

### DIFF
--- a/broker-cli/commands/order/index.js
+++ b/broker-cli/commands/order/index.js
@@ -38,7 +38,7 @@ module.exports = (program) => {
     .option('--cancelled', 'Only return cancelled records from summary', program.BOOL)
     .option('--completed', 'Only return completed records from summary', program.BOOL)
     .option('--failed', 'Only return failed records from summary', program.BOOL)
-    .option('--json', 'Export command result as json', program.BOOL)
+    .option('--json', 'Export result as json', program.BOOL, false)
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING, validations.isHost)
     .action(async (args, opts, logger) => {
       const {
@@ -102,6 +102,6 @@ module.exports = (program) => {
     .option('--market <marketName>', MARKET_NAME_HELP_STRING, validations.isMarketName, null, true)
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING, validations.isHost)
     .command(`order ${SUPPORTED_COMMANDS.TRADE_HISTORY}`, 'Get information about completed and processing trades')
-    .option('--json [json]', 'Export command result as json')
+    .option('--json', 'Export result as json')
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING)
 }

--- a/broker-cli/commands/order/index.js
+++ b/broker-cli/commands/order/index.js
@@ -38,21 +38,13 @@ module.exports = (program) => {
     .option('--cancelled', 'Only return cancelled records from summary', program.BOOL)
     .option('--completed', 'Only return completed records from summary', program.BOOL)
     .option('--failed', 'Only return failed records from summary', program.BOOL)
+    .option('--json', 'Export command result as json', program.BOOL)
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING, validations.isHost)
     .action(async (args, opts, logger) => {
       const {
         command,
         subArguments
       } = args
-
-      const {
-        market,
-        limit,
-        active,
-        cancelled,
-        completed,
-        failed
-      } = opts
 
       let blockOrderId
 
@@ -72,17 +64,18 @@ module.exports = (program) => {
 
         case SUPPORTED_COMMANDS.SUMMARY:
           opts = {
-            market: validations.isMarketName(market),
-            limit,
-            active,
-            cancelled,
-            completed,
-            failed
+            market: validations.isMarketName(opts.market),
+            limit: opts.limit,
+            active: opts.active,
+            cancelled: opts.cancelled,
+            completed: opts.completed,
+            failed: opts.failed,
+            json: opts.json
           }
           return summary(args, opts, logger)
 
         case SUPPORTED_COMMANDS.CANCEL_ALL:
-          opts.market = validations.isMarketName(market)
+          opts.market = validations.isMarketName(opts.market)
           return cancelAll(args, opts, logger)
 
         case SUPPORTED_COMMANDS.TRADE_HISTORY:
@@ -109,5 +102,6 @@ module.exports = (program) => {
     .option('--market <marketName>', MARKET_NAME_HELP_STRING, validations.isMarketName, null, true)
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING, validations.isHost)
     .command(`order ${SUPPORTED_COMMANDS.TRADE_HISTORY}`, 'Get information about completed and processing trades')
-    .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING, validations.isHost)
+    .option('--json [json]', 'Export command result as json')
+    .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING)
 }

--- a/broker-cli/commands/order/summary.js
+++ b/broker-cli/commands/order/summary.js
@@ -23,7 +23,7 @@ const ORDER_SUMMARY_RPC_DEADLINE = 30
  * Prints table of the users orders
  * @param {string} market
  * @param {Array<Order>} orders
- * @returns {void}
+ * @returns {string} ui for summary
  */
 function createUI (market, orders) {
   const windowWidth = size.get().width
@@ -49,7 +49,7 @@ function createUI (market, orders) {
   })
 
   ui.push(orderTable.toString())
-  console.log(ui.join('\n') + '\n')
+  return ui.join('\n') + '\n'
 }
 
 /**
@@ -98,7 +98,8 @@ async function summary (args, opts, logger) {
       return logger.info(JSON.stringify(orders.blockOrders, null, 2))
     }
 
-    createUI(market, orders.blockOrders)
+    const summary = createUI(market, orders.blockOrders)
+    logger.info(summary)
   } catch (e) {
     logger.error(handleError(e))
   }

--- a/broker-cli/commands/order/summary.js
+++ b/broker-cli/commands/order/summary.js
@@ -71,6 +71,7 @@ async function summary (args, opts, logger) {
     cancelled,
     completed,
     failed,
+    json,
     rpcAddress
   } = opts
 
@@ -91,6 +92,11 @@ async function summary (args, opts, logger) {
     // We extend the gRPC deadline of this call because there's a possibility to return
     // a lot of records from the endpoint.
     const orders = await brokerDaemonClient.orderService.getBlockOrders(request, { deadline: grpcDeadline(ORDER_SUMMARY_RPC_DEADLINE) })
+
+    if (json) {
+      return logger.info(JSON.stringify(orders.blockOrders, null, 2))
+    }
+
     createUI(market, orders.blockOrders)
   } catch (e) {
     logger.error(handleError(e))

--- a/broker-cli/commands/order/summary.js
+++ b/broker-cli/commands/order/summary.js
@@ -62,6 +62,7 @@ function createUI (market, orders) {
  * @param {string} opts.market
  * @param {string} opts.rpcaddress
  * @param {Logger} logger
+ * @returns {void}
  */
 async function summary (args, opts, logger) {
   const {

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -624,7 +624,7 @@ module.exports = (program) => {
     .option('--wallet-address [address]', 'used in sparkswap withdraw ONLY')
     .option('--reserved', 'Display total reserved balance')
     .option('--force', 'Force close all channels. This options is only used in the sparkswap release command', null, false)
-    .option('--json [json]', 'export result of command as json', null, false)
+    .option('--json', 'Export result as json', program.BOOL, false)
     .action(async (args, opts, logger) => {
       const { command, subArguments } = args
       const { market } = opts
@@ -765,6 +765,6 @@ module.exports = (program) => {
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING)
     .command(`wallet ${SUPPORTED_COMMANDS.HISTORY}`, 'Transaction History of a wallet')
     .argument('<symbol>', `Supported currencies: ${SUPPORTED_SYMBOLS.join('/')}`)
-    .option('--json [json]', 'export result of command as json')
+    .option('--json', 'Export result as json')
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING)
 }

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -544,7 +544,7 @@ async function unlock (args, opts, logger) {
  */
 async function history (args, opts, logger) {
   const { symbol } = args
-  const { rpcAddress } = opts
+  const { rpcAddress, json } = opts
 
   try {
     const client = new BrokerDaemonClient(rpcAddress)
@@ -559,6 +559,10 @@ async function history (args, opts, logger) {
       head: ['Type', 'Amount', 'Fees', 'Timestamp', 'Transaction', 'Height', 'Pending'],
       style: { head: ['gray'] }
     })
+
+    if (json) {
+      return logger.info(JSON.stringify(transactions, null, 2))
+    }
 
     transactions.forEach(({ type, amount, fees, timestamp, transactionHash, blockHeight, pending }) => {
       transactionTable.push([type, amount, fees, timestamp, transactionHash, blockHeight, pending])
@@ -620,6 +624,7 @@ module.exports = (program) => {
     .option('--wallet-address [address]', 'used in sparkswap withdraw ONLY')
     .option('--reserved', 'Display total reserved balance')
     .option('--force', 'Force close all channels. This options is only used in the sparkswap release command', null, false)
+    .option('--json [json]', 'export result of command as json', null, false)
     .action(async (args, opts, logger) => {
       const { command, subArguments } = args
       const { market } = opts
@@ -760,5 +765,6 @@ module.exports = (program) => {
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING)
     .command(`wallet ${SUPPORTED_COMMANDS.HISTORY}`, 'Transaction History of a wallet')
     .argument('<symbol>', `Supported currencies: ${SUPPORTED_SYMBOLS.join('/')}`)
+    .option('--json [json]', 'export result of command as json')
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING)
 }

--- a/broker-cli/commands/wallet.spec.js
+++ b/broker-cli/commands/wallet.spec.js
@@ -914,16 +914,14 @@ describe('cli wallet', () => {
     let symbol
     let walletServiceStub
     let transactions
-    let jsonStub
     let reverts
+    let tablePushStub
+    let tableStub
 
     const history = program.__get__('history')
 
     beforeEach(() => {
       reverts = []
-      jsonStub = {
-        stringify: sinon.stub()
-      }
       transactions = [{
         type: 'mytype',
         amount: '10000',
@@ -933,6 +931,9 @@ describe('cli wallet', () => {
         blockHeight: '1337',
         pending: false
       }]
+      tablePushStub = sinon.stub()
+      tableStub = sinon.stub()
+      tableStub.prototype.push = tablePushStub
       walletServiceStub = {
         walletService: {
           walletHistory: sinon.stub().resolves({ transactions })
@@ -950,26 +951,26 @@ describe('cli wallet', () => {
       }
 
       reverts.push(program.__set__('BrokerDaemonClient', daemonStub))
-    })
-
-    beforeEach(async () => {
-      await history(args, opts, logger)
+      reverts.push(program.__set__('Table', tableStub))
     })
 
     afterEach(() => {
       reverts.forEach(r => r())
     })
 
-    it('create a broker daemon client', () => {
+    it('create a broker daemon client', async () => {
+      await history(args, opts, logger)
       expect(daemonStub).to.have.been.calledOnce()
     })
 
-    it('makes a call to walletHistory', () => {
+    it('makes a call to walletHistory', async () => {
+      await history(args, opts, logger)
       expect(walletServiceStub.walletService.walletHistory).to.have.been.calledWith({ symbol })
     })
 
-    it('prints a table of transactions', () => {
-      const table = logger.info.args[1][0]
+    it.only('prints a table of transactions', async () => {
+      await history(args, opts, logger)
+      const table = tablePushStub.args[0][0]
       expect(table).to.include(transactions[0].type)
       expect(table).to.include(transactions[0].amount)
       expect(table).to.include(transactions[0].fees)
@@ -980,10 +981,14 @@ describe('cli wallet', () => {
     })
 
     it('exports transactions as json if option is specified', async () => {
+      const jsonStub = { stringify: sinon.stub() }
       reverts.push(program.__set__('JSON', jsonStub))
       opts.json = true
+
       await history(args, opts, logger)
+
       expect(jsonStub.stringify).to.have.been.calledWith(transactions)
+      expect(tablePushStub).to.not.have.been.called()
     })
   })
 })

--- a/broker-cli/commands/wallet.spec.js
+++ b/broker-cli/commands/wallet.spec.js
@@ -914,11 +914,16 @@ describe('cli wallet', () => {
     let symbol
     let walletServiceStub
     let transactions
-    let revert
+    let jsonStub
+    let reverts
 
     const history = program.__get__('history')
 
     beforeEach(() => {
+      reverts = []
+      jsonStub = {
+        stringify: sinon.stub()
+      }
       transactions = [{
         type: 'mytype',
         amount: '10000',
@@ -944,7 +949,7 @@ describe('cli wallet', () => {
         error: sinon.stub()
       }
 
-      revert = program.__set__('BrokerDaemonClient', daemonStub)
+      reverts.push(program.__set__('BrokerDaemonClient', daemonStub))
     })
 
     beforeEach(async () => {
@@ -952,7 +957,7 @@ describe('cli wallet', () => {
     })
 
     afterEach(() => {
-      revert()
+      reverts.forEach(r => r())
     })
 
     it('create a broker daemon client', () => {
@@ -972,6 +977,13 @@ describe('cli wallet', () => {
       expect(table).to.include(transactions[0].transactionHash)
       expect(table).to.include(transactions[0].blockHeight)
       expect(table).to.include(transactions[0].pending)
+    })
+
+    it('exports transactions as json if option is specified', async () => {
+      reverts.push(program.__set__('JSON', jsonStub))
+      opts.json = true
+      await history(args, opts, logger)
+      expect(jsonStub.stringify).to.have.been.calledWith(transactions)
     })
   })
 })

--- a/broker-cli/commands/wallet.spec.js
+++ b/broker-cli/commands/wallet.spec.js
@@ -968,7 +968,7 @@ describe('cli wallet', () => {
       expect(walletServiceStub.walletService.walletHistory).to.have.been.calledWith({ symbol })
     })
 
-    it.only('prints a table of transactions', async () => {
+    it('prints a table of transactions', async () => {
       await history(args, opts, logger)
       const table = tablePushStub.args[0][0]
       expect(table).to.include(transactions[0].type)


### PR DESCRIPTION
## Description
This PR adds a `--json` flag to the `order summary` and `wallet history` commands on the CLI to allow for easier accounting on the broker.

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
