### PR TITLE
Calculate capacity across multiple channels

### DIFF
--- a/broker-daemon/block-order-worker/index.js
+++ b/broker-daemon/block-order-worker/index.js
@@ -307,17 +307,14 @@ class BlockOrderWorker extends EventEmitter {
     const [
       totalOutboundCapacity,
       totalInboundCapacity,
-      maxOutboundCapacityObject,
-      maxInboundCapacityObject
+      { maxBalance: maxOutboundCapacity },
+      { maxBalance: maxInboundCapacity }
     ] = await Promise.all([
       outboundEngine.getTotalBalanceForAddress(outboundAddress),
       inboundEngine.getTotalBalanceForAddress(inboundAddress, { outbound: false }),
       outboundEngine.getMaxChannelForAddress(outboundAddress),
       inboundEngine.getMaxChannelForAddress(inboundAddress, { outbound: false })
     ])
-
-    const maxOutboundCapacity = maxOutboundCapacityObject.maxBalance
-    const maxInboundCapacity = maxInboundCapacityObject.maxBalance
 
     if (totalOutboundAmount.gt(totalOutboundCapacity)) {
       throw new Error(`Insufficient funds in outbound ${blockOrder.outboundSymbol} channels to create order. ` +


### PR DESCRIPTION
## Description
Check that there is enough total capacity to accommodate the current order plus all active orders, and there is a single channel with capacity for the current order. 

## Related PRs
Depends on https://github.com/sparkswap/lnd-engine/pull/222

## Todos
- [X] Tests

