### PR TITLE
remove unavailable options for tif and add correct help menu

### DIFF
--- a/broker-cli/commands/buy.js
+++ b/broker-cli/commands/buy.js
@@ -1,8 +1,18 @@
 const BrokerDaemonClient = require('../broker-daemon-client')
-const { ENUMS, validations, handleError } = require('../utils')
-const { RPC_ADDRESS_HELP_STRING, MARKET_NAME_HELP_STRING } = require('../utils/strings')
+const {
+  ENUMS,
+  validations,
+  handleError
+} = require('../utils')
+const {
+  RPC_ADDRESS_HELP_STRING,
+  MARKET_NAME_HELP_STRING
+} = require('../utils/strings')
 
-const { ORDER_TYPES, TIME_IN_FORCE } = ENUMS
+const {
+  ORDER_TYPES,
+  TIME_IN_FORCE
+} = ENUMS
 
 /**
  * sparkswap buy

--- a/broker-cli/commands/buy.js
+++ b/broker-cli/commands/buy.js
@@ -1,18 +1,8 @@
 const BrokerDaemonClient = require('../broker-daemon-client')
-const {
-  ENUMS,
-  validations,
-  handleError
-} = require('../utils')
-const {
-  RPC_ADDRESS_HELP_STRING,
-  MARKET_NAME_HELP_STRING
-} = require('../utils/strings')
+const { ENUMS, validations, handleError } = require('../utils')
+const { RPC_ADDRESS_HELP_STRING, MARKET_NAME_HELP_STRING } = require('../utils/strings')
 
-const {
-  ORDER_TYPES,
-  TIME_IN_FORCE
-} = ENUMS
+const { ORDER_TYPES, TIME_IN_FORCE } = ENUMS
 
 /**
  * sparkswap buy

--- a/broker-cli/commands/sell.js
+++ b/broker-cli/commands/sell.js
@@ -56,7 +56,7 @@ module.exports = (program) => {
     .argument('<amount>', 'Amount of counter currency to sell', validations.isDecimal)
     .argument('[price]', 'Worst price that this order should be executed at. (If omitted, the market price will be used)', validations.isDecimal)
     .option('--market <marketName>', MARKET_NAME_HELP_STRING, validations.isMarketName, null, true)
-    .option('--time-in-force [time-in-force]', 'Time in force policy for this order', Object.keys(TIME_IN_FORCE), 'GTC')
+    .option('--time-in-force [time-in-force]', `Time in force policy for this order. Available Options: ${Object.values(TIME_IN_FORCE).join(', ')}`, Object.values(TIME_IN_FORCE), TIME_IN_FORCE.GTC)
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING, validations.isHost)
     .action(sell)
 }

--- a/broker-cli/utils/enums.js
+++ b/broker-cli/utils/enums.js
@@ -20,9 +20,10 @@
  */
 const TIME_IN_FORCE = Object.freeze({
   PO: 'PO',
-  FOK: 'FOK',
-  IOC: 'IOC',
   GTC: 'GTC'
+  // FOK and IOC are not supported on the broker yet.
+  // FOK: 'FOK',
+  // IOC: 'IOC',
 })
 
 /**


### PR DESCRIPTION
## Description
This PR makes a small change to the CLI help screens to allow users to see what `time-in-force` options are available on the broker

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
