### PR TITLE
Feature - Post Only order type

### DIFF
--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -310,9 +310,9 @@ service AdminService {
 enum TimeInForce {
   GTC = 0; // Good-til-cancelled, an order that remains in force until cancelled by the user
   // FOK is not supported
-  FOK = 1; // Fill-or-kill, an order that can be completely filled or will not be executed
+  // FOK = 1; // Fill-or-kill, an order that can be completely filled or will not be executed
   // IOC is not supported
-  IOC = 2; // Immediate-or-cancel, an order that will have as much filled immediately as possible with the remainder cancelled
+  // IOC = 2; // Immediate-or-cancel, an order that will have as much filled immediately as possible with the remainder cancelled
   PO = 3; // Post Only, an order that will be rejected if any part of the order would match and execute immediately
 }
 

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -309,8 +309,8 @@ service AdminService {
  */
 enum TimeInForce {
   GTC = 0; // Good-til-cancelled, an order that remains in force until cancelled by the user
-  // FOK = 1; // Not supported - Fill-or-kill, an order that can be completely filled or will not be executed
-  // IOC = 2; // Not supported - Immediate-or-cancel, an order that will have as much filled immediately as possible with the remainder cancelled
+  FOK = 1; // Fill-or-kill, an order that can be completely filled or will not be executed. Note: this time restriction is not currently supported.
+  IOC = 2; // Immediate-or-cancel, an order that will have as much filled immediately as possible with the remainder cancelled. Note: this time restriction is not currently supported.
   PO = 3; // Post Only, an order that will be rejected if any part of the order would match and execute immediately
 }
 

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -309,8 +309,11 @@ service AdminService {
  */
 enum TimeInForce {
   GTC = 0; // Good-til-cancelled, an order that remains in force until cancelled by the user
+  // FOK is not supported
   FOK = 1; // Fill-or-kill, an order that can be completely filled or will not be executed
+  // IOC is not supported
   IOC = 2; // Immediate-or-cancel, an order that will have as much filled immediately as possible with the remainder cancelled
+  PO = 3; // Post Only, an order that will be rejected if any part of the order would match and execute immediately
 }
 
 /**

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -309,10 +309,8 @@ service AdminService {
  */
 enum TimeInForce {
   GTC = 0; // Good-til-cancelled, an order that remains in force until cancelled by the user
-  // FOK is not supported
-  // FOK = 1; // Fill-or-kill, an order that can be completely filled or will not be executed
-  // IOC is not supported
-  // IOC = 2; // Immediate-or-cancel, an order that will have as much filled immediately as possible with the remainder cancelled
+  // FOK = 1; // Not supported - Fill-or-kill, an order that can be completely filled or will not be executed
+  // IOC = 2; // Not supported - Immediate-or-cancel, an order that will have as much filled immediately as possible with the remainder cancelled
   PO = 3; // Post Only, an order that will be rejected if any part of the order would match and execute immediately
 }
 

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -572,6 +572,8 @@ class BlockOrderWorker extends EventEmitter {
     const { orders, depth: availableDepth } = await orderbook.getBestOrders({ side: blockOrder.inverseSide, depth: targetDepth.toString(), quantumPrice: blockOrder.quantumPrice })
 
     if (blockOrder.timeInForce === BlockOrder.TIME_RESTRICTIONS.GTC) {
+      // Good-til-Cancelled orders will take any available liquidity that is at
+      // a marketable price, then place an outstanding limit order for the remaining quantity
       await this._fillOrders(blockOrder, orders, targetDepth.toString())
     } else if (blockOrder.timeInForce === BlockOrder.TIME_RESTRICTIONS.PO) {
       // Post Only orders are maker only, so if any orders exist at a marketable

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -585,7 +585,7 @@ class BlockOrderWorker extends EventEmitter {
         return this.cancelBlockOrder(blockOrder.id)
       }
     } else {
-      throw new Error('')
+      throw new Error(`Unknown time restriction: ${blockOrder.timeInForce}`)
     }
 
     if (targetDepth.gt(availableDepth)) {

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -566,10 +566,6 @@ class BlockOrderWorker extends EventEmitter {
    * @returns {void}
    */
   async workLimitBlockOrder (blockOrder, targetDepth) {
-    if ((blockOrder.timeInForce !== BlockOrder.TIME_RESTRICTIONS.GTC) && (blockOrder.timeInForce !== BlockOrder.TIME_RESTRICTIONS.PO)) {
-      throw new Error('Only Good-til-cancelled and Post Only limit orders are currently supported.')
-    }
-
     const orderbook = this.orderbooks.get(blockOrder.marketName)
 
     // get available orders for the requested depth and price
@@ -585,7 +581,7 @@ class BlockOrderWorker extends EventEmitter {
         return this.cancelBlockOrder(blockOrder.id)
       }
     } else {
-      throw new Error(`Unknown time restriction: ${blockOrder.timeInForce}`)
+      throw new Error(`Only Good-til-cancelled and Post Only limit orders are currently supported. Unsupported time restriction: ${blockOrder.timeInForce}`)
     }
 
     if (targetDepth.gt(availableDepth)) {

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -1537,9 +1537,7 @@ describe('BlockOrderWorker', () => {
     })
 
     it('throws if the order is neither GTC nor PO', async () => {
-      blockOrder = {
-        timeInForce: 'NA'
-      }
+      blockOrder.timeInForce = 'NA'
 
       return expect(worker.workLimitBlockOrder(blockOrder, Big('100000000000'))).to.eventually.be.rejectedWith('Only Good-til-cancelled and Post Only limit orders are currently supported.')
     })

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -1527,11 +1527,7 @@ describe('BlockOrderWorker', () => {
       OrderStateMachine.create.resolves(order)
 
       orders = [
-        {
-          orderId: '1',
-          baseAmount: '90000000000',
-          quantumPrice: '900.00000000000000000'
-        }
+        { orderId: '1', baseAmount: '90000000000' }
       ]
 
       orderbooks.get('BTC/LTC').getBestOrders.resolves({
@@ -1594,7 +1590,6 @@ describe('BlockOrderWorker', () => {
         })
 
         it('cancels a buy order if the order would take any liquidity', async () => {
-          blockOrder.isBid = true
           await worker.workLimitBlockOrder(blockOrder, Big('100000000000'))
 
           expect(worker.cancelBlockOrder).to.have.been.calledOnce()
@@ -1604,19 +1599,17 @@ describe('BlockOrderWorker', () => {
         it('cancels a sell order if the order would take any liquidity', async () => {
           blockOrder.side = 'ASK'
           blockOrder.inverseSide = 'BID'
-          blockOrder.isBid = false
 
           orders = [
             {
               orderId: '1',
-              baseAmount: '110000000000',
-              quantumPrice: '1100.00000000000000000'
+              baseAmount: '100000000000'
             }
           ]
 
           orderbooks.get('BTC/LTC').getBestOrders.resolves({
             orders,
-            depth: '110000000000'
+            depth: '100000000000'
           })
 
           await worker.workLimitBlockOrder(blockOrder, Big('100000000000'))
@@ -1626,19 +1619,9 @@ describe('BlockOrderWorker', () => {
         })
 
         it('places a buy order if the order would not take any liquidity', async () => {
-          blockOrder.isBid = true
-
-          orders = [
-            {
-              orderId: '1',
-              baseAmount: '110000000000',
-              quantumPrice: '1100.00000000000000000'
-            }
-          ]
-
           orderbooks.get('BTC/LTC').getBestOrders.resolves({
-            orders,
-            depth: '110000000000'
+            orders: [],
+            depth: '0'
           })
 
           await worker.workLimitBlockOrder(blockOrder, Big('100000000000'))
@@ -1651,7 +1634,11 @@ describe('BlockOrderWorker', () => {
         it('places a sell order if the order would not take any liquidity', async () => {
           blockOrder.side = 'ASK'
           blockOrder.inverseSide = 'BID'
-          blockOrder.isBid = false
+
+          orderbooks.get('BTC/LTC').getBestOrders.resolves({
+            orders: [],
+            depth: '0'
+          })
 
           await worker.workLimitBlockOrder(blockOrder, Big('100000000000'))
 

--- a/broker-daemon/broker-rpc/order-service/create-block-order.js
+++ b/broker-daemon/broker-rpc/order-service/create-block-order.js
@@ -19,16 +19,16 @@ async function createBlockOrder ({ params, blockOrderWorker }, { CreateBlockOrde
     timeInForce
   } = params
 
-  if (TimeInForce[timeInForce] !== TimeInForce.GTC) {
-    throw new Error('Only Good-til-cancelled orders are currently supported')
+  if ((TimeInForce[timeInForce] !== TimeInForce.GTC) && (TimeInForce[timeInForce] !== TimeInForce.PO)) {
+    throw new Error('Only Good-til-cancelled and Post Only limit orders are currently supported.')
   }
 
   const blockOrderId = await blockOrderWorker.createBlockOrder({
     marketName: market,
-    side: side,
-    amount: amount,
+    side,
+    amount,
     price: isMarketOrder ? null : limitPrice,
-    timeInForce: 'GTC'
+    timeInForce
   })
 
   return new CreateBlockOrderResponse({ blockOrderId })

--- a/broker-daemon/broker-rpc/order-service/create-block-order.spec.js
+++ b/broker-daemon/broker-rpc/order-service/create-block-order.spec.js
@@ -13,7 +13,8 @@ describe('createBlockOrder', () => {
   beforeEach(() => {
     CreateBlockOrderResponse = sinon.stub()
     TimeInForce = {
-      GTC: 1
+      GTC: 1,
+      PO: 3
     }
     blockOrderWorker = {
       createBlockOrder: sinon.stub().resolves('fakeId')
@@ -39,12 +40,12 @@ describe('createBlockOrder', () => {
     revert()
   })
 
-  it('throws if trying to use a time in force other than GTC', () => {
+  it('throws if trying to use a time in force other than GTC or PO', () => {
     const params = {
       limitPrice: '1000.678',
       timeInForce: 'FOK'
     }
-    return expect(createBlockOrder({ params, blockOrderWorker }, { CreateBlockOrderResponse, TimeInForce })).to.be.rejectedWith('Only Good-til-cancelled orders are currently supported')
+    return expect(createBlockOrder({ params, blockOrderWorker }, { CreateBlockOrderResponse, TimeInForce })).to.be.rejectedWith('Only Good-til-cancelled and Post Only limit orders are currently supported.')
   })
 
   it('creates a block order on the BlockOrderWorker', async () => {

--- a/broker-daemon/broker-rpc/order-service/create-block-order.spec.js
+++ b/broker-daemon/broker-rpc/order-service/create-block-order.spec.js
@@ -13,7 +13,7 @@ describe('createBlockOrder', () => {
   beforeEach(() => {
     CreateBlockOrderResponse = sinon.stub()
     TimeInForce = {
-      GTC: 1,
+      GTC: 0,
       PO: 3
     }
     blockOrderWorker = {

--- a/broker-daemon/models/block-order.js
+++ b/broker-daemon/models/block-order.js
@@ -479,7 +479,8 @@ class BlockOrder {
 }
 
 BlockOrder.TIME_RESTRICTIONS = Object.freeze({
-  GTC: 'GTC'
+  GTC: 'GTC',
+  PO: 'PO'
 })
 
 BlockOrder.SIDES = Object.freeze({

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -310,9 +310,9 @@ service AdminService {
 enum TimeInForce {
   GTC = 0; // Good-til-cancelled, an order that remains in force until cancelled by the user
   // FOK is not supported
-  FOK = 1; // Fill-or-kill, an order that can be completely filled or will not be executed
+  // FOK = 1; // Fill-or-kill, an order that can be completely filled or will not be executed
   // IOC is not supported
-  IOC = 2; // Immediate-or-cancel, an order that will have as much filled immediately as possible with the remainder cancelled
+  // IOC = 2; // Immediate-or-cancel, an order that will have as much filled immediately as possible with the remainder cancelled
   PO = 3; // Post Only, an order that will be rejected if any part of the order would match and execute immediately
 }
 

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -309,8 +309,8 @@ service AdminService {
  */
 enum TimeInForce {
   GTC = 0; // Good-til-cancelled, an order that remains in force until cancelled by the user
-  // FOK = 1; // Not supported - Fill-or-kill, an order that can be completely filled or will not be executed
-  // IOC = 2; // Not supported - Immediate-or-cancel, an order that will have as much filled immediately as possible with the remainder cancelled
+  FOK = 1; // Fill-or-kill, an order that can be completely filled or will not be executed. Note: this time restriction is not currently supported.
+  IOC = 2; // Immediate-or-cancel, an order that will have as much filled immediately as possible with the remainder cancelled. Note: this time restriction is not currently supported.
   PO = 3; // Post Only, an order that will be rejected if any part of the order would match and execute immediately
 }
 

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -309,8 +309,11 @@ service AdminService {
  */
 enum TimeInForce {
   GTC = 0; // Good-til-cancelled, an order that remains in force until cancelled by the user
+  // FOK is not supported
   FOK = 1; // Fill-or-kill, an order that can be completely filled or will not be executed
+  // IOC is not supported
   IOC = 2; // Immediate-or-cancel, an order that will have as much filled immediately as possible with the remainder cancelled
+  PO = 3; // Post Only, an order that will be rejected if any part of the order would match and execute immediately
 }
 
 /**

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -309,10 +309,8 @@ service AdminService {
  */
 enum TimeInForce {
   GTC = 0; // Good-til-cancelled, an order that remains in force until cancelled by the user
-  // FOK is not supported
-  // FOK = 1; // Fill-or-kill, an order that can be completely filled or will not be executed
-  // IOC is not supported
-  // IOC = 2; // Immediate-or-cancel, an order that will have as much filled immediately as possible with the remainder cancelled
+  // FOK = 1; // Not supported - Fill-or-kill, an order that can be completely filled or will not be executed
+  // IOC = 2; // Not supported - Immediate-or-cancel, an order that will have as much filled immediately as possible with the remainder cancelled
   PO = 3; // Post Only, an order that will be rejected if any part of the order would match and execute immediately
 }
 


### PR DESCRIPTION
## Description
This PR adds a new order type, Post Only orders.

With this order type, an order is moved to a cancelled state if any portion of the order would immediately execute when placed. This is a useful feature for market makers that wish to place orders that provide liquidity instead of taking.

**Changes**
1. Update `workLimitBlockOrder` to handle both `GTC` and `PO` orders
2. Add Post Only to `TimeInForce` enum in proto

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
