### PR TITLE
Feature/healthcheck json

### DIFF
--- a/broker-cli/commands/health-check.js
+++ b/broker-cli/commands/health-check.js
@@ -69,7 +69,7 @@ async function healthCheck (args, opts, logger) {
     const res = await client.adminService.healthCheck({})
 
     if (json) {
-      return console.log(JSON.stringify(res))
+      return logger.info(JSON.stringify(res, null, 2))
     }
 
     const {

--- a/broker-cli/commands/health-check.js
+++ b/broker-cli/commands/health-check.js
@@ -58,16 +58,25 @@ const ENGINE_STATUS_CODES = Object.freeze({
  */
 
 async function healthCheck (args, opts, logger) {
-  const { rpcAddress } = opts
+  const {
+    rpcAddress,
+    json
+  } = opts
 
   try {
     const client = new BrokerDaemonClient(rpcAddress)
+
+    const res = await client.adminService.healthCheck({})
+
+    if (json) {
+      return console.log(JSON.stringify(res))
+    }
 
     const {
       engineStatus = [],
       orderbookStatus: orderbookStatuses = [],
       relayerStatus = STATUS_CODES.UNKNOWN
-    } = await client.adminService.healthCheck({})
+    } = res
 
     const healthcheckTable = new Table({
       head: ['Component', 'Status'],
@@ -114,5 +123,6 @@ module.exports = (program) => {
   program
     .command('healthcheck', 'Checks the connection between Broker and the Exchange')
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING, validations.isHost)
+    .option('--json', 'Export result as json', program.BOOL, false)
     .action(healthCheck)
 }

--- a/broker-cli/commands/health-check.spec.js
+++ b/broker-cli/commands/health-check.spec.js
@@ -74,9 +74,12 @@ describe('healthCheck', () => {
 
   it('returns json if the user specifies a json flag', async () => {
     opts.json = true
+    const result = 'result'
+    jsonStub.stringify.returns(result)
     await healthCheck(args, opts, logger)
     expect(instanceTableStub.push).to.not.have.been.called()
     expect(jsonStub.stringify).to.have.been.calledWith(healthCheckResponse)
+    expect(logger.info).to.have.been.calledWith(result)
   })
 
   it('adds engine statuses to the healthcheck table', async () => {


### PR DESCRIPTION
## Description
This PR adds a `--json` flag to the healthcheck command to allow the healthcheck to be parsable by other programs

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
