### PR TITLE
Fix/network status slow

### DIFF
--- a/broker-cli/commands/order/summary.js
+++ b/broker-cli/commands/order/summary.js
@@ -92,7 +92,7 @@ async function summary (args, opts, logger) {
 
     // We extend the gRPC deadline of this call because there's a possibility to return
     // a lot of records from the endpoint.
-    const orders = await brokerDaemonClient.orderService.getBlockOrders(request, { deadline: grpcDeadline(ORDER_SUMMARY_RPC_DEADLINE) })
+    const orders = await brokerDaemonClient.orderService.getBlockOrders(request, null, { deadline: grpcDeadline(ORDER_SUMMARY_RPC_DEADLINE) })
 
     if (json) {
       return logger.info(JSON.stringify(orders.blockOrders, null, 2))

--- a/broker-cli/commands/order/summary.spec.js
+++ b/broker-cli/commands/order/summary.spec.js
@@ -23,10 +23,14 @@ describe('summary', () => {
   let instanceTableStub
   let jsonStub
   let reverts
+  let deadline
+  let grpcDeadlineStub
 
   const summary = program.__get__('summary')
 
   beforeEach(() => {
+    deadline = 30
+    grpcDeadlineStub = sinon.stub().returns(deadline)
     reverts = []
     jsonStub = {
       stringify: sinon.stub()
@@ -64,6 +68,7 @@ describe('summary', () => {
     reverts.push(program.__set__('BrokerDaemonClient', brokerStub))
     reverts.push(program.__set__('Table', tableStub))
     reverts.push(program.__set__('JSON', jsonStub))
+    reverts.push(program.__set__('grpcDeadline', grpcDeadlineStub))
 
     logger = {
       info: infoSpy,
@@ -80,7 +85,7 @@ describe('summary', () => {
     delete expectedOptions.rpcAddress
     delete expectedOptions.market
     await summary(args, opts, logger)
-    expect(getBlockOrdersStub).to.have.been.calledWith(sinon.match({ market, options: expectedOptions }), sinon.match.object)
+    expect(getBlockOrdersStub).to.have.been.calledWith(sinon.match({ market, options: expectedOptions }), null, { deadline })
   })
 
   it('adds orders to the table', async () => {

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -331,7 +331,7 @@ async function networkStatus (args, opts, logger) {
 
   try {
     const client = new BrokerDaemonClient(rpcAddress)
-    const { baseSymbolCapacities, counterSymbolCapacities } = await client.walletService.getTradingCapacities({ market }, { deadline: grpcDeadline(NETWORK_STATUS_GRPC_DEADLINE) })
+    const { baseSymbolCapacities, counterSymbolCapacities } = await client.walletService.getTradingCapacities({ market }, null, { deadline: grpcDeadline(NETWORK_STATUS_GRPC_DEADLINE) })
 
     const baseSymbol = baseSymbolCapacities.symbol.toUpperCase()
     const counterSymbol = counterSymbolCapacities.symbol.toUpperCase()

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -7,7 +7,13 @@ const Table = require('cli-table2')
 require('colors')
 
 const BrokerDaemonClient = require('../broker-daemon-client')
-const { validations, askQuestion, Big, handleError } = require('../utils')
+const {
+  validations,
+  askQuestion,
+  Big,
+  handleError,
+  grpcDeadline
+} = require('../utils')
 const { RPC_ADDRESS_HELP_STRING, MARKET_NAME_HELP_STRING } = require('../utils/strings')
 const { currencies: currencyConfig } = require('../config')
 
@@ -26,6 +32,16 @@ const ACCEPTED_ANSWERS = Object.freeze(['y', 'yes'])
 const SUPPORTED_SYMBOLS = Object.freeze(
   Object.values(currencyConfig).map(currency => currency.symbol)
 )
+
+/**
+ * Custom gRPC client deadline for `wallet network-status` that allows 30 seconds
+ * before the client will disconnect
+ *
+ * @constant
+ * @type {string}
+ * @default
+ */
+const NETWORK_STATUS_GRPC_DEADLINE = 30
 
 /**
  * Supported commands for `sparkswap wallet`
@@ -315,7 +331,7 @@ async function networkStatus (args, opts, logger) {
 
   try {
     const client = new BrokerDaemonClient(rpcAddress)
-    const { baseSymbolCapacities, counterSymbolCapacities } = await client.walletService.getTradingCapacities({ market })
+    const { baseSymbolCapacities, counterSymbolCapacities } = await client.walletService.getTradingCapacities({ market }, { deadline: grpcDeadline(NETWORK_STATUS_GRPC_DEADLINE) })
 
     const baseSymbol = baseSymbolCapacities.symbol.toUpperCase()
     const counterSymbol = counterSymbolCapacities.symbol.toUpperCase()

--- a/broker-cli/commands/wallet.js
+++ b/broker-cli/commands/wallet.js
@@ -38,7 +38,7 @@ const SUPPORTED_SYMBOLS = Object.freeze(
  * before the client will disconnect
  *
  * @constant
- * @type {string}
+ * @type {number}
  * @default
  */
 const NETWORK_STATUS_GRPC_DEADLINE = 30

--- a/broker-cli/commands/wallet.spec.js
+++ b/broker-cli/commands/wallet.spec.js
@@ -267,15 +267,18 @@ describe('cli wallet', () => {
     let counterSymbolCapacities
     let NETWORK_STATUSES
     let reverts = []
+    let grpcDeadlineStub
 
     const networkStatus = program.__get__('networkStatus')
     const formatBalance = program.__get__('formatBalance')
+    const deadline = 1234
 
     beforeEach(() => {
       market = 'BTC/LTC'
       rpcAddress = 'test:1337'
       opts = { rpcAddress, market }
       logger = { info: sinon.stub(), error: sinon.stub() }
+      grpcDeadlineStub = sinon.stub().returns(deadline)
       baseSymbolCapacities = {
         symbol: 'BTC',
         activeReceiveCapacity: '0.00001',
@@ -313,6 +316,7 @@ describe('cli wallet', () => {
 
       reverts.push(program.__set__('BrokerDaemonClient', daemonStub))
       reverts.push(program.__set__('Table', tableStub))
+      reverts.push(program.__set__('grpcDeadline', grpcDeadlineStub))
 
       NETWORK_STATUSES = program.__get__('NETWORK_STATUSES')
     })
@@ -328,6 +332,7 @@ describe('cli wallet', () => {
     it('calls broker daemon for the network status', () => {
       expect(daemonStub).to.have.been.calledWith(rpcAddress)
       expect(getTradingCapacitiesStub).to.have.been.calledOnce()
+      expect(getTradingCapacitiesStub).to.have.been.calledWith(market, { deadline })
     })
 
     it('adds available header', () => {

--- a/broker-cli/commands/wallet.spec.js
+++ b/broker-cli/commands/wallet.spec.js
@@ -332,7 +332,7 @@ describe('cli wallet', () => {
     it('calls broker daemon for the network status', () => {
       expect(daemonStub).to.have.been.calledWith(rpcAddress)
       expect(getTradingCapacitiesStub).to.have.been.calledOnce()
-      expect(getTradingCapacitiesStub).to.have.been.calledWith(market, { deadline })
+      expect(getTradingCapacitiesStub).to.have.been.calledWith({ market }, { deadline })
     })
 
     it('adds available header', () => {

--- a/broker-cli/commands/wallet.spec.js
+++ b/broker-cli/commands/wallet.spec.js
@@ -332,7 +332,7 @@ describe('cli wallet', () => {
     it('calls broker daemon for the network status', () => {
       expect(daemonStub).to.have.been.calledWith(rpcAddress)
       expect(getTradingCapacitiesStub).to.have.been.calledOnce()
-      expect(getTradingCapacitiesStub).to.have.been.calledWith({ market }, { deadline })
+      expect(getTradingCapacitiesStub).to.have.been.calledWith({ market }, null, { deadline })
     })
 
     it('adds available header', () => {


### PR DESCRIPTION
## Description
This PR is a temporary fix to allow `network-status` to not fail when a broker has > 20,000 orders for a particular market

1. consolidates some logic from `calculateActiveFunds` to allow mutliple `populate` commands to be ran in parallel
2. Increased client deadline of `network-status` to allow for longs than 5 second queries
## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
