### PR TITLE
[wip] Break up orders and fills to fit into available channels

### DIFF
--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -2450,12 +2450,13 @@ describe('BlockOrderWorker', () => {
         baseSymbol: 'BTC',
         counterSymbol: 'LTC',
         outboundSymbol: 'BTC',
+        inboundSymbol: 'LTC',
         quantumPrice: '1000'
       }
     })
 
     it('throws if one of the engines is missing', () => {
-      blockOrder.counterSymbol = 'XYZ'
+      blockOrder.inboundSymbol = 'XYZ'
 
       return expect(worker._placeOrders(blockOrder, '100')).to.eventually.be.rejectedWith('No engine available')
     })

--- a/broker-daemon/block-order-worker/index.spec.js
+++ b/broker-daemon/block-order-worker/index.spec.js
@@ -2135,6 +2135,16 @@ describe('BlockOrderWorker', () => {
       expect(FillStateMachine.create.args[1][3]).to.be.eql({ fillAmount: '50' })
     })
 
+    it('rejects if there is not channel balance remaining', () => {
+      engineLtc.getMaxChannelForAddress.withArgs(
+        ltcAddress,
+        { outbound: true }
+      ).resolves('0')
+
+      return expect(worker._fillOrders(blockOrder, orders, targetDepth)).to
+        .eventually.be.rejectedWith('Trying to fill order with an amount of 0')
+    })
+
     it('provides the fill store the FillStateMachine', async () => {
       await worker._fillOrders(blockOrder, orders, targetDepth)
 
@@ -2631,6 +2641,11 @@ describe('BlockOrderWorker', () => {
         }
       }
       OrderStateMachine.create.resolves(order)
+    })
+
+    it('rejects if the amount is 0', () => {
+      expect(worker._placeOrder(blockOrder, '0')).to.eventually.be.rejectedWith(
+        'Cannot create an order with an amount of 0')
     })
 
     it('creates an OrderStateMachine', async () => {

--- a/broker-daemon/utils/index.js
+++ b/broker-daemon/utils/index.js
@@ -19,6 +19,7 @@ const payInvoice = require('./pay-invoice')
 const retry = require('./retry')
 const CachedCall = require('./cached-call')
 const SubsetStore = require('./subset-store')
+const minBig = require('./min-big')
 
 module.exports = {
   getRecords,
@@ -41,5 +42,6 @@ module.exports = {
   payInvoice,
   retry,
   CachedCall,
-  SubsetStore
+  SubsetStore,
+  minBig
 }

--- a/broker-daemon/utils/min-big.js
+++ b/broker-daemon/utils/min-big.js
@@ -1,0 +1,17 @@
+const Big = require('./big')
+
+/**
+ * Find the minimum value of a group of Big.js numbers
+ * @param   {...Big} bigs - List of Big.js numbers to compare
+ * @returns {string}        Smallest Big.js number in the set
+ */
+function minBig (...bigs) {
+  return bigs.reduce((min, big) => {
+    if (Big(min).gt(big)) {
+      return big
+    }
+    return min
+  }).toString()
+}
+
+module.exports = minBig

--- a/broker-daemon/utils/min-big.spec.js
+++ b/broker-daemon/utils/min-big.spec.js
@@ -1,0 +1,20 @@
+const { expect } = require('test/test-helper')
+
+const minBig = require('./min-big')
+
+describe('minBig', () => {
+  it('returns the min of two numbers', () => {
+    expect(minBig(1, 3)).to.be.eql('1')
+  })
+  it('returns the min of a set of numbers', () => {
+    expect(minBig(3, 1, 2)).to.be.eql('1')
+  })
+
+  it('returns the min of positive and negative numbers', () => {
+    expect(minBig(-1, 0, 1)).to.be.eql('-1')
+  })
+
+  it('returns the only number in a one number set', () => {
+    expect(minBig(1)).to.be.eql('1')
+  })
+})


### PR DESCRIPTION
## Description
This change breaks up orders when being placed, and fills to fit into available channels.

It does in a naive way: simply finding the maximum channel size (or maximum payment size) and making sure every order and fill is smaller than that.

It has a few problems, in particular: one would expect that when repeating this operation multiple times, the second (or nth) operation is destined to fail during settlement. We'll handle this failure in a later change.

It also has a particular egregious issue on fills: it will fill the best priced order only up until its channel limit, and then move to the next best priced order. This could result in the average fill price being worse than expected. Fixing this would require a much more sophisticated approach that will be handled down the road.

## Todos
- [x] Tests

## Future considerations
- Handling failures from capacity at settlement time
- Assigning fills and orders to specific channels to ensure capacity availability
- Filling worst priced orders due to capacity constraints