### PR TITLE
Index active orders and fills

### DIFF
--- a/broker-daemon/block-order-worker/active-fills-index.js
+++ b/broker-daemon/block-order-worker/active-fills-index.js
@@ -1,0 +1,33 @@
+const { FillStateMachine } = require('../state-machines')
+const { SubsetStore } = require('../utils')
+
+/**
+ * @class Index of of our own fills currently in an active state
+ */
+class ActiveFillsIndex extends SubsetStore {
+  /**
+   * Create a new index of a subset of only active fills
+   * @param {sublevel} store - Store of fills to create an active subset of
+   */
+  constructor (store) {
+    super(store.sublevel('activeFills'), store)
+  }
+
+  /**
+   * Create an object that can be passed to Sublevel to create or remove a record
+   * @param {string} key   - Key of the record to create an index op for
+   * @param {string} value - Value of the record being added to the events store to create an index op for
+   * @returns {Object} object for create/delete for use with sublevel
+   */
+  _addToIndexOperation (key, value) {
+    const { state } = JSON.parse(value)
+
+    if (Object.values(FillStateMachine.ACTIVE_STATES.includes(state))) {
+      return { key, value, type: 'put', prefix: this.store }
+    }
+
+    return { key, type: 'del', prefix: this.store }
+  }
+}
+
+module.exports = ActiveFillsIndex

