### PR TITLE
added error logs for sublevel

### DIFF
--- a/broker-daemon/utils/sublevel-index.js
+++ b/broker-daemon/utils/sublevel-index.js
@@ -206,7 +206,7 @@ class Index {
     this.store.get(baseKey, async (err, value) => {
       if (err) {
         // TODO: error handling on index removal
-        return logger.error(`Error while removing ${baseKey} from ${this.name} index`, err)
+        return logger.error(`Error trying to get key when removing ${baseKey} from ${this.name} index`, { err: err.toString() })
       }
 
       try {
@@ -218,7 +218,7 @@ class Index {
         this._finishDeletion(baseKey)
       } catch (e) {
         // TODO: error handling on index removal
-        return logger.error(`Error while removing ${baseKey} from ${this.name} index`, e)
+        return logger.error(`Error while removing ${baseKey} from ${this.name} index`, { err: e.toString() })
       }
     })
   }


### PR DESCRIPTION
## Description
While troubleshooting our production brokers, found that `err` and `e` respectively in the code is not being logged properly through winston.

## Related PRs
List related PRs if applicable


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Link to Trello
