### PR TITLE
Feature - Add second parameter for range method calls

### DIFF
--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -154,7 +154,7 @@ class BlockOrderWorker extends EventEmitter {
       },
       // limit the orders we retrieve to those that belong to this blockOrder, i.e. those that are in
       // its prefix range.
-      Order.rangeForBlockOrder(blockOrder.id)
+      Order.rangeForBlockOrder(blockOrder.id, blockOrder.id)
     )
     return osms
   }
@@ -183,7 +183,7 @@ class BlockOrderWorker extends EventEmitter {
       },
       // limit the orders we retrieve to those that belong to this blockOrder, i.e. those that are in
       // its prefix range.
-      Fill.rangeForBlockOrder(blockOrder.id)
+      Fill.rangeForBlockOrder(blockOrder.id, blockOrder.id)
     )
 
     return fsms

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -154,7 +154,7 @@ class BlockOrderWorker extends EventEmitter {
       },
       // limit the orders we retrieve to those that belong to this blockOrder, i.e. those that are in
       // its prefix range.
-      Order.rangeForBlockOrder(blockOrder.id, blockOrder.id)
+      Order.rangeForBlockOrderIds(blockOrder.id, blockOrder.id)
     )
     return osms
   }
@@ -183,7 +183,7 @@ class BlockOrderWorker extends EventEmitter {
       },
       // limit the orders we retrieve to those that belong to this blockOrder, i.e. those that are in
       // its prefix range.
-      Fill.rangeForBlockOrder(blockOrder.id, blockOrder.id)
+      Fill.rangeForBlockOrderIds(blockOrder.id, blockOrder.id)
     )
 
     return fsms

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -49,13 +49,13 @@ describe('BlockOrderWorker', () => {
     Order = {
       fromObject: sinon.stub(),
       fromStorage: sinon.stub(),
-      rangeForBlockOrder: sinon.stub()
+      rangeForBlockOrderIds: sinon.stub()
     }
     BlockOrderWorker.__set__('Order', Order)
 
     Fill = {
       fromObject: sinon.stub(),
-      rangeForBlockOrder: sinon.stub()
+      rangeForBlockOrderIds: sinon.stub()
     }
     BlockOrderWorker.__set__('Fill', Fill)
 
@@ -466,12 +466,12 @@ describe('BlockOrderWorker', () => {
 
     it('retrieves all open orders associated with the block order', async () => {
       const fakeRange = 'myrange'
-      Order.rangeForBlockOrder.returns(fakeRange)
+      Order.rangeForBlockOrderIds.returns(fakeRange)
 
       await worker.getOrderStateMachines(blockOrder)
 
-      expect(Order.rangeForBlockOrder).to.have.been.calledOnce()
-      expect(Order.rangeForBlockOrder).to.have.been.calledWith(blockOrder.id, blockOrder.id)
+      expect(Order.rangeForBlockOrderIds).to.have.been.calledOnce()
+      expect(Order.rangeForBlockOrderIds).to.have.been.calledWith(blockOrder.id, blockOrder.id)
       expect(getRecords).to.have.been.calledOnce()
       expect(getRecords).to.have.been.calledWith(ordersStore, sinon.match.func, fakeRange)
     })
@@ -520,12 +520,12 @@ describe('BlockOrderWorker', () => {
 
     it('retrieves all open fills associated with the block order', async () => {
       const fakeRange = 'myrange'
-      Fill.rangeForBlockOrder.returns(fakeRange)
+      Fill.rangeForBlockOrderIds.returns(fakeRange)
 
       await worker.getFillStateMachines(blockOrder)
 
-      expect(Fill.rangeForBlockOrder).to.have.been.calledOnce()
-      expect(Fill.rangeForBlockOrder).to.have.been.calledWith(blockOrder.id, blockOrder.id)
+      expect(Fill.rangeForBlockOrderIds).to.have.been.calledOnce()
+      expect(Fill.rangeForBlockOrderIds).to.have.been.calledWith(blockOrder.id, blockOrder.id)
       expect(getRecords).to.have.been.calledOnce()
       expect(getRecords).to.have.been.calledWith(fillsStore, sinon.match.func, fakeRange)
     })

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -471,7 +471,7 @@ describe('BlockOrderWorker', () => {
       await worker.getOrderStateMachines(blockOrder)
 
       expect(Order.rangeForBlockOrder).to.have.been.calledOnce()
-      expect(Order.rangeForBlockOrder).to.have.been.calledWith(blockOrder.id)
+      expect(Order.rangeForBlockOrder).to.have.been.calledWith(blockOrder.id, blockOrder.id)
       expect(getRecords).to.have.been.calledOnce()
       expect(getRecords).to.have.been.calledWith(ordersStore, sinon.match.func, fakeRange)
     })
@@ -525,7 +525,7 @@ describe('BlockOrderWorker', () => {
       await worker.getFillStateMachines(blockOrder)
 
       expect(Fill.rangeForBlockOrder).to.have.been.calledOnce()
-      expect(Fill.rangeForBlockOrder).to.have.been.calledWith(blockOrder.id)
+      expect(Fill.rangeForBlockOrder).to.have.been.calledWith(blockOrder.id, blockOrder.id)
       expect(getRecords).to.have.been.calledOnce()
       expect(getRecords).to.have.been.calledWith(fillsStore, sinon.match.func, fakeRange)
     })

--- a/broker-daemon/models/block-order.js
+++ b/broker-daemon/models/block-order.js
@@ -343,7 +343,7 @@ class BlockOrder {
       },
       // limit the orders we retrieve to those that belong to this blockOrder, i.e. those that are in
       // its prefix range.
-      Order.rangeForBlockOrder(this.id)
+      Order.rangeForBlockOrder(this.id, this.id)
     )
     this.orders = orders
   }
@@ -362,7 +362,7 @@ class BlockOrder {
       },
       // limit the fills we retrieve to those that belong to this blockOrder, i.e. those that are in
       // its prefix range.
-      Fill.rangeForBlockOrder(this.id)
+      Fill.rangeForBlockOrder(this.id, this.id)
     )
     this.fills = fills
   }

--- a/broker-daemon/models/block-order.js
+++ b/broker-daemon/models/block-order.js
@@ -343,7 +343,7 @@ class BlockOrder {
       },
       // limit the orders we retrieve to those that belong to this blockOrder, i.e. those that are in
       // its prefix range.
-      Order.rangeForBlockOrder(this.id, this.id)
+      Order.rangeForBlockOrderIds(this.id, this.id)
     )
     this.orders = orders
   }