--- a/broker-daemon/block-order-worker/active-fills-index.js
+++ b/broker-daemon/block-order-worker/active-fills-index.js
@@ -22,7 +22,7 @@ class ActiveFillsIndex extends SubsetStore {
   _addToIndexOperation (key, value) {
     const { state } = JSON.parse(value)
 
-    if (Object.values(FillStateMachine.ACTIVE_STATES.includes(state))) {
+    if (Object.values(FillStateMachine.ACTIVE_STATES).includes(state)) {
       return { key, value, type: 'put', prefix: this.store }
     }
 

--- a/broker-daemon/block-order-worker/active-fills-index.js
+++ b/broker-daemon/block-order-worker/active-fills-index.js
@@ -15,6 +15,7 @@ class ActiveFillsIndex extends SubsetStore {
 
   /**
    * Create an object that can be passed to Sublevel to create or remove a record
+   * @private
    * @param {string} key   - Key of the record to create an index op for
    * @param {string} value - Value of the record being added to the events store to create an index op for
    * @returns {Object} object for create/delete for use with sublevel

--- a/broker-daemon/block-order-worker/active-fills-index.js
+++ b/broker-daemon/block-order-worker/active-fills-index.js
@@ -19,7 +19,7 @@ class ActiveFillsIndex extends SubsetStore {
    * @param {string} value - Value of the record being added to the events store to create an index op for
    * @returns {Object} object for create/delete for use with sublevel
    */
-  _addToIndexOperation (key, value) {
+  addToIndexOperation (key, value) {
     const { state } = JSON.parse(value)
 
     if (Object.values(FillStateMachine.ACTIVE_STATES).includes(state)) {

--- a/broker-daemon/block-order-worker/active-fills-index.spec.js
+++ b/broker-daemon/block-order-worker/active-fills-index.spec.js
@@ -1,0 +1,99 @@
+const path = require('path')
+const { expect, sinon, rewire } = require('test/test-helper')
+
+const ActiveFillsIndex = rewire(path.resolve(__dirname, 'active-fills-index'))
+
+describe('ActiveFillsIndex', () => {
+  let baseStore
+  let SubsetStore
+  let FillStateMachine
+  let resets
+
+  beforeEach(() => {
+    baseStore = {
+      sublevel: sinon.stub()
+    }
+
+    FillStateMachine = {
+      ACTIVE_STATES: {
+        SOME: 'SOME',
+        ACTIVE: 'ACTIVE',
+        STATES: 'STATES'
+      }
+    }
+
+    resets = []
+    resets.push(ActiveFillsIndex.__set__('FillStateMachine', FillStateMachine))
+    SubsetStore = ActiveFillsIndex.__get__('SubsetStore')
+  })
+
+  afterEach(() => {
+    resets.forEach((reset) => reset())
+  })
+
+  describe('constructor', () => {
+    let activeFillsIndex
+    let fakeStore
+
+    beforeEach(() => {
+      fakeStore = 'mystore'
+      baseStore.sublevel.returns(fakeStore)
+      activeFillsIndex = new ActiveFillsIndex(baseStore)
+    })
+
+    it('is a sub-class of SubsetStore', () => {
+      expect(activeFillsIndex).to.be.an.instanceOf(SubsetStore)
+    })
+
+    it('creates a store for the index', () => {
+      expect(baseStore.sublevel).to.have.been.calledOnce()
+      expect(baseStore.sublevel).to.have.been.calledWith('activeFills')
+      // normally I would check that a stub had been called instead of reaching
+      // into the functionality of the dependency, but class constructors are
+      // basically impossible to stub.
+      expect(activeFillsIndex.store).to.be.eql(fakeStore)
+    })
+
+    it('uses the base store as the source store', () => {
+      // normally I would check that a stub had been called instead of reaching
+      // into the functionality of the dependency, but class constructors are
+      // basically impossible to stub.
+      expect(activeFillsIndex.sourceStore).to.be.eql(baseStore)
+    })
+  })
+
+  describe('addToIndexOperation', () => {
+    let fillKey
+    let fillValue
+    let activeFillsIndex
+
+    beforeEach(() => {
+      fillKey = 'mykey'
+      fillValue = JSON.stringify({
+        state: 'ACTIVE'
+      })
+
+      activeFillsIndex = new ActiveFillsIndex(baseStore)
+    })
+
+    it('adds fills in active states', () => {
+      expect(activeFillsIndex.addToIndexOperation(fillKey, fillValue)).to.be.eql({
+        key: fillKey,
+        value: fillValue,
+        type: 'put',
+        prefix: activeFillsIndex.store
+      })
+    })
+
+    it('removes fills in inactive states', () => {
+      fillValue = JSON.stringify({
+        state: 'INACTIVE'
+      })
+      expect(activeFillsIndex.addToIndexOperation(fillKey, fillValue)).to.be.eql({
+        key: fillKey,
+        type: 'del',
+        prefix: activeFillsIndex.store
+      })
+    })
+  })
+})

--- a/broker-daemon/block-order-worker/active-orders-index.js
+++ b/broker-daemon/block-order-worker/active-orders-index.js
@@ -15,6 +15,7 @@ class ActiveOrdersIndex extends SubsetStore {
 
   /**
    * Create an object that can be passed to Sublevel to create or remove a record
+   * @private
    * @param {string} key   - Key of the record to create an index op for
    * @param {string} value - Value of the record being added to the events store to create an index op for
    * @returns {Object} object for create/delete for use with sublevel

--- a/broker-daemon/block-order-worker/active-orders-index.js
+++ b/broker-daemon/block-order-worker/active-orders-index.js
@@ -22,7 +22,7 @@ class ActiveOrdersIndex extends SubsetStore {
   _addToIndexOperation (key, value) {
     const { state } = JSON.parse(value)
 
-    if (Object.values(OrderStateMachine.ACTIVE_STATES.includes(state))) {
+    if (Object.values(OrderStateMachine.ACTIVE_STATES).includes(state)) {
       return { key, value, type: 'put', prefix: this.store }
     }
 

--- a/broker-daemon/block-order-worker/active-orders-index.js
+++ b/broker-daemon/block-order-worker/active-orders-index.js
@@ -1,0 +1,33 @@
+const { OrderStateMachine } = require('../state-machines')
+const { SubsetStore } = require('../utils')
+
+/**
+ * @class Index of of our own orders currently in an active state
+ */
+class ActiveOrdersIndex extends SubsetStore {
+  /**
+   * Create a new index of a subset of only active orders
+   * @param {sublevel} store - Store of orders to create an active subset of
+   */
+  constructor (store) {
+    super(store.sublevel('activeOrders'), store)
+  }
+
+  /**
+   * Create an object that can be passed to Sublevel to create or remove a record
+   * @param {string} key   - Key of the record to create an index op for
+   * @param {string} value - Value of the record being added to the events store to create an index op for
+   * @returns {Object} object for create/delete for use with sublevel
+   */
+  _addToIndexOperation (key, value) {
+    const { state } = JSON.parse(value)
+
+    if (Object.values(OrderStateMachine.ACTIVE_STATES.includes(state))) {
+      return { key, value, type: 'put', prefix: this.store }
+    }
+
+    return { key, type: 'del', prefix: this.store }
+  }
+}
+
+module.exports = ActiveOrdersIndex

--- a/broker-daemon/block-order-worker/active-orders-index.js
+++ b/broker-daemon/block-order-worker/active-orders-index.js
@@ -19,7 +19,7 @@ class ActiveOrdersIndex extends SubsetStore {
    * @param {string} value - Value of the record being added to the events store to create an index op for
    * @returns {Object} object for create/delete for use with sublevel
    */
-  _addToIndexOperation (key, value) {
+  addToIndexOperation (key, value) {
     const { state } = JSON.parse(value)
 
     if (Object.values(OrderStateMachine.ACTIVE_STATES).includes(state)) {

--- a/broker-daemon/block-order-worker/active-orders-index.spec.js
+++ b/broker-daemon/block-order-worker/active-orders-index.spec.js
@@ -1,0 +1,99 @@
+const path = require('path')
+const { expect, sinon, rewire } = require('test/test-helper')
+
+const ActiveOrdersIndex = rewire(path.resolve(__dirname, 'active-orders-index'))
+
+describe('ActiveOrdersIndex', () => {
+  let baseStore
+  let SubsetStore
+  let OrderStateMachine
+  let resets
+
+  beforeEach(() => {
+    baseStore = {
+      sublevel: sinon.stub()
+    }
+
+    OrderStateMachine = {
+      ACTIVE_STATES: {
+        SOME: 'SOME',
+        ACTIVE: 'ACTIVE',
+        STATES: 'STATES'
+      }
+    }
+
+    resets = []
+    resets.push(ActiveOrdersIndex.__set__('OrderStateMachine', OrderStateMachine))
+    SubsetStore = ActiveOrdersIndex.__get__('SubsetStore')
+  })
+
+  afterEach(() => {
+    resets.forEach((reset) => reset())
+  })
+
+  describe('constructor', () => {
+    let activeOrdersIndex
+    let fakeStore
+
+    beforeEach(() => {
+      fakeStore = 'mystore'
+      baseStore.sublevel.returns(fakeStore)
+      activeOrdersIndex = new ActiveOrdersIndex(baseStore)
+    })
+
+    it('is a sub-class of SubsetStore', () => {
+      expect(activeOrdersIndex).to.be.an.instanceOf(SubsetStore)
+    })
+
+    it('creates a store for the index', () => {
+      expect(baseStore.sublevel).to.have.been.calledOnce()
+      expect(baseStore.sublevel).to.have.been.calledWith('activeOrders')
+      // normally I would check that a stub had been called instead of reaching
+      // into the functionality of the dependency, but class constructors are
+      // basically impossible to stub.
+      expect(activeOrdersIndex.store).to.be.eql(fakeStore)
+    })
+
+    it('uses the base store as the source store', () => {
+      // normally I would check that a stub had been called instead of reaching
+      // into the functionality of the dependency, but class constructors are
+      // basically impossible to stub.
+      expect(activeOrdersIndex.sourceStore).to.be.eql(baseStore)
+    })
+  })
+
+  describe('addToIndexOperation', () => {
+    let orderKey
+    let orderValue
+    let activeOrdersIndex
+
+    beforeEach(() => {
+      orderKey = 'mykey'
+      orderValue = JSON.stringify({
+        state: 'ACTIVE'
+      })
+
+      activeOrdersIndex = new ActiveOrdersIndex(baseStore)
+    })
+
+    it('adds orders in active states', () => {
+      expect(activeOrdersIndex.addToIndexOperation(orderKey, orderValue)).to.be.eql({
+        key: orderKey,
+        value: orderValue,
+        type: 'put',
+        prefix: activeOrdersIndex.store
+      })
+    })
+
+    it('removes orders in inactive states', () => {
+      orderValue = JSON.stringify({
+        state: 'INACTIVE'
+      })
+      expect(activeOrdersIndex.addToIndexOperation(orderKey, orderValue)).to.be.eql({
+        key: orderKey,
+        type: 'del',
+        prefix: activeOrdersIndex.store
+      })
+    })
+  })
+})

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -255,7 +255,7 @@ class BlockOrderWorker extends EventEmitter {
     const {
       outbound: activeOutboundAmount,
       inbound: activeInboundAmount
-    } = await this.calculateActiveFunds(marketName, inboundSymbol, outboundSymbol)
+    } = await this.calculateActiveFunds(marketName, { inboundSymbol, outboundSymbol })
 
     const outboundEngine = this.engines.get(outboundSymbol)
     const inboundEngine = this.engines.get(inboundSymbol)
@@ -326,13 +326,14 @@ class BlockOrderWorker extends EventEmitter {
    *
    * @todo Change return value from Big to String
    * @param {string} market
-   * @param {string} inboundSymbol
-   * @param {string} outboundSymbol
+   * @param {Object} symbols
+   * @param {string} symbols.inboundSymbol
+   * @param {string} symbols.outboundSymbol
    * @returns {Object} res
-   * @returns {string} inbound - int64 string of active inbound amount
-   * @returns {string} outbound - int64 string of active outbound amount
+   * @returns {string} res.inbound - int64 string of active inbound amount
+   * @returns {string} res.outbound - int64 string of active outbound amount
    */
-  async calculateActiveFunds (market, inboundSymbol, outboundSymbol) {
+  async calculateActiveFunds (market, { inboundSymbol, outboundSymbol }) {
     const [
       activeOrders,
       activeFills

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -391,6 +391,7 @@ class BlockOrderWorker extends EventEmitter {
       orders,
       fills
     ] = await Promise.all([
+      // TODO: add indexes for active states
       // TODO: add indexes on orders/fills for market
       // TODO: add index for side of market on order/fills
       Order.getAllOrders(this.ordersStore),

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -329,8 +329,8 @@ class BlockOrderWorker extends EventEmitter {
    * @param {string} inboundSymbol
    * @param {string} outboundSymbol
    * @returns {Object} res
-   * @returns {Big} activeOutboundAmount
-   * @returns {Big} activeInboundAmount
+   * @returns {string} inbound - int64 string of active inbound amount
+   * @returns {string} outbound - int64 string of active outbound amount
    */
   async calculateActiveFunds (market, inboundSymbol, outboundSymbol) {
     const [
@@ -361,9 +361,12 @@ class BlockOrderWorker extends EventEmitter {
       }
     })
 
+    inbound = inbound.toString()
+    outbound = outbound.toString()
+
     this.logger.debug('Calculated active funds', {
-      inbound: inbound.toString(),
-      outbound: outbound.toString()
+      inbound: inbound,
+      outbound: outbound
     })
 
     return {

--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -63,7 +63,7 @@ class BlockOrderWorker extends EventEmitter {
     const filterOrdersWithOrderId = (key, value) => !!Order.fromStorage(key, value).orderId
     const getOrderIdFromOrder = (key, value) => Order.fromStorage(key, value).orderId
 
-    // create a subset of active orders and fills
+    // create a subset of only the *active* orders and fills
     this.activeOrders = new ActiveOrdersIndex(this.ordersStore)
     this.activeFills = new ActiveFillsIndex(this.fillsStore)
 

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -818,7 +818,12 @@ describe('BlockOrderWorker', () => {
       await worker.checkFundsAreSufficient(blockOrderStub)
       expect(worker.calculateActiveFunds).to.have.been.calledOnce()
       expect(worker.calculateActiveFunds).to.have.been.calledWith(
-        blockOrderStub.marketName, blockOrderStub.inboundSymbol, blockOrderStub.outboundSymbol)
+        blockOrderStub.marketName,
+        {
+          inboundSymbol: blockOrderStub.inboundSymbol,
+          outboundSymbol: blockOrderStub.outboundSymbol
+        }
+      )
     })
 
     it('gets the addresses to the relayer to check engine balances', async () => {
@@ -1528,18 +1533,18 @@ describe('BlockOrderWorker', () => {
     })
 
     it('grabs all active orders', async () => {
-      await worker.calculateActiveFunds(market, inboundSymbol, outboundSymbol)
+      await worker.calculateActiveFunds(market, { inboundSymbol, outboundSymbol })
       expect(getRecords).to.have.been.calledWith(activeOrdersStoreStub, orderFromStorage)
     })
 
     it('grabs all active fills', async () => {
-      await worker.calculateActiveFunds(market, inboundSymbol, outboundSymbol)
+      await worker.calculateActiveFunds(market, { inboundSymbol, outboundSymbol })
       expect(getRecords).to.have.been.calledWith(activeFillsStoreStub, fillFromStorage)
     })
 
     context('inbound BTC', () => {
       it('returns the active inbound and outbound amounts', async () => {
-        const res = await worker.calculateActiveFunds(market, inboundSymbol, outboundSymbol)
+        const res = await worker.calculateActiveFunds(market, { inboundSymbol, outboundSymbol })
 
         expect(res.outbound).to.eql('1200')
         expect(res.inbound).to.eql('3100')
@@ -1553,7 +1558,7 @@ describe('BlockOrderWorker', () => {
       })
 
       it('returns the active inbound and outbound amounts', async () => {
-        const res = await worker.calculateActiveFunds(market, inboundSymbol, outboundSymbol)
+        const res = await worker.calculateActiveFunds(market, { inboundSymbol, outboundSymbol })
 
         expect(res.outbound).to.eql('5070')
         expect(res.inbound).to.eql('1300')

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -1422,10 +1422,10 @@ describe('BlockOrderWorker', () => {
       worker.ordersStore = ordersStoreStub
       worker.fillsStore = fillsStoreStub
 
-      activeAmountOrderStub = sinon.stub().resolves({ inbound: Big(1234), outbound: Big(1234) })
+      activeAmountOrderStub = sinon.stub().returns({ inbound: Big(1234), outbound: Big(1234) })
       worker.activeAmountsForOrders = activeAmountOrderStub
 
-      activeAmountFillStub = sinon.stub().resolves({ inbound: Big(103), outbound: Big(0) })
+      activeAmountFillStub = sinon.stub().returns({ inbound: Big(103), outbound: Big(0) })
       worker.activeAmountsForFills = activeAmountFillStub
 
       orders = [{ order: { market: 'BTC/LTC', side: 'BID' } }]

--- a/broker-daemon/broker-rpc/wallet-service/get-trading-capacities.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-trading-capacities.js
@@ -3,16 +3,6 @@ const { Big } = require('../../utils')
 
 /**
  * @constant
- * @type {Object<key, string>}
- * @default
- */
-const SIDES = Object.freeze({
-  BID: 'BID',
-  ASK: 'ASK'
-})
-
-/**
- * @constant
  * @type {Object}
  * @default
  */
@@ -123,11 +113,11 @@ async function getTradingCapacities ({ params, engines, orderbooks, blockOrderWo
   logger.debug(`Calculating active funds for ${market}`)
 
   const [
-    { activeOutboundAmount: committedCounterSendCapacity, activeInboundAmount: committedBaseReceiveCapacity },
-    { activeOutboundAmount: committedBaseSendCapacity, activeInboundAmount: committedCounterReceiveCapacity }
+    { outbound: committedCounterSendCapacity, inbound: committedBaseReceiveCapacity },
+    { outbound: committedBaseSendCapacity, inbound: committedCounterReceiveCapacity }
   ] = await Promise.all([
-    blockOrderWorker.calculateActiveFunds(market, SIDES.BID),
-    blockOrderWorker.calculateActiveFunds(market, SIDES.ASK)
+    blockOrderWorker.calculateActiveFunds(market, { outboundSymbol: counterSymbol, inboundSymbol: baseSymbol }),
+    blockOrderWorker.calculateActiveFunds(market, { outboundSymbol: baseSymbol, inboundSymbol: counterSymbol })
   ])
 
   // Capacities will always be returned for each side of the market, however if

--- a/broker-daemon/broker-rpc/wallet-service/get-trading-capacities.spec.js
+++ b/broker-daemon/broker-rpc/wallet-service/get-trading-capacities.spec.js
@@ -40,8 +40,20 @@ describe('get-trading-capacities', () => {
       committedBaseReceiveCapacity = '0.00002'
       committedCounterSendCapacity = '0.00003'
       committedCounterReceiveCapacity = '0.00004'
-      blockOrderWorker.calculateActiveFunds.withArgs(params.market, 'BID').resolves({ activeInboundAmount: committedBaseReceiveCapacity, activeOutboundAmount: committedCounterSendCapacity })
-      blockOrderWorker.calculateActiveFunds.withArgs(params.market, 'ASK').resolves({ activeInboundAmount: committedCounterReceiveCapacity, activeOutboundAmount: committedBaseSendCapacity })
+      blockOrderWorker.calculateActiveFunds.withArgs(params.market, {
+        inboundSymbol: 'BTC',
+        outboundSymbol: 'LTC'
+      }).resolves({
+        inbound: committedBaseReceiveCapacity,
+        outbound: committedCounterSendCapacity
+      })
+      blockOrderWorker.calculateActiveFunds.withArgs(params.market, {
+        inboundSymbol: 'LTC',
+        outboundSymbol: 'BTC'
+      }).resolves({
+        inbound: committedCounterReceiveCapacity,
+        outbound: committedBaseSendCapacity
+      })
 
       revert = getTradingCapacities.__set__('getCapacities', getCapacitiesStub)
     })
@@ -75,8 +87,14 @@ describe('get-trading-capacities', () => {
       await getTradingCapacities({ params, logger, engines, orderbooks, blockOrderWorker }, { GetTradingCapacitiesResponse })
 
       expect(blockOrderWorker.calculateActiveFunds).to.have.been.calledTwice()
-      expect(blockOrderWorker.calculateActiveFunds).to.have.been.calledWith(params.market, 'BID')
-      expect(blockOrderWorker.calculateActiveFunds).to.have.been.calledWith(params.market, 'ASK')
+      expect(blockOrderWorker.calculateActiveFunds).to.have.been.calledWith(params.market, {
+        inboundSymbol: 'BTC',
+        outboundSymbol: 'LTC'
+      })
+      expect(blockOrderWorker.calculateActiveFunds).to.have.been.calledWith(params.market, {
+        inboundSymbol: 'LTC',
+        outboundSymbol: 'BTC'
+      })
     })
 
     it('gets the balances from a particular engine', async () => {

--- a/broker-daemon/models/order.js
+++ b/broker-daemon/models/order.js
@@ -169,18 +169,44 @@ class Order {
   }
 
   /**
-   * Get the symbol of the currency we will receive inbound
-   * @returns {string} Currency symbol
+   * Get the amount (as an integer in its currency's smallest units) that we will receive inbound for this order
+   * @returns {string} 64-bit integer represented as a string
    */
   get inboundAmount () {
+    if (this.fillAmount) {
+      return this.inboundFillAmount
+    }
+
+    return this.inboundTotalAmount
+  }
+
+  /**
+   * Get the amount (as an integer in its currency's smallest units) that we will send outbound for this order
+   * @returns {string} 64-bit integer represented as a string
+   */
+  get outboundAmount () {
+    if (this.fillAmount) {
+      return this.outboundFillAmount
+    }
+
+    return this.outboundTotalAmount
+  }
+
+  /**
+   * Get the amount (as an integer in its currency's smallest units) that we will receive inbound for this order
+   * if the entirety of the order is filled.
+   * @returns {string} 64-bit integer represented as a string
+   */
+  get inboundTotalAmount () {
     return this.side === Order.SIDES.BID ? this.baseAmount : this.counterAmount
   }
 
   /**
-   * Get the symbol of the currency we will send outbound
-   * @returns {string} Currency symbol
+   * Get the amount (as an integer in its currency's smallest units) that we will send outbound for this order
+   * if the entirety of the order is filled.
+   * @returns {string} 64-bit integer represented as a string
    */
-  get outboundAmount () {
+  get outboundTotalAmount () {
     return this.side === Order.SIDES.BID ? this.counterAmount : this.baseAmount
   }
 

--- a/broker-daemon/models/order.spec.js
+++ b/broker-daemon/models/order.spec.js
@@ -275,32 +275,52 @@ describe('Order', () => {
         expect(order).to.have.property('outboundSymbol', params.counterSymbol)
       })
 
-      it('defines an inbound amount getter', () => {
-        expect(order).to.have.property('inboundAmount', params.baseAmount)
+      it('defines an inbound total amount getter', () => {
+        expect(order).to.have.property('inboundTotalAmount', params.baseAmount)
       })
 
-      it('defines an outbound amount getter', () => {
-        expect(order).to.have.property('outboundAmount', params.counterAmount)
+      it('defines an outbound total amount getter', () => {
+        expect(order).to.have.property('outboundTotalAmount', params.counterAmount)
       })
 
-      it('defines an inbound fill amount getter', () => {
-        expect(order).to.have.property('inboundFillAmount', '9000')
+      context('order has been filled', () => {
+        it('defines an inbound fill amount getter', () => {
+          expect(order).to.have.property('inboundFillAmount', '9000')
+        })
+
+        it('defines an outbound fill amount getter', () => {
+          expect(order).to.have.property('outboundFillAmount', '90000')
+        })
+
+        it('defines an inbound amount getter', () => {
+          expect(order).to.have.property('inboundAmount', '9000')
+        })
+
+        it('defines an outbound fill amount getter', () => {
+          expect(order).to.have.property('outboundAmount', '90000')
+        })
       })
 
-      it('throws if trying to use the inbound fill amount without a fill amount', () => {
-        order.fillAmount = null
+      context('order has not been filled', () => {
+        beforeEach(() => {
+          order.fillAmount = null
+        })
 
-        expect(() => order.inboundFillAmount).to.throw()
-      })
+        it('throws if trying to use the inbound fill amount without a fill amount', () => {
+          expect(() => order.inboundFillAmount).to.throw()
+        })
 
-      it('defines an outbound fill amount getter', () => {
-        expect(order).to.have.property('outboundFillAmount', '90000')
-      })
+        it('throws if trying to use the outbound fill amount without a fill amount', () => {
+          expect(() => order.outboundFillAmount).to.throw()
+        })
 
-      it('throws if trying to use the outbound fill amount without a fill amount', () => {
-        order.fillAmount = null
+        it('defines an inbound amount getter', () => {
+          expect(order).to.have.property('inboundAmount', params.baseAmount)
+        })
 
-        expect(() => order.outboundFillAmount).to.throw()
+        it('defines an outbound amount getter', () => {
+          expect(order).to.have.property('outboundAmount', params.counterAmount)
+        })
       })
     })
 

--- a/broker-daemon/orderbook/orderbook-index.js
+++ b/broker-daemon/orderbook/orderbook-index.js
@@ -18,6 +18,7 @@ class OrderbookIndex extends SubsetStore {
 
   /**
    * Create an object that can be passed to Sublevel to create or remove an orderbook record
+   * @private
    * @param {string} key   - Key of the record to create an index op for
    * @param {string} value - Value of the record being added to the events store to create an index op for
    * @returns {Object} object for create/delete for use with sublevel

--- a/broker-daemon/orderbook/orderbook-index.js
+++ b/broker-daemon/orderbook/orderbook-index.js
@@ -22,7 +22,7 @@ class OrderbookIndex extends SubsetStore {
    * @param {string} value - Value of the record being added to the events store to create an index op for
    * @returns {Object} object for create/delete for use with sublevel
    */
-  _addToIndexOperation (key, value) {
+  addToIndexOperation (key, value) {
     const event = MarketEvent.fromStorage(key, value)
     const order = MarketEventOrder.fromEvent(event, this.marketName)
 

--- a/broker-daemon/utils/index.js
+++ b/broker-daemon/utils/index.js
@@ -18,6 +18,7 @@ const Checksum = require('./checksum')
 const payInvoice = require('./pay-invoice')
 const retry = require('./retry')
 const CachedCall = require('./cached-call')
+const SubsetStore = require('./subset-store')
 
 module.exports = {
   getRecords,
@@ -39,5 +40,6 @@ module.exports = {
   Checksum,
   payInvoice,
   retry,
-  CachedCall
+  CachedCall,
+  SubsetStore
 }

--- a/broker-daemon/utils/subset-store.js
+++ b/broker-daemon/utils/subset-store.js
@@ -1,0 +1,77 @@
+const migrateStore = require('./migrate-store')
+
+/**
+ * @class Subset of another sublevel store based on criteria
+ */
+class SubsetStore {
+  /**
+   * Create a new subset from a target store and a source store
+   * @param {sublevel} targetStore - store to keep the subset in
+   * @param {sublevel} sourceStore - Store of records to create a subset of
+   */
+  constructor (targetStore, sourceStore) {
+    this.store = targetStore
+    this.sourceStore = sourceStore
+  }
+
+  /**
+   * Rebuild the index and add hooks for new events
+   * @returns {void} resolves when the index is rebuilt and ready for new events
+   */
+  async ensureIndex () {
+    await this._clearIndex()
+    await this._rebuildIndex()
+    this._addIndexHook()
+  }
+
+  /**
+   * Create an object that can be passed to Sublevel to create or remove a record
+   * In this abstract class, all records will be added to the subset. It should be overwritten by implementers.
+   * @param {string} key   - Key of the record to create an index op for
+   * @param {string} value - Value of the record being added to the events store to create an index op for
+   * @returns {Object} object for create/delete for use with sublevel
+   */
+  _addToIndexOperation (key, value) {
+    return { key, value, type: 'put', prefix: this.store }
+  }
+
+  /**
+   * Clear the existing index
+   * @returns {Promise} resolves when the index is cleared
+   */
+  _clearIndex () {
+    // remove any previously applied hooks
+    if (this._removeHook) {
+      this._removeHook()
+    }
+    return migrateStore(this.store, this.store, (key) => { return { type: 'del', key } })
+  }
+
+  /**
+   * Rebuild the index from events
+   * @returns {Promise} resolves when the index is rebuilt
+   */
+  _rebuildIndex () {
+    return migrateStore(this.sourceStore, this.store, this._addToIndexOperation.bind(this))
+  }
+
+  /**
+   * Create a hook for new events added to the store to modify the orderbook
+   * @returns {void}
+   */
+  _addIndexHook () {
+    const indexHook = (dbOperation, add) => {
+      if (dbOperation.type === 'put') {
+        add(this._addToIndexOperation(dbOperation.key, dbOperation.value))
+      } else if (dbOperation.type === 'del') {
+        add({ key: dbOperation.key, type: 'del', prefix: this.store })
+      }
+    }
+
+    // `.pre` adds a hook for before a `put` in the sourceStore, and returns
+    // a function to remove that same hook.
+    this._removeHook = this.sourceStore.pre(indexHook)
+  }
+}
+
+module.exports = SubsetStore

--- a/broker-daemon/utils/subset-store.spec.js
+++ b/broker-daemon/utils/subset-store.spec.js
@@ -1,0 +1,200 @@
+const path = require('path')
+const { expect, sinon, rewire } = require('test/test-helper')
+
+const SubsetStore = rewire(path.resolve(__dirname, 'subset-store'))
+
+describe('SubsetStore', () => {
+  let targetStore
+  let sourceStore
+  let migrateStore
+  let logger
+
+  beforeEach(() => {
+    targetStore = { fake: 'store' }
+    sourceStore = {
+      pre: sinon.stub()
+    }
+
+    migrateStore = sinon.stub().resolves()
+    logger = {
+      debug: sinon.stub(),
+      warn: sinon.stub()
+    }
+    SubsetStore.__set__('migrateStore', migrateStore)
+    SubsetStore.__set__('logger', logger)
+  })
+
+  describe('constructor', () => {
+    let subset
+
+    beforeEach(() => {
+      subset = new SubsetStore(targetStore, sourceStore)
+    })
+
+    it('assigns the target store', () => {
+      expect(subset.store).to.be.equal(targetStore)
+    })
+
+    it('assigns the source store', () => {
+      expect(subset.sourceStore).to.be.equal(sourceStore)
+    })
+  })
+
+  describe('ensureIndex', () => {
+    let subset
+
+    beforeEach(async () => {
+      subset = new SubsetStore(targetStore, sourceStore)
+      subset.clearIndex = sinon.stub().resolves()
+      subset.rebuildIndex = sinon.stub().resolves()
+      subset.addIndexHook = sinon.stub()
+
+      await subset.ensureIndex()
+    })
+
+    it('clears the index', () => {
+      expect(subset.clearIndex).to.have.been.calledOnce()
+    })
+
+    it('rebuilds the index', () => {
+      expect(subset.rebuildIndex).to.have.been.calledOnce()
+    })
+
+    it('adds a hook for new events', () => {
+      expect(subset.addIndexHook).to.have.been.calledOnce()
+    })
+  })
+
+  describe('addToIndexOperation', () => {
+    let key
+    let value
+    let subset
+    let expectedAddOp
+
+    beforeEach(() => {
+      key = 'mykey'
+      value = 'myvalue'
+
+      expectedAddOp = {
+        key,
+        value,
+        type: 'put',
+        prefix: targetStore
+      }
+
+      subset = new SubsetStore(targetStore, sourceStore)
+    })
+
+    it('adds the record to the target store', () => {
+      expect(subset.addToIndexOperation(key, value)).to.be.eql(expectedAddOp)
+    })
+  })
+
+  describe('clearIndex', () => {
+    let subset
+
+    beforeEach(() => {
+      subset = new SubsetStore(targetStore, sourceStore)
+      subset.removeHook = sinon.stub()
+    })
+
+    it('removes any previous hooks', async () => {
+      await subset.clearIndex()
+
+      expect(subset.removeHook).to.have.been.calledOnce()
+    })
+
+    it('deletes the store through a self migration', async () => {
+      await subset.clearIndex()
+
+      expect(migrateStore).to.have.been.calledOnce()
+      expect(migrateStore).to.have.been.calledWith(targetStore, targetStore)
+    })
+
+    it('deletes every key in the store', async () => {
+      await subset.clearIndex()
+
+      const migrator = migrateStore.args[0][2]
+
+      expect(migrator).to.be.a('function')
+      expect(migrator('mykey')).to.be.eql({ type: 'del', key: 'mykey' })
+    })
+  })
+
+  describe('rebuildIndex', () => {
+    let subset
+
+    beforeEach(() => {
+      subset = new SubsetStore(targetStore, sourceStore)
+    })
+
+    it('rebuilds the store from the source', async () => {
+      const fakeBound = 'fakefunc'
+      subset.addToIndexOperation.bind = sinon.stub().returns(fakeBound)
+
+      await subset.rebuildIndex()
+
+      expect(migrateStore).to.have.been.calledOnce()
+      expect(migrateStore).to.have.been.calledWith(sourceStore, targetStore, fakeBound)
+    })
+  })
+
+  describe('addIndexHook', () => {
+    let subset
+    let preHook
+    let add
+
+    beforeEach(() => {
+      subset = new SubsetStore(targetStore, sourceStore)
+      subset.addIndexHook()
+      preHook = sourceStore.pre.args[0] ? sourceStore.pre.args[0][0] : undefined
+      add = sinon.stub()
+    })
+
+    it('monitors the event store', () => {
+      expect(sourceStore.pre).to.have.been.calledOnce()
+      expect(sourceStore.pre).to.have.been.calledWithMatch(sinon.match.func)
+    })
+
+    it('deletes from the target store when deletes happen on the source store', () => {
+      const eventKey = 'yourkey'
+
+      preHook(
+        {
+          type: 'del',
+          key: eventKey
+        },
+        add
+      )
+
+      expect(add).to.have.been.calledOnce()
+      expect(add).to.have.been.calledWith({
+        type: 'del',
+        key: eventKey,
+        prefix: targetStore
+      })
+    })
+
+    it('adds the index op when put operations happen on the source store', () => {
+      const eventKey = 'yourkey'
+      const eventValue = 'myvalue'
+      const fakeOp = 'myop'
+
+      subset.addToIndexOperation = sinon.stub().returns(fakeOp)
+
+      preHook(
+        {
+          type: 'put',
+          key: eventKey,
+          value: eventValue
+        },
+        add
+      )
+
+      expect(add).to.have.been.calledOnce()
+      expect(subset.addToIndexOperation).to.have.been.calledOnce()
+      expect(subset.addToIndexOperation).to.have.been.calledWith(eventKey, eventValue)
+      expect(add).to.have.been.calledWith(fakeOp)
+    })
+  })
+})


### PR DESCRIPTION
## Description
This change improves the performance of block order creation by speeding up the process of calculating outstanding funds.

In particular, it:
- adds an index of only currently active orders and fills
- parallelizes async operations

In so doing, it also cleans up a lot of the active order/fills calculations.

The performance increase for large datasets (\~150k records) is 100x (\~10s ➡️\~100ms) and should change the growth from linear with total orders and fills to linear with active orders and fills (which is unlikely to grow significantly).

## Related PRs
This is a follow-up to https://github.com/sparkswap/broker/pull/527

## Todos
- [x] Tests
