### PR TITLE
Fix - Broker proto enum validations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,19 @@ jobs:
     steps:
       - checkout
 
+      # We need to update image packages for the time being or else the update
+      # and installation of protoc will fail.
+      #
+      # This can be removed once 8.11-jessie has resolved the issue (or we move to another node version)
+      - run: printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+
+      # Install the protoc binary to allow us to test proto files in later steps
+      - run: apt-get update && apt-get install unzip
+      - run: curl -L https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protoc-3.7.1-linux-x86_64.zip >> ./protoc.zip
+      - run: rm -rf ./protoc && mkdir -p ./protoc && ls -la ./ && unzip ./protoc.zip -d ./protoc
+      - run: cp -vr ./protoc/include /usr/local/include/
+      - run: echo 'export PATH=./protoc/bin:$PATH' >> $BASH_ENV
+
       # Make sure we are on atleast v6 npm
       - run: npm i -g npm@6
 
@@ -29,8 +42,11 @@ jobs:
             - node_modules
           key: v3-dependencies-{{ checksum "package.json" }}
 
-      # This checks if the broker proto files are valid during our CI run
+      # This checks if the broker proto files are valid through protobufjs during our CI run
       - run: npm run broker-proto
+
+      # This checks if our proto files are valid for other languages
+      - run: npm run validate-proto
 
       - run: npm run ci-test
   publish-cli:

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ typings/
 
 # Mac
 .DS_Store
+
+# Temp proto folder used for validating our proto files
+./proto-temp

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -1725,11 +1725,11 @@ message WalletHistoryRequest {
  */
 message WalletHistoryResponse {
   enum TransactionType {
+    UNKNOWN = 0;
     CHANNEL_CLOSE = 1;
     CHANNEL_OPEN = 2;
     DEPOSIT = 3;
     WITHDRAW = 4;
-    UNKNOWN = 10;
   }
 
   message Transaction {

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -1725,11 +1725,11 @@ message WalletHistoryRequest {
  */
 message WalletHistoryResponse {
   enum TransactionType {
+    UNKNOWN = 0;
     CHANNEL_CLOSE = 1;
     CHANNEL_OPEN = 2;
     DEPOSIT = 3;
     WITHDRAW = 4;
-    UNKNOWN = 10;
   }
 
   message Transaction {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "start-sparkswapd-watch": "pm2-docker pm2.json --watch",
     "validate-config": "eslint ~/.sparkswap/config.js --ext .js --max-warnings=0 --no-ignore -c ./.eslintrc",
     "broker-proto": "pbjs -t proto3 broker.proto -p ./broker-daemon/proto -o /dev/null && cp -r ./broker-daemon/proto/ ./broker-cli/proto/",
+    "validate-proto": "mkdir ./proto-tmp && protoc --proto_path=./broker-daemon/proto --proto_path=./broker-daemon/proto/google/api ./broker-daemon/proto/broker.proto --js_out ./proto-tmp && rm -rf ./proto-tmp",
     "check-for-cycles": "madge --circular broker-daemon/",
     "check-unused": "node ./scripts/check-unused.js",
     "env-setup": "bash ./scripts/env-setup.sh"


### PR DESCRIPTION
## Description
This PR fixes `broker.proto` where we had forgotten to add a `0` index to the `TransactionType` enum. This PR also adds a circleci hook that will compile our proto files with `protoc` to ensure that CI catches any issues like this in the future

**Changes**
1. fix broker.proto for bad enum change
2. add `protoc` check to circleci

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