@@ -362,7 +362,7 @@ class BlockOrder {
       },
       // limit the fills we retrieve to those that belong to this blockOrder, i.e. those that are in
       // its prefix range.
-      Fill.rangeForBlockOrder(this.id, this.id)
+      Fill.rangeForBlockOrderIds(this.id, this.id)
     )
     this.fills = fills
   }

--- a/broker-daemon/models/block-order.spec.js
+++ b/broker-daemon/models/block-order.spec.js
@@ -290,7 +290,7 @@ describe('BlockOrder', () => {
       Order = {
         fromObject: sinon.stub(),
         fromStorage: sinon.stub(),
-        rangeForBlockOrder: sinon.stub()
+        rangeForBlockOrderIds: sinon.stub()
       }
       OrderStateMachine = {
         serialize: sinon.stub(),
@@ -321,7 +321,7 @@ describe('BlockOrder', () => {
 
       Fill = {
         fromObject: sinon.stub(),
-        rangeForBlockOrder: sinon.stub()
+        rangeForBlockOrderIds: sinon.stub()
       }
 
       BlockOrder.__set__('Fill', Fill)
@@ -904,12 +904,12 @@ describe('BlockOrder', () => {
 
       it('retrieves all open orders associated with the block order', async () => {
         const fakeRange = 'myrange'
-        Order.rangeForBlockOrder.returns(fakeRange)
+        Order.rangeForBlockOrderIds.returns(fakeRange)
 
         await blockOrder.populateOrders(ordersStore)
 
-        expect(Order.rangeForBlockOrder).to.have.been.calledOnce()
-        expect(Order.rangeForBlockOrder).to.have.been.calledWith(blockOrder.id, blockOrder.id)
+        expect(Order.rangeForBlockOrderIds).to.have.been.calledOnce()
+        expect(Order.rangeForBlockOrderIds).to.have.been.calledWith(blockOrder.id, blockOrder.id)
         expect(getRecords).to.have.been.calledOnce()
         expect(getRecords).to.have.been.calledWith(ordersStore, sinon.match.func, fakeRange)
         expect(blockOrder).to.have.property('orders', orders)
@@ -960,12 +960,12 @@ describe('BlockOrder', () => {
 
       it('retrieves all fills associated with a block order', async () => {
         const fakeRange = 'myrange'
-        Fill.rangeForBlockOrder.returns(fakeRange)
+        Fill.rangeForBlockOrderIds.returns(fakeRange)
 
         await blockOrder.populateFills(fillsStore)
 
-        expect(Fill.rangeForBlockOrder).to.have.been.calledOnce()
-        expect(Fill.rangeForBlockOrder).to.have.been.calledWith(blockOrder.id, blockOrder.id)
+        expect(Fill.rangeForBlockOrderIds).to.have.been.calledOnce()
+        expect(Fill.rangeForBlockOrderIds).to.have.been.calledWith(blockOrder.id, blockOrder.id)
         expect(getRecords).to.have.been.calledOnce()
         expect(getRecords).to.have.been.calledWith(fillsStore, sinon.match.func, fakeRange)
         expect(blockOrder).to.have.property('fills', fills)

--- a/broker-daemon/models/block-order.spec.js
+++ b/broker-daemon/models/block-order.spec.js
@@ -909,7 +909,7 @@ describe('BlockOrder', () => {
         await blockOrder.populateOrders(ordersStore)
 
         expect(Order.rangeForBlockOrder).to.have.been.calledOnce()
-        expect(Order.rangeForBlockOrder).to.have.been.calledWith(blockOrder.id)
+        expect(Order.rangeForBlockOrder).to.have.been.calledWith(blockOrder.id, blockOrder.id)
         expect(getRecords).to.have.been.calledOnce()
         expect(getRecords).to.have.been.calledWith(ordersStore, sinon.match.func, fakeRange)
         expect(blockOrder).to.have.property('orders', orders)
@@ -965,7 +965,7 @@ describe('BlockOrder', () => {
         await blockOrder.populateFills(fillsStore)
 
         expect(Fill.rangeForBlockOrder).to.have.been.calledOnce()
-        expect(Fill.rangeForBlockOrder).to.have.been.calledWith(blockOrder.id)
+        expect(Fill.rangeForBlockOrder).to.have.been.calledWith(blockOrder.id, blockOrder.id)
         expect(getRecords).to.have.been.calledOnce()
         expect(getRecords).to.have.been.calledWith(fillsStore, sinon.match.func, fakeRange)
         expect(blockOrder).to.have.property('fills', fills)

--- a/broker-daemon/models/fill.js
+++ b/broker-daemon/models/fill.js
@@ -429,7 +429,7 @@ class Fill {
    * @param {string} endId - id of the block order to end the range
    * @returns {Object} Options object that can be used in {@link https://github.com/Level/levelup#createReadStream}
    */
-  static rangeForBlockOrder (startId, endId) {
+  static rangeForBlockOrderIds (startId, endId) {
     return {
       gte: `${startId}${DELIMITER}${LOWER_BOUND}`,
       lte: `${endId}${DELIMITER}${UPPER_BOUND}`

--- a/broker-daemon/models/fill.js
+++ b/broker-daemon/models/fill.js
@@ -425,13 +425,14 @@ class Fill {
    * Create a set of options that can be passed to a LevelUP `createReadStream` call
    * that limits the set to fills that belong to the given blockOrderId.
    * This works because all fills are prefixed with their blockOrderId and the Delimiter.
-   * @param {string} blockOrderId - of of the block order to create a range for
+   * @param {string} startId - of of the block order to start the range
+   * @param {string} endId - id of the block order to end the range
    * @returns {Object} Options object that can be used in {@link https://github.com/Level/levelup#createReadStream}
    */
-  static rangeForBlockOrder (blockOrderId) {
+  static rangeForBlockOrder (startId, endId) {
     return {
-      gte: `${blockOrderId}${DELIMITER}${LOWER_BOUND}`,
-      lte: `${blockOrderId}${DELIMITER}${UPPER_BOUND}`
+      gte: `${startId}${DELIMITER}${LOWER_BOUND}`,
+      lte: `${endId}${DELIMITER}${UPPER_BOUND}`
     }
   }
 }

--- a/broker-daemon/models/fill.js
+++ b/broker-daemon/models/fill.js
@@ -425,7 +425,7 @@ class Fill {
    * Create a set of options that can be passed to a LevelUP `createReadStream` call
    * that limits the set to fills that belong to the given blockOrderId.
    * This works because all fills are prefixed with their blockOrderId and the Delimiter.
-   * @param {string} startId - of of the block order to start the range
+   * @param {string} startId - id of the block order to start the range
    * @param {string} endId - id of the block order to end the range
    * @returns {Object} Options object that can be used in {@link https://github.com/Level/levelup#createReadStream}
    */

--- a/broker-daemon/models/fill.spec.js
+++ b/broker-daemon/models/fill.spec.js
@@ -176,11 +176,12 @@ describe('Fill', () => {
 
   describe('::rangeForBlockOrder', () => {
     it('creates a range for block orders', () => {
-      const blockOrderId = 'blockid'
+      const startId = 'startid'
+      const endId = 'endid'
 
-      expect(Fill.rangeForBlockOrder(blockOrderId)).to.be.eql({
-        gte: 'blockid:' + '\x00',
-        lte: 'blockid:' + '\uffff'
+      expect(Fill.rangeForBlockOrder(startId, endId)).to.be.eql({
+        gte: 'startid:' + '\x00',
+        lte: 'endid:' + '\uffff'
       })
     })
   })

--- a/broker-daemon/models/fill.spec.js
+++ b/broker-daemon/models/fill.spec.js
@@ -174,12 +174,12 @@ describe('Fill', () => {
     })
   })
 
-  describe('::rangeForBlockOrder', () => {
+  describe('::rangeForBlockOrderIds', () => {
     it('creates a range for block orders', () => {
       const startId = 'startid'
       const endId = 'endid'
 
-      expect(Fill.rangeForBlockOrder(startId, endId)).to.be.eql({
+      expect(Fill.rangeForBlockOrderIds(startId, endId)).to.be.eql({
         gte: 'startid:' + '\x00',
         lte: 'endid:' + '\uffff'
       })

--- a/broker-daemon/models/order.js
+++ b/broker-daemon/models/order.js
@@ -465,7 +465,7 @@ class Order {
    * @param {string} endId - id of the block order to end the range
    * @returns {Object} Options object that can be used in {@link https://github.com/Level/levelup#createReadStream}
    */
-  static rangeForBlockOrder (startId, endId) {
+  static rangeForBlockOrderIds (startId, endId) {
     return {
       gte: `${startId}${DELIMITER}${LOWER_BOUND}`,
       lte: `${endId}${DELIMITER}${UPPER_BOUND}`

--- a/broker-daemon/models/order.js
+++ b/broker-daemon/models/order.js
@@ -461,7 +461,7 @@ class Order {
    * Create a set of options that can be passed to a LevelUP `createReadStream` call
    * that limits the set to orders that belong to the given blockOrderid.
    * This works because all orders are prefixed with their blockOrderId and the Delimiter.
-   * @param {string} startId - of of the block order to start the range
+   * @param {string} startId - id of the block order to start the range
    * @param {string} endId - id of the block order to end the range
    * @returns {Object} Options object that can be used in {@link https://github.com/Level/levelup#createReadStream}
    */

--- a/broker-daemon/models/order.js
+++ b/broker-daemon/models/order.js
@@ -461,13 +461,14 @@ class Order {
    * Create a set of options that can be passed to a LevelUP `createReadStream` call
    * that limits the set to orders that belong to the given blockOrderid.
    * This works because all orders are prefixed with their blockOrderId and the Delimiter.
-   * @param {string} blockOrderId - of of the block order to create a range for
+   * @param {string} startId - of of the block order to start the range
+   * @param {string} endId - id of the block order to end the range
    * @returns {Object} Options object that can be used in {@link https://github.com/Level/levelup#createReadStream}
    */
-  static rangeForBlockOrder (blockOrderId) {
+  static rangeForBlockOrder (startId, endId) {
     return {
-      gte: `${blockOrderId}${DELIMITER}${LOWER_BOUND}`,
-      lte: `${blockOrderId}${DELIMITER}${UPPER_BOUND}`
+      gte: `${startId}${DELIMITER}${LOWER_BOUND}`,
+      lte: `${endId}${DELIMITER}${UPPER_BOUND}`
     }
   }
 }

--- a/broker-daemon/models/order.spec.js
+++ b/broker-daemon/models/order.spec.js
@@ -148,11 +148,12 @@ describe('Order', () => {
 
   describe('::rangeForBlockOrder', () => {
     it('creates a range for block orders', () => {
-      const blockOrderId = 'blockid'
+      const startId = 'startid'
+      const endId = 'endid'
 
-      expect(Order.rangeForBlockOrder(blockOrderId)).to.be.eql({
-        gte: 'blockid:' + '\x00',
-        lte: 'blockid:' + '\uffff'
+      expect(Order.rangeForBlockOrder(startId, endId)).to.be.eql({
+        gte: 'startid:' + '\x00',
+        lte: 'endid:' + '\uffff'
       })
     })
   })

--- a/broker-daemon/models/order.spec.js
+++ b/broker-daemon/models/order.spec.js
@@ -146,12 +146,12 @@ describe('Order', () => {
     })
   })
 
-  describe('::rangeForBlockOrder', () => {
+  describe('::rangeForBlockOrderIds', () => {
     it('creates a range for block orders', () => {
       const startId = 'startid'
       const endId = 'endid'
 
-      expect(Order.rangeForBlockOrder(startId, endId)).to.be.eql({
+      expect(Order.rangeForBlockOrderIds(startId, endId)).to.be.eql({
         gte: 'startid:' + '\x00',
         lte: 'endid:' + '\uffff'
       })


### PR DESCRIPTION
## Description
This PR adds a second parameter to both `rangeForOrders` and `rangeForFills` helpers on the Order/Fill models respectively. These changes allow those methods to performance ranges that are outside of a single block order

This PR is related to the performance changes included in <https://github.com/sparkswap/broker/pull/527>

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
