### PR TITLE
Add a flag to check the number of records

### DIFF
--- a/broker-cli/commands/health-check.js
+++ b/broker-cli/commands/health-check.js
@@ -60,13 +60,16 @@ const ENGINE_STATUS_CODES = Object.freeze({
 async function healthCheck (args, opts, logger) {
   const {
     rpcAddress,
+    count,
     json
   } = opts
 
   try {
     const client = new BrokerDaemonClient(rpcAddress)
 
-    const res = await client.adminService.healthCheck({})
+    const res = await client.adminService.healthCheck({
+      includeRecordCounts: count
+    })
 
     if (json) {
       return logger.info(JSON.stringify(res, null, 2))
@@ -122,6 +125,7 @@ async function healthCheck (args, opts, logger) {
 module.exports = (program) => {
   program
     .command('healthcheck', 'Checks the connection between Broker and the Exchange')
+    .option('--count', 'Count the number of records in the Broker', program.BOOL, false)
     .option('--rpc-address [rpc-address]', RPC_ADDRESS_HELP_STRING, validations.isHost)
     .option('--json', 'Export result as json', program.BOOL, false)
     .action(healthCheck)

--- a/broker-cli/commands/health-check.spec.js
+++ b/broker-cli/commands/health-check.spec.js
@@ -72,6 +72,12 @@ describe('healthCheck', () => {
     expect(healthCheckStub).to.have.been.called()
   })
 
+  it('adds the record count if the flag is passed', async () => {
+    opts.count = true
+    await healthCheck(args, opts, logger)
+    expect(healthCheckStub).to.have.been.calledWith({ includeRecordCounts: true })
+  })
+
   it('returns json if the user specifies a json flag', async () => {
     opts.json = true
     const result = 'result'

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -141,7 +141,11 @@ message RecordCount {
   int32 count = 3;
 }
 
+/**
+ * HealthCheckRequest is a request about the status and health of a BrokerDaemon.
+ */
 message HealthCheckRequest {
+  // Whether to calculate and include the number of records in the stores of the BrokerDaemon.
   bool include_record_counts = 1;
 }
 
@@ -155,6 +159,7 @@ message HealthCheckResponse {
   RelayerStatuses relayer_status = 2;
   // The status of every orderbook available on the BrokerDaemon.
   repeated OrderbookStatus orderbook_status = 3;
+  // The number of records in every store on the BrokerDaemon. Omitted unless `include_record_counts` is `true`.
   repeated RecordCount record_counts = 4;
 }
 

--- a/broker-cli/proto/broker.proto
+++ b/broker-cli/proto/broker.proto
@@ -74,7 +74,6 @@ enum Side {
   ASK = 1;
 }
 
-
 // Statuses of the relayer
 enum RelayerStatuses {
   // Relayer is not available
@@ -130,6 +129,23 @@ message OrderbookStatus {
 }
 
 /**
+ * RecordCount is the number of records in a store on the Broker,
+ * along with its name the name of its parent store.
+ */
+message RecordCount {
+  // The name of the store
+  string name = 1;
+  // The name of the parent store of this store
+  string parent_name = 2;
+  // The number of records in this store
+  int32 count = 3;
+}
+
+message HealthCheckRequest {
+  bool include_record_counts = 1;
+}
+
+/**
  * HealthCheckResponse provides information on the health of a BrokerDaemon.
  */
 message HealthCheckResponse {
@@ -139,6 +155,7 @@ message HealthCheckResponse {
   RelayerStatuses relayer_status = 2;
   // The status of every orderbook available on the BrokerDaemon.
   repeated OrderbookStatus orderbook_status = 3;
+  repeated RecordCount record_counts = 4;
 }
 
 /**
@@ -222,7 +239,7 @@ service AdminService {
    * └───────────────────┴───────────────────┘
    * ```
    */
-  rpc HealthCheck (google.protobuf.Empty) returns (HealthCheckResponse) {
+  rpc HealthCheck (HealthCheckRequest) returns (HealthCheckResponse) {
     option (.google.api.http) = {
       get: "/v1/admin/healthcheck"
     };

--- a/broker-daemon/broker-rpc/admin-service/health-check.js
+++ b/broker-daemon/broker-rpc/admin-service/health-check.js
@@ -109,11 +109,9 @@ async function healthCheck ({ params, relayer, logger, engines, orderbooks, stor
   }
 
   if (includeRecordCounts) {
-    const recordCounts = await getRecordCounts(store)
+    message.recordCounts = await getRecordCounts(store)
 
     logger.debug('Received record counts from the data store')
-
-    message.recordCounts = recordCounts
   }
 
   return new HealthCheckResponse(message)

--- a/broker-daemon/broker-rpc/admin-service/health-check.js
+++ b/broker-daemon/broker-rpc/admin-service/health-check.js
@@ -38,10 +38,21 @@ async function getRelayerStatus (relayer, { logger }) {
   }
 }
 
+/**
+ * Get the number of records in a store and its children
+ * @param   {Sublevel} store    - Store to get record count from
+ * @param   {string} name       - Name of this store
+ * @param   {string} parentName - Name of the parent of this store
+ * @param   {Array}  stores     - Array to include this store's record count in
+ * @returns {Array}               All stores and their record counts including
+ *                                `store` and its sublevels.
+ */
 async function getRecordCounts (store, name = 'store', parentName = '', stores = []) {
   let count = 0
   await eachRecord(store, () => { count++ })
 
+  // We use a flat structure to make it simpler to send over the wire despite the fact
+  // that it is actually nested.
   stores.push({
     parentName,
     name,

--- a/broker-daemon/broker-rpc/admin-service/health-check.spec.js
+++ b/broker-daemon/broker-rpc/admin-service/health-check.spec.js
@@ -61,6 +61,8 @@ describe('health-check', () => {
       relayerStatusOK = healthCheck.__get__('RELAYER_STATUS_CODES').RELAYER_OK
       relayerStatusStub = sinon.stub().returns(relayerStatusOK)
 
+      // simulate looping over every record in the store, using the stub's
+      // _numRecords as an indicator of how many records are in our fake store.
       eachRecordStub = sinon.stub().callsFake(({ _numRecords }, cb) => {
         return new Promise(async (resolve, reject) => {
           for (let i = 0; i < _numRecords; i++) {

--- a/broker-daemon/broker-rpc/admin-service/index.js
+++ b/broker-daemon/broker-rpc/admin-service/index.js
@@ -13,9 +13,10 @@ class AdminService {
    * @param {Object} opts.relayer
    * @param {Map} opts.engines
    * @param {Map} opts.orderbooks
+   * @param {Sublevel} opts.store
    * @param {Function} opts.auth
    */
-  constructor (protoPath, { logger, relayer, engines, orderbooks, auth }) {
+  constructor (protoPath, { logger, relayer, engines, orderbooks, store, auth }) {
     this.protoPath = protoPath
     this.proto = loadProto(this.protoPath)
     this.logger = logger
@@ -30,7 +31,7 @@ class AdminService {
     } = this.proto.broker.rpc
 
     this.implementation = {
-      healthCheck: new GrpcUnaryMethod(healthCheck, this.messageId('healthCheck'), { logger, relayer, engines, orderbooks, auth }, { HealthCheckResponse }).register(),
+      healthCheck: new GrpcUnaryMethod(healthCheck, this.messageId('healthCheck'), { logger, relayer, engines, orderbooks, store, auth }, { HealthCheckResponse }).register(),
       getIdentity: new GrpcUnaryMethod(getIdentity, this.messageId('getIdentity'), { logger, relayer, auth }, { GetIdentityResponse }).register(),
       register: new GrpcUnaryMethod(register, this.messageId('register'), { logger, relayer }, { RegisterResponse }).register()
     }

--- a/broker-daemon/broker-rpc/admin-service/index.spec.js
+++ b/broker-daemon/broker-rpc/admin-service/index.spec.js
@@ -20,6 +20,7 @@ describe('AdminService', () => {
   let relayer
   let engines
   let orderbooks
+  let store
   let auth
 
   let server
@@ -47,6 +48,7 @@ describe('AdminService', () => {
     relayer = sinon.stub()
     engines = new Map()
     orderbooks = new Map()
+    store = { fake: 'sublevel' }
 
     GrpcMethod = sinon.stub()
     fakeRegistered = sinon.stub()
@@ -65,7 +67,7 @@ describe('AdminService', () => {
   })
 
   beforeEach(() => {
-    server = new AdminService(protoPath, { logger, relayer, engines, orderbooks, auth })
+    server = new AdminService(protoPath, { logger, relayer, engines, orderbooks, store, auth })
   })
 
   it('assigns a proto path', () => {
@@ -146,6 +148,10 @@ describe('AdminService', () => {
 
       it('passes in the orderbooks', () => {
         expect(callArgs[2]).to.have.property('orderbooks', orderbooks)
+      })
+
+      it('passes in the store', () => {
+        expect(callArgs[2]).to.have.property('store', store)
       })
 
       it('passes in auth', () => {

--- a/broker-daemon/broker-rpc/broker-rpc-server.js
+++ b/broker-daemon/broker-rpc/broker-rpc-server.js
@@ -64,12 +64,13 @@ class BrokerRPCServer {
    * @param {Map<string, Engine>} opts.engines
    * @param {RelayerClient} opts.relayer
    * @param {BlockOrderWorker} opts.blockOrderWorker
+   * @param {Sublevel} opts.store - BrokerDaemon sublevel store
    * @param {Map<Orderbook>} opts.orderbooks
    * @param {string} opts.privKeyPath - Path to private key for broker rpc
    * @param {string} opts.pubKeyPath - Path to public key for broker rpc
    * @param {boolean} [opts.disableAuth=false]
    */
-  constructor ({ logger, engines, relayer, blockOrderWorker, orderbooks, pubKeyPath, privKeyPath, disableAuth = false, enableCors = false, isCertSelfSigned, rpcUser = null, rpcPass = null, rpcHttpProxyAddress, rpcHttpProxyMethods, rpcAddress } = {}) {
+  constructor ({ logger, engines, relayer, blockOrderWorker, orderbooks, store, pubKeyPath, privKeyPath, disableAuth = false, enableCors = false, isCertSelfSigned, rpcUser = null, rpcPass = null, rpcHttpProxyAddress, rpcHttpProxyMethods, rpcAddress } = {}) {
     this.logger = logger
     this.engines = engines
     this.relayer = relayer
@@ -87,7 +88,7 @@ class BrokerRPCServer {
 
     this.httpServer = createHttpServer(this.protoPath, this.rpcAddress, { disableAuth, enableCors, isCertSelfSigned, privKeyPath, pubKeyPath, httpMethods: rpcHttpProxyMethods, logger })
 
-    this.adminService = new AdminService(this.protoPath, { logger, relayer, engines, orderbooks, auth: this.auth })
+    this.adminService = new AdminService(this.protoPath, { logger, relayer, engines, orderbooks, store, auth: this.auth })
     this.server.addService(this.adminService.definition, this.adminService.implementation)
 
     this.orderService = new OrderService(this.protoPath, { logger, blockOrderWorker, auth: this.auth })

--- a/broker-daemon/broker-rpc/broker-rpc-server.spec.js
+++ b/broker-daemon/broker-rpc/broker-rpc-server.spec.js
@@ -17,6 +17,8 @@ describe('BrokerRPCServer', () => {
   let pathResolve
   let protoPath
   let engines
+  let orderbooks
+  let store
   let httpServer
   let grpcGateway
   let router
@@ -69,6 +71,10 @@ describe('BrokerRPCServer', () => {
     BrokerRPCServer.__set__('createHttpServer', httpServer)
 
     engines = new Map()
+
+    orderbooks = new Map()
+
+    store = { fake: 'sublevel' }
 
     protoPath = 'mypath'
     pathResolve = sinon.stub().returns(protoPath)
@@ -185,10 +191,10 @@ describe('BrokerRPCServer', () => {
       const logger = 'mylogger'
       const relayer = 'myrelayer'
 
-      const server = new BrokerRPCServer({ logger, relayer, engines })
+      const server = new BrokerRPCServer({ logger, relayer, engines, orderbooks, store })
 
       expect(AdminService).to.have.been.calledOnce()
-      expect(AdminService).to.have.been.calledWith(protoPath, sinon.match({ logger, relayer, engines }))
+      expect(AdminService).to.have.been.calledWith(protoPath, sinon.match({ logger, relayer, engines, orderbooks, store }))
       expect(AdminService).to.have.been.calledWithNew()
       expect(server).to.have.property('adminService')
       expect(server.adminService).to.be.equal(adminService)

--- a/broker-daemon/index.js
+++ b/broker-daemon/index.js
@@ -157,6 +157,7 @@ class BrokerDaemon {
       relayer: this.relayer,
       orderbooks: this.orderbooks,
       blockOrderWorker: this.blockOrderWorker,
+      store: this.store,
       privKeyPath: privRpcKeyPath,
       pubKeyPath: pubRpcKeyPath,
       disableAuth,

--- a/broker-daemon/index.spec.js
+++ b/broker-daemon/index.spec.js
@@ -248,6 +248,10 @@ describe('broker daemon', () => {
         expect(rpcServer).to.have.been.calledWith(sinon.match({ blockOrderWorker: brokerDaemon.blockOrderWorker }))
       })
 
+      it('sets the store', () => {
+        expect(rpcServer).to.have.been.calledWith(sinon.match({ store: brokerDaemon.store }))
+      })
+
       it('sets the private key path', () => {
         expect(rpcServer).to.have.been.calledWith(sinon.match({ privKeyPath: privRpcKeyPath }))
       })

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -141,7 +141,11 @@ message RecordCount {
   int32 count = 3;
 }
 
+/**
+ * HealthCheckRequest is a request about the status and health of a BrokerDaemon.
+ */
 message HealthCheckRequest {
+  // Whether to calculate and include the number of records in the stores of the BrokerDaemon.
   bool include_record_counts = 1;
 }
 
@@ -155,6 +159,7 @@ message HealthCheckResponse {
   RelayerStatuses relayer_status = 2;
   // The status of every orderbook available on the BrokerDaemon.
   repeated OrderbookStatus orderbook_status = 3;
+  // The number of records in every store on the BrokerDaemon. Omitted unless `include_record_counts` is `true`.
   repeated RecordCount record_counts = 4;
 }
 

--- a/broker-daemon/proto/broker.proto
+++ b/broker-daemon/proto/broker.proto
@@ -74,7 +74,6 @@ enum Side {
   ASK = 1;
 }
 
-
 // Statuses of the relayer
 enum RelayerStatuses {
   // Relayer is not available
@@ -130,6 +129,23 @@ message OrderbookStatus {
 }
 
 /**
+ * RecordCount is the number of records in a store on the Broker,
+ * along with its name the name of its parent store.
+ */
+message RecordCount {
+  // The name of the store
+  string name = 1;
+  // The name of the parent store of this store
+  string parent_name = 2;
+  // The number of records in this store
+  int32 count = 3;
+}
+
+message HealthCheckRequest {
+  bool include_record_counts = 1;
+}
+
+/**
  * HealthCheckResponse provides information on the health of a BrokerDaemon.
  */
 message HealthCheckResponse {
@@ -139,6 +155,7 @@ message HealthCheckResponse {
   RelayerStatuses relayer_status = 2;
   // The status of every orderbook available on the BrokerDaemon.
   repeated OrderbookStatus orderbook_status = 3;
+  repeated RecordCount record_counts = 4;
 }
 
 /**
@@ -222,7 +239,7 @@ service AdminService {
    * └───────────────────┴───────────────────┘
    * ```
    */
-  rpc HealthCheck (google.protobuf.Empty) returns (HealthCheckResponse) {
+  rpc HealthCheck (HealthCheckRequest) returns (HealthCheckResponse) {
     option (.google.api.http) = {
       get: "/v1/admin/healthcheck"
     };


### PR DESCRIPTION
## Description
This change adds a flag to the `healthcheck` to count the number of records in every store in the BrokerDaemon. Since this is considered a dev feature, it is only accessible when using the `--json` flag as well.

This should allow more visibility into the Broker and help debug issues related to large data stores.

## Todos
- [x] Tests
- [x] Documentation
